### PR TITLE
Duplicate Donor Choice charities gives error in Amount distribution page

### DIFF
--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -1198,7 +1198,7 @@ class AnnualCampaignController extends Controller
                             $new_pledge_charity->charity_id = $bi_weekly_pledge->charity->id;
                             $new_pledge_charity->additional = $bi_weekly_pledge->name2;
                             $new_pledge_charity->percentage = $bi_weekly_pledge->percent;
-                            $new_pledge_charity->amount = $bi_weekly_pledge->amount;
+                            $new_pledge_charity->amount = $bi_weekly_pledge->amount / 26;
                             $new_pledge_charity->frequency = 'bi-weekly'; // : 'one-time',
                             $new_pledge_charity->goal_amount = $new_pledge_charity->amount * $campaignYear->number_of_periods;
 


### PR DESCRIPTION
Bug found by Steffi,  

In the donation page, when duplicate a pledge from history, the Dollar amount gives an error as it expects the total amount to be the one selected in the previous step. 

![image](https://user-images.githubusercontent.com/86217312/235004738-55ca20b5-eda8-4d3d-b6cf-cb92949cc0c1.png)


Root cause analysis: the BI history data is stored in annual amount basis, the biweekly distribution amount expected in annual pledge page is pledge amount. 

Solution: the amount should be divided by 26 period.




 

 