### PR TITLE
Volunteer e-form: Pre-populate Gov employee data when employee ID is …

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -7,6 +7,7 @@ use App\Models\BankDepositForm;
 use App\Models\BankDepositFormOrganizations;
 use App\Models\BankDepositFormAttachments;
 use App\Models\Charity;
+use App\Models\EmployeeJob;
 use App\Models\Organization;
 use App\Models\Pledge;
 use Illuminate\Http\Request;
@@ -610,10 +611,33 @@ class BankDepositFormController extends Controller
             $organizations->groupBy("f_s_pool_charities.charity_id");
         }
 
-        $organizations = $organizations->where("charity_status","=","Registered")->paginate(7);
+        $organizations = $organizations->where("charity_status","=","Registered")->paginate(7)->onEachSide(1);
         $total = $organizations->total();
         $selected_vendors = explode(",",$request->selected_vendors);
 
         return view('volunteering.partials.organizations', compact('selected_vendors','organizations','total'))->render();
     }
+
+    function bc_gov_id(Request $request){
+        $record = EmployeeJob::where("emplid","=",$request->id)->join("business_units","business_units.code","employee_jobs.business_unit")->selectRaw("business_units.id as business_unit_id, employee_jobs.office_city, employee_jobs.region_id")->first();
+        if(!empty($record)){
+            return response()->json($record, 200);
+        }
+        else{
+            return response()->json([
+                'message' => 'Employee Id not found'], 404);
+        }
+    }
+
+    function business_unit(Request $request){
+        $record = Organization::where("organizations.code","=",$request->id)->join("business_units","business_units.code","organizations.bu_code")->selectRaw("business_units.id as business_unit_id, organizations.bu_code")->first();
+        if(!empty($record->bu_code)){
+            return response()->json($record, 200);
+        }
+        else{
+            return response()->json([
+                'message' => 'Organization Code not found'], 404);
+        }
+    }
+
 }

--- a/resources/views/volunteering/partials/add-event-js.blade.php
+++ b/resources/views/volunteering/partials/add-event-js.blade.php
@@ -455,4 +455,73 @@ $("#attachment_input_1").val("");
             templateSelection:formatState
         }
     );
+
+
+    $("body").on("blur","#bc_gov_id",function(){
+        $.ajax({
+            url: "/bank_deposit_form/bc_gov_id?id="+$(this).val(),
+            type: "GET",
+            headers: {'X-CSRF-TOKEN': $("input[name='_token']").val()},
+            processData: false,
+            cache: false,
+            contentType: false,
+            dataType: 'json',
+            success:function(response){
+                $("#employment_city").parents(".form-body").fadeTo("fast",0.25);
+                $("#employment_city").val(response.office_city).select2();
+                $("#region").val(response.region_id).select2();
+                $("#business_unit").val(response.business_unit_id).select2();
+                setTimeout(function(){
+                    $("#employment_city").parents(".form-body").fadeTo("slow",1);
+                },500);
+            },
+            error: function(response) {
+                Swal.fire({
+                    title: '<strong>Not Found!</strong>',
+                    icon: 'error',
+                    html:
+                        'Employee Id not Found!',
+                    showCloseButton: true,
+                    showCancelButton: true,
+                    focusConfirm: false,
+                });
+            },
+        });
+    });
+
+    $("body").on("change","#organization_code",function(){
+        if($(this).val() != "GOV"){
+            $.ajax({
+                url: "/bank_deposit_form/business_unit?id="+$(this).val(),
+                type: "GET",
+                headers: {'X-CSRF-TOKEN': $("input[name='_token']").val()},
+                processData: false,
+                cache: false,
+                contentType: false,
+                dataType: 'json',
+                success:function(response){
+                    $("#employment_city").parents(".form-body").fadeTo("fast",0.25);
+                    $("#business_unit").val(response.business_unit_id).select2();
+                    setTimeout(function(){
+                        $("#employment_city").parents(".form-body").fadeTo("slow",1);
+                    },500);
+                },
+                error: function(response) {
+                    Swal.fire({
+                        title: '<strong>Not Found!</strong>',
+                        icon: 'error',
+                        html:
+                            'Business Unit not found!',
+                        showCloseButton: true,
+                        showCancelButton: true,
+                        focusConfirm: false,
+                    });
+                },
+            });
+        }
+
+
+    });
+
+
 </script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -177,6 +177,8 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/bank_deposit_form/organization_code', [BankDepositFormController::class, 'organization_code'])->name('organization_code_ajax');
     Route::get('/bank_deposit_form/organization_name', [BankDepositFormController::class, 'organization_name'])->name('organization_name_ajax');
     Route::get('/bank_deposit_form/organizations', [BankDepositFormController::class, 'organizations'])->name('organizations');
