### PR TITLE
Duplicate pledge gives error when the FSP or charities are active and inactive [jp-bugfix-0004]

### DIFF
--- a/app/Models/PledgeHistorySummary.php
+++ b/app/Models/PledgeHistorySummary.php
@@ -18,8 +18,8 @@ class PledgeHistorySummary extends Model
     public function fund_supported_pool() {
 
         if ($this->source == 'P') {
-            $region = Region::where('name', $this->region)->first();
-            return FSPool::current()->where('region_id', $region->id)->first();
+            $region = Region::where('code', $this->region)->first();
+            return $region ? FSPool::current()->where('region_id', $region->id)->first() : null;
         } else {
             return null;
         }


### PR DESCRIPTION
The Donation History is needed to Duplicate the Pledge. Chances are that the charities and FSP might not be active anymore. So, when the Duplicate Pledge button is clicked, the user gets a pop-up message saying that the charity or FSP is not active anymore. And when continue is clicked, user must be navigated to the First step of the donations flow.  

![image](https://user-images.githubusercontent.com/86217312/235248342-63e9726d-7df8-47c3-bfdf-bf4482ee92ba.png)

**Root cause**: Issue caused by the recent change on the BI summary data, the summary transaction is now storing region code instead of region name, need to update this program to use 'region code'.

**Resolution**: For BI summary data, in model class, use regioin code instead of region name for lookup Region instance.



 

 