### PR TITLE
Test migration - Admin: Next button doesn't work for Create/edit campaign pledge [jp-bugfix-0010]

### DIFF
--- a/resources/views/admin-pledge/campaign/wizard.blade.php
+++ b/resources/views/admin-pledge/campaign/wizard.blade.php
@@ -422,7 +422,7 @@ $(function () {
 
             $.ajax({
                 method: "POST",
-                url:  '/admin-pledge/campaign/' ,
+                url : "{{ route('admin-pledge.campaign.store') }}",
                 //data: form.serialize(),
                 data: form.find(':not(input[name=_method])').serialize(),  // serializes the form's elements exclude _method.
                 async: false,


### PR DESCRIPTION
[Issue Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FGkbV4oAxFkqNduBZo0KcL2UADqz8%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)

Root Cause:
Mixed Content: The page at 'https://pecsf-new-test.apps.silver.devops.gov.bc.ca/admin-pledge/campaign/create' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://pecsf-new-test.apps.silver.devops.gov.bc.ca/admin-pledge/campaign'. This request has been blocked; the content must be served over HTTPS.
send @ app.js:16712

Solution:
Use: replace the hardcoded by using route function called