### PR TITLE
Browser Back button control on Annual Campaign page [jp-bugfix-0015]

### DIFF
--- a/resources/views/annual-campaign/wizard.blade.php
+++ b/resources/views/annual-campaign/wizard.blade.php
@@ -292,6 +292,25 @@ $(function () {
         }
     });
 
+    // treat browser back button like the 'back' button in this wizard page
+    history.pushState(null, null, location.href);
+    window.addEventListener('popstate', function(event) {
+        url = this.location.href;
+        if (url.indexOf('annual-campaign/create')) {
+            current_step = $("input[type=hidden][name='step']").val();
+            if (current_step == 1) {
+                // back
+                $(".cancel").trigger("click");
+            } else {
+                history.pushState(null, null, location.href);
+                $(".back").trigger("click");
+            }
+        }
+    });
+
+
+
+
     $(document).on("keyup keypress", "#annual-campaign-form", function(e) {
         var keyCode = e.keyCode || e.which;
         if (keyCode === 13) {
@@ -436,6 +455,9 @@ $(function () {
 
     // DISPLAY AND HIDE "NEXT", "BACK" AND "SUMBIT" BUTTONS
     hideButtons = function(step) {
+        // sync variable and the hidden variable
+        $("input[type=hidden][name='step']").val( step );
+
         var limit = parseInt($(".step").length);
         $(".action").hide();
         $(".cancel").hide();


### PR DESCRIPTION
The ‘Back’ button from the browser when clicked in the Donations flow, leaves the user on the home page.  

We are hoping to find a solution so that the browser back button behaves the same way as the Back button in the donation flow.  

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2FtaskListType%2FsmartList%2FSL_AssignedToMe%2Fplan%2FZOb3bFXcakWu8Gl2Zd_PuGUAFIJt%2Ftask%2FafY-XLDot0yuiHi5r862FGUAE2zN%22%7D)