### PR TITLE
PECSF slides - Pause Youtube video when user navigate to next page [jp-bugfix-0011]

### DIFF
--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -136,7 +136,12 @@
 <script src="{{ asset('vendor/sweetalert2/sweetalert2.min.js') }}" ></script>
 
 <script>
+
+$(function () {    
     $('#learn-more-modal').on('slide.bs.carousel', function (e) {
+
+        $('#movie_player').attr('src', 'https://www.youtube-nocookie.com/embed/ZMEjHqr3npo')
+        
         if(e.to == 0) {
             $(this).find(".prev-btn").addClass("d-none");
             $(this).find(".start-btn").removeClass("d-none");
@@ -151,6 +156,7 @@
             $(this).find(".next-btn").removeClass("d-none")
             $(this).find(".ready-btn").addClass("d-none");
         }
+
     })
 
     $('#learn-more-modal').on('show.bs.modal', function (event) {
@@ -192,7 +198,7 @@
 
         }
     });
-
+});
 
 </script>
 @endpush

--- a/resources/views/donations/partials/learn-more-modal.blade.php
+++ b/resources/views/donations/partials/learn-more-modal.blade.php
@@ -17,7 +17,7 @@
                             Why donate to the Provincial Employees Community Service Fund?
                         </h3>
                         <div class="my-4">
-                            <iframe width="560" height="315" src="https://www.youtube-nocookie.com/embed/ZMEjHqr3npo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            <iframe id="movie_player" width="560" height="315" src="https://www.youtube-nocookie.com/embed/ZMEjHqr3npo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                         </div>
                     </div>
                     <div class="carousel-item">


### PR DESCRIPTION
The PECSF slides displayed on the click of ‘Why Donate to PECSF’ button has a Youtube video on the first page.  

The video can be played by clicking the play button. 

While the video is playing, user can click on ‘Learn more about how to donate’ button. When button is clicked, user navigates to the next page, but the YouTube video keeps on playing in the background 

Expected result: Can we pause the video when user clicks on Why Donate to PECSF button 

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2FtaskListType%2FsmartList%2FSL_AssignedToMe%2Fplan%2FZOb3bFXcakWu8Gl2Zd_PuGUAFIJt%2Ftask%2FhEkLqcXZAUyjRO0zGXtYxmUAIQIQ%22%7D)