### PR TITLE
S40(23) Donations: CRA list - Change validation message for custom amount PG-bugfix-0010

### DIFF
--- a/app/Http/Requests/AnnualCampaignRequest.php
+++ b/app/Http/Requests/AnnualCampaignRequest.php
@@ -191,17 +191,17 @@ class AnnualCampaignRequest extends FormRequest
     public function messages()
     {
         return [
-
             'charities.required' => 'At least one charity must be specified.',
             'charities.min' => 'At least one charity must be specified.',
             'charities.*.exists' =>  'The invalid charity entered.',
             'one_time_amount_custom.required' => 'The amount is required.',
-            'one_time_amount_custom.min'      => 'The min amount is $ 1.',
+            'one_time_amount_custom.min'      => 'The minimum One-time custom amount is $1.',
             'one_time_amount_custom.regex' => ' The One-time custom amount must have maximum of 2 decimal places.',
             'one_time_amount_custom.numeric' => ' The One-time custom amount must be a number.',
             'bi_weekly_amount_custom.required' => 'The amount is required.',
             'bi_weekly_amount_custom.min' => 'The minimum Bi-weekly custom amount is $1.',
             'bi_weekly_amount_custom.regex' => ' The Bi-weekly custom amount must have maximum of 2 decimal places.',
+            'bi_weekly_amount_custom.numeric' => ' The Bi-weekly custom amount must be a number.',
             'biWeeklyPercent.*.required' => 'The Percentage field is required.',
             'biWeeklyPercent.*.numeric' => 'The Percentage must be a number.',
             'biWeeklyPercent.*.between' => 'The percentage must be between 0.01 and 100.',


### PR DESCRIPTION
[Doc 1](https://bcgov.sharepoint.com/:w:/r/teams/02365/_layouts/15/Doc.aspx?action=editNew&sourcedoc=%7Bb7e42418-0742-4ed0-b9d6-bbaa386212fe%7D&wdOrigin=TEAMS-ELECTRON.teamsSdk.openFilePreview&wdExp=TEAMS-CONTROL&wdhostclicktime=1682352480664&web=1&cid=57e64ede-eb02-45c9-9bb6-e207fc80cfa0)

Some inconsistencies between one-time and bi-weekly messages needed to be fixed. Steffi's Notes are below. 

May 2 

I still see an inconsistency in some of the messages 

For zero – Bi-weekly message is perfect, but the one-time is not 

 

For alphabets: Can we change the message to ‘The Bi-weekly custom amount must be a number’ 

 

Can we have the same general message for all other cases? Here 2 messages are different for the same scenario 

 