### PR TITLE
s41(16) PECSF slides - Pause Youtube video when user navigate to next page [jp-bugfix-0011] 

### DIFF
--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -140,7 +140,8 @@
 $(function () {    
     $('#learn-more-modal').on('slide.bs.carousel', function (e) {
 
-        $('#movie_player').attr('src', 'https://www.youtube-nocookie.com/embed/ZMEjHqr3npo')
+        movie_id = $('#movie_player').attr('movie-id');
+        $('#movie_player').attr('src', movie_id);
         
         if(e.to == 0) {
             $(this).find(".prev-btn").addClass("d-none");
@@ -158,10 +159,16 @@ $(function () {
         }
 
     })
-
+    
     $('#learn-more-modal').on('show.bs.modal', function (event) {
         $('#donateGuideCarousel').carousel(0);
+        movie_id = $('#movie_player').attr('movie-id');
+        $('#movie_player').attr('src', movie_id);
     })
+
+    $("#learn-more-modal").on("hidden.bs.modal", function () {
+        $('#movie_player').attr('src', '')
+    });
 
     $('.more-info').click( function(event) {
         event.stopPropagation();

--- a/resources/views/donations/partials/learn-more-modal.blade.php
+++ b/resources/views/donations/partials/learn-more-modal.blade.php
@@ -17,7 +17,8 @@
                             Why donate to the Provincial Employees Community Service Fund?
                         </h3>
                         <div class="my-4">
-                            <iframe id="movie_player" width="560" height="315" src="https://www.youtube-nocookie.com/embed/ZMEjHqr3npo" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                            <iframe id="movie_player" movie-id="https://www.youtube-nocookie.com/embed/ZMEjHqr3npo"
+                                width="560" height="315" src="" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                         </div>
                     </div>
                     <div class="carousel-item">


### PR DESCRIPTION
Fixed the addition finding reported on May 12 -- I have seen one more issue here when we play the youtube video and close the PECSF slides modal, the video still keeps playing in the background. 

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FhEkLqcXZAUyjRO0zGXtYxmUAIQIQ%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)