### PR TITLE
S40(09) DEV - Daily Campaign Update - Part 2 [jp-0001]

### DIFF
--- a/app/Exports/DailyCampaignByBUExport.php
+++ b/app/Exports/DailyCampaignByBUExport.php
@@ -38,7 +38,7 @@ class DailyCampaignByBUExport implements FromCollection, WithHeadings, WithColum
                             ->where('campaign_year', $this->campaign_year)
                             ->where('as_of_date', $this->as_of_date)
                             ->where('eligible_employee_count', '>=', 5)
-                            ->whereNotNull('dollars')
+                            // ->whereNotNull('dollars')
                             ->select('business_unit_name', 'donors', 'dollars')
                             ->orderBy('business_unit_name')
                             ->get();


### PR DESCRIPTION
The daily campaign update will be a more detailed view of stats, accessible for anyone who using the PECSF app. These are updated daily during a PECSF campaign (typically, mid/late Sept to early Nov) and once final totals have been announced (late January).

Additional change : fix bug in DailyCampaignByBUExport

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2F2lqkNB58wEuqiMkpBLGjtWUANfWQ%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)