### PR TITLE
S41(16) PECSF slides - PECSF Youtube link: Make the Closed captioning setting turned on by default [jp-bugfix-0011]

### DIFF
--- a/resources/views/donations/partials/learn-more-modal.blade.php
+++ b/resources/views/donations/partials/learn-more-modal.blade.php
@@ -17,7 +17,7 @@
                             Why donate to the Provincial Employees Community Service Fund?
                         </h3>
                         <div class="my-4">
-                            <iframe id="movie_player" movie-id="https://www.youtube-nocookie.com/embed/ZMEjHqr3npo"
+                            <iframe id="movie_player" movie-id="https://www.youtube-nocookie.com/embed/ZMEjHqr3npo?cc_load_policy=1"
                                 width="560" height="315" src="" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
                         </div>
                     </div>


### PR DESCRIPTION
Enhancement received from UAT: "for accessiblity those who cannot hear would need closed captioning, can this be added to videos?"
Right now, when the Youtube link is played, the CC option is turned off. Is there any way to turn on and make the setting as default?

[Ticket ](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2FtaskListType%2FsmartList%2FSL_AssignedToMe%2Fplan%2FZOb3bFXcakWu8Gl2Zd_PuGUAFIJt%2Ftask%2FTttqFlKUY0yP043KbipcUWUAA4gR%22%7D)