### PR TITLE
Store locked Status - PG-bugfix-0008

### DIFF
--- a/app/Http/Controllers/Admin/EventSubmissionQueueController.php
+++ b/app/Http/Controllers/Admin/EventSubmissionQueueController.php
@@ -106,6 +106,12 @@ class EventSubmissionQueueController extends Controller
                     }
                 }
         }
+
+        if($request->status == 2){
+            BankDepositForm::where("id",$request->submission_id)->update(['approved' => $request->status]);
+
+        }
+
     }
 
     /**


### PR DESCRIPTION
[TEAMS](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2F3WzLf06FdECUqghkAYTZ7WUAIesb%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)
[TICKET](https://bcgov.sharepoint.com/:w:/r/teams/02365/Shared%20Documents/Greenfield%20-%20Maintain%20Event%20Pledges.docx?d=w80cf2bea391545f2af48a931ef32b6d0&csf=1&web=1&e=H1ctUN)

Employee ID should only be 6 numbers. S shouldn’t be in front of Employee IDs. PECSF ID are F, S, R, G numbers.   

Verified on the E-Form S numbers are not allowed must be 6 chars. The numbers you are looking at might be data from before the validations were in place but if you start the process from today it shouldn’t be possible to put an S in front of an employee ID and submit the form.  The exception when a form is approved is if there is another GOV form submitted then an S is put infront of the employee id as we were instructed to do earlier. (PG) 

 

 The name of submitter changed to mine after I edited in the queue. Doesn’t show as coming from the original submitter. 

Cant reproduce this when I submit an approval the original form submitter is saved (PG) 

 

I locked 3 duplicate submissions (no facility to delete duplicates) and the next time in the queue, they show as pending again. 

Fixed (PG) 

 

I was able to take the S off the Employee ID in the form, but when it was approved and showed up in the list, the S was back in front of the EE ID. 

If it’s a GOV form and there is a previous GOV form we were told to append an S (PG) 