### PR TITLE
DEV - PSFT integration -- conditionally allow send transaction immediately to PSFT [jp-bugfix-0012]

### DIFF
--- a/app/Console/Commands/ExportPledgesToPSFT.php
+++ b/app/Console/Commands/ExportPledgesToPSFT.php
@@ -11,6 +11,7 @@ use App\Models\ExportAuditLog;
 use App\Models\DonateNowPledge;
 use Illuminate\Console\Command;
 use App\Models\ScheduleJobAudit;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Http;
 use App\Models\SpecialCampaignPledge;
 
@@ -25,7 +26,7 @@ class ExportPledgesToPSFT extends Command
      *
      * @var string
      */
-    protected $signature = 'command:ExportPledgesToPSFT'; 
+    protected $signature = 'command:ExportPledgesToPSFT {--now=0}'; 
 
     /**
      * The console command description.
@@ -37,7 +38,7 @@ class ExportPledgesToPSFT extends Command
     /* Source Type is HCM */
     protected $message;
     protected $status;
-    
+    protected $bypass_rule_for_testing_purpose;
 
     /**
      * Create a new command instance.
@@ -53,6 +54,8 @@ class ExportPledgesToPSFT extends Command
         $this->skip = 0;
         $this->failure = 0;
 
+        $this->bypass_rule_for_testing_purpose = false;
+
         $this->message = '';
         $this->status = 'Completed';
 
@@ -66,11 +69,24 @@ class ExportPledgesToPSFT extends Command
     public function handle()
     {
 
+        // This flag use for testing purpose, by pass business rule when to send data to PSFT
+        $this->bypass_rule_for_testing_purpose = false;
+        if ($this->option('now') && $this->option('now') == 1 && (!(App::environment('prod')) )) {
+            $this->bypass_rule_for_testing_purpose = true;
+        }
+
         $this->task = ScheduleJobAudit::Create([
             'job_name' => $this->signature,
             'start_time' => Carbon::now(),
             'status' => 'Processing',
         ]);
+
+
+        $this->LogMessage("Process run on " . today()->format('Y-m-d'));
+        if (!(App::environment('prod'))) {
+            $this->LogMessage("Bypass Rule (when to send to PSFT) for testing purpose is " . ($this->bypass_rule_for_testing_purpose ? 'Yes' : 'No'));
+        }
+        $this->LogMessage( "" );        
 
         // Step 1 : Send Campiagn Type data to PeopleSoft access endpoint 
         $this->LogMessage( now() );        
@@ -138,12 +154,14 @@ class ExportPledgesToPSFT extends Command
                 continue;
             }
 
-            // check whether the campaign is not open or active
-            $campaign_year = CampaignYear::where('id',   $pledge->campaign_year_id )->first();
-            if (!($campaign_year->canSendToPSFT() )) {
-                $this->LogMessage( "(SKIP) Campaign Year is not allow to send to PSFT in Transaction {$pledge->id} - " . json_encode( $pledge->only(['id','organization_id','user_id','campaign_year_id', 'type', 'f_s_pool_id','one_time_amount','pay_period_amount','goal_amount','ods_export_status','ods_export_at'])) );
-                $pledge_skip_count += 1;
-                continue;
+            if (!($this->bypass_rule_for_testing_purpose)) {
+                // check whether the campaign is not open or active
+                $campaign_year = CampaignYear::where('id',   $pledge->campaign_year_id )->first();
+                if (!($campaign_year->canSendToPSFT() )) {
+                    $this->LogMessage( "(SKIP) Campaign Year is not allow to send to PSFT in Transaction {$pledge->id} - " . json_encode( $pledge->only(['id','organization_id','user_id','campaign_year_id', 'type', 'f_s_pool_id','one_time_amount','pay_period_amount','goal_amount','ods_export_status','ods_export_at'])) );
+                    $pledge_skip_count += 1;
+                    continue;
+                }
             }
 
             // Calculate the deduct pay from 
@@ -257,9 +275,9 @@ class ExportPledgesToPSFT extends Command
         $this->LogMessage("Total number of pledge sent      - " . $pledge_success_count);
 
         $this->logMessage("");
-        $this->LogMessage("ODS Processed - " . $this->row_count);
-        $this->LogMessage("ODS Success   - " . $this->success);
-        $this->LogMessage("ODS failure   - " . $this->failure);
+        $this->LogMessage("ODS transactions (Biweekly and/or One-Time) Processed - " . $this->row_count);
+        $this->LogMessage("ODS transactions (Biweekly and/or One-Time) Success   - " . $this->success);
+        $this->LogMessage("ODS transactions (Biweekly and/or One-Time) failure   - " . $this->failure);
         $this->LogMessage( now() );
         
         return 0;
@@ -292,6 +310,18 @@ class ExportPledgesToPSFT extends Command
             //     continue;
             // }
 
+            if (!($this->bypass_rule_for_testing_purpose)) {
+                if (!( today() >= $pledge->deduct_pay_from->subDays(8) )) {
+                    $this->LogMessage( "(SKIP) The deduct_pay_from (" . $pledge->deduct_pay_from->format('Y-m-d') . ") on this transaction is not reached yet (8 days rule) - " . 
+                                json_encode( $pledge->only(['id','organization_id','emplid', 'pecsf_id','yearcd','seqno','type','region_id',
+                                        'fs_pool_id','charity_id','sepcial program',
+                                        'one_time_amount','deduct_pay_from', 'ods_export_status','ods_export_at']))
+                                 );
+                    $this->skip += 1;
+                    continue;
+                }
+            }
+
             // validation -- GUID 
             $user = User::where('id', $pledge->user_id)->first();
             // if (!$user->guid ) {
@@ -311,7 +341,6 @@ class ExportPledgesToPSFT extends Command
                 $this->skip += 1;
                 continue;
             }
-
 
             // One-time
             if ($pledge->one_time_amount != 0) { 
@@ -396,6 +425,17 @@ class ExportPledgesToPSFT extends Command
             //     continue;
             // }
 
+            if (!($this->bypass_rule_for_testing_purpose)) {
+                if (!( today() >= $pledge->deduct_pay_from->subDays(8) )) {
+                    $this->LogMessage( "(SKIP) The deduct_pay_from (" . $pledge->deduct_pay_from->format('Y-m-d') . ") on this transaction is not reached yet (8 days rule) - " . 
+                                json_encode( $pledge->only(['id','organization_id','emplid', 'pecsf_id','yearcd','seqno', 'special_campaign_id',
+                                    'one_time_amount','deduct_pay_from', 'ods_export_status','ods_export_at']))
+                                );
+                    $this->skip += 1;
+                    continue;
+                }
+            }
+
             // validation -- GUID 
             $user = User::where('id', $pledge->user_id)->first();
             // if (!$user->guid ) {
@@ -415,6 +455,8 @@ class ExportPledgesToPSFT extends Command
                 $this->skip += 1;
                 continue;
             }
+
+
 
             // One-time
             if ($pledge->one_time_amount != 0) { 


### PR DESCRIPTION
For allow sending transaction on lower region, update the program, allow to send transactions to PSFT immediately on the lower region conditionally with a flag called --now=1

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FdvBz8hF1MEO5dAWWe7t0tWUAI956%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)