### PR TITLE
Donations: Missing 'Why Donate to PECSF' button when there is no donation history [jp-bugfix-0003]

### DIFF
--- a/resources/views/donations/partials/learn-more-modal.blade.php
+++ b/resources/views/donations/partials/learn-more-modal.blade.php
@@ -131,7 +131,11 @@ deduction plan.
                     <x-button href="#donateGuideCarousel" style="outline-primary" class="prev-btn d-none" role="button" data-slide="prev">Back</x-button>
                     <div class="flex-fill"></div>
                     <x-button href="#donateGuideCarousel" role="button" class="next-btn" data-slide="next">Next</x-button>
-                    <x-button :href="route('annual-campaign.index')" role="button" class="ready-btn d-none">I'm ready to Donate!</x-button>
+                    @if ( $campaignYear->isOpen() )
+                        <x-button :href="route('annual-campaign.index')" role="button" class="ready-btn d-none">I'm ready to Donate!</x-button>
+                    @else
+                        <x-button :href="route('donate-now.index')" role="button" class="ready-btn d-none">I'm ready to Donate!</x-button>
+                    @endif
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Additional change request:

Conditionally jump to difference page when th user click on the "I'm ready to Donate!" button. depend on the annual campiagn is open or not.

![image](https://user-images.githubusercontent.com/86217312/235483083-09b780ef-3a89-44ba-bf34-3287cfc807ca.png)