+    Route::get('/bank_deposit_form/bc_gov_id',[BankDepositFormController::class, 'bc_gov_id'])->name('bc_gov_id');
+    Route::get('/bank_deposit_form/business_unit',[BankDepositFormController::class, 'business_unit'])->name('business_unit');
 
     Route::post('/bank_deposit_form', [BankDepositFormController::class, 'store'])->name('bank_deposit_form');
     Route::post('/bank_deposit_form/update', [BankDepositFormController::class, 'update'])->name('bank_deposit_form.update');
@@ -299,7 +301,7 @@ Route::middleware(['auth'])->prefix('reporting')->name('reporting.')->group(func
     Route::resource('/donation-upload', DonationUploadController::class)->only(['index','store','show']);
     Route::resource('/donation-data', DonationDataController::class)->only(['index']);
 
-    // Eligible Employee Count 
+    // Eligible Employee Count
     Route::resource('/eligible-employee-count', EligibleEmployeeCountController::class)->only(['index']);
 
     // Eligible Employee Reporting
@@ -308,19 +310,19 @@ Route::middleware(['auth'])->prefix('reporting')->name('reporting.')->group(func
     Route::get('/eligible-employees/download-export-file/{id}', [EligibleEmployeeReportController::class,'downloadExportFile'])->name('eligible-employees.download-export-file');
     Route::resource('/eligible-employees', EligibleEmployeeReportController::class)->only(['index']);
 
-    // Annual and Event Pledge Report 
+    // Annual and Event Pledge Report
     Route::get('/pledges/export', [PledgeReportController::class,'export2csv'])->name('pledges.export2csv');
     Route::get('/pledges/export-progress/{id}', [PledgeReportController::class,'exportProgress'])->name('pledges.export2csv-progress');
     Route::get('/pledges/download-export-file/{id}', [PledgeReportController::class,'downloadExportFile'])->name('pledges.download-export-file');
     Route::resource('/pledges', PledgeReportController::class)->only(['index', 'show']);
 
-    // Annual and Event Charities Report 
+    // Annual and Event Charities Report
     Route::get('/pledge-charities/export', [PledgeCharityReportController::class,'export2csv'])->name('pledge-charities.export2csv');
     Route::get('/pledge-charities/export-progress/{id}', [PledgeCharityReportController::class,'exportProgress'])->name('pledge-charities.export2csv-progress');
     Route::get('/pledge-charities/download-export-file/{id}', [PledgeCharityReportController::class,'downloadExportFile'])->name('pledge-charities.download-export-file');
     Route::resource('/pledge-charities', PledgeCharityReportController::class)->only(['index', 'show']);
 
-    // Charities Report 
+    // Charities Report
     Route::get('/cra-charities/export', [CRACharityReportController::class,'export2csv'])->name('cra-charities.export2csv');
     Route::get('/cra-charities/export-progress/{id}', [CRACharityReportController::class,'exportProgress'])->name('cra-charities.export2csv-progress');
     Route::get('/cra-charities/download-export-file/{id}', [CRACharityReportController::class,'downloadExportFile'])->name('cra-charities.download-export-file');


### PR DESCRIPTION
[Ticket](https://bcgov.sharepoint.com/:w:/r/teams/02365/Shared%20Documents/Greenfield%20Backlog/Business%20requirements/Greenfield%20-eForm%20Demographic%20pre-population.docx?d=wb9bf8960beef47888f6a544762575a10&csf=1&web=1&e=kivJjM)

Programming:  

When a user has selected GOV and entered their employee ID, the Employment city, Region and Business Unit should pre-populate with their user profile demographic information.  

Graphical user interface, application

Description automatically generated 

If there is no user profile demographic information, the user should fill out their own information. 

When a user has selected anything other than gov the associated/linked business unit pre-populates in the Business Unit field.  