### PR TITLE
Donations: Missing 'Why Donate to PECSF' button when there is no donation history

### DIFF
--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -46,13 +46,13 @@
 
     <div class="d-flex mt-3">
         <h1>My Donations</h1>
+        <div class="flex-fill"></div>        
         @if($totalPledgedDataTillNow > 0)
-            <div class="flex-fill"></div>
             @if (!$campaignYear->isOpen() )
                 <x-button :href="route('donate-now.index')">Donate to PECSF Now</x-button>
             @endif
-            <x-button style="outline-primary" class="ml-2" data-toggle="modal" data-target="#learn-more-modal" >Why donate to PECSF?</x-button>
         @endif
+        <x-button style="outline-primary" class="ml-2" data-toggle="modal" data-target="#learn-more-modal" >Why donate to PECSF?</x-button>
     </div>
     <div class="d-flex flex-column">
         <p class="m-0">
@@ -148,6 +148,10 @@
             $(this).find(".next-btn").removeClass("d-none")
             $(this).find(".ready-btn").addClass("d-none");
         }
+    })
+
+    $('#learn-more-modal').on('show.bs.modal', function (event) {
+        $('#donateGuideCarousel').carousel(0);
     })
 
     $('.more-info').click( function(event) {


### PR DESCRIPTION
Issue: 

User does not see the ‘Why Donate to PECSF’ button when there is no donation history.  Can we add that button regardless of the donations.  

Also, I’m ready to donate button in the Why Donate to PECSF flow when clicked, must navigate user to the first page/step of the donation flow.  

![image](https://user-images.githubusercontent.com/86217312/235231180-f6946034-0f68-4abb-a7fe-d2ca19dc30dc.png)


**Enhancement done**
1. Always display "‘Why Donate to PECSF’ button on the right side
2. Always start from the first page after click on "Why Donate to PECSF" page.



 