### PR TITLE
Duplicate Donor Choice charities gives error in Amount distribution [jp-bugfix-0002]

### DIFF
--- a/resources/views/annual-campaign/partials/distribution-js.blade.php
+++ b/resources/views/annual-campaign/partials/distribution-js.blade.php
@@ -63,6 +63,7 @@ $(function () {
            
         $.each(rows, function(i) {
             if (i == (rows.length -1 ) ) {
+                current = $(this).val();
                 newValue = 0;
                 if (type == 'amount') {
                     // newValue = expectedTotal - sum;


### PR DESCRIPTION
Additional found on duplicate Donor Choice charities gives error in Amount distribution page, the incorrect distribute amount when percentage change. 

Root cause: varibale 'current' didn't initialize before calculation.

