### PR TITLE
Dev - System Notification in the Event of Data Interface Errors [jp-0002]

### DIFF
--- a/app/Console/Commands/ImportNonGovPledgeHistory.php
+++ b/app/Console/Commands/ImportNonGovPledgeHistory.php
@@ -129,9 +129,11 @@ class ImportNonGovPledgeHistory extends Command
         $filter = '(yearcd eq '. $in_year .')';
                 
         // try {
-            $response = Http::withHeaders(['Content-Type' => 'application/json'])
-                ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
-                ->get(env('ODS_INBOUND_REPORT_NON_GOV_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
+        $response = Http::withHeaders(['Content-Type' => 'application/json'])
+            ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
+            ->get(env('ODS_INBOUND_REPORT_NON_GOV_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
+
+        if ($response->successful()) {
 
             $row_count = json_decode($response->body())->{'@odata.count'};
             
@@ -219,6 +221,15 @@ class ImportNonGovPledgeHistory extends Command
                 }
 
             }
+
+        } else {
+
+            $this->status = 'Error';
+            $this->LogMessage( $response->status() . ' - ' . $response->body() );
+            
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
+
+        }
 
         // } catch (\Exception $ex) {
 

--- a/app/Console/Commands/ImportPledgeHistory.php
+++ b/app/Console/Commands/ImportPledgeHistory.php
@@ -186,12 +186,13 @@ class ImportPledgeHistory extends Command
     {
 
         // try {
-            $response = Http::withHeaders(['Content-Type' => 'application/json'])
-            ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
-            ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_VNDR_BI_ENDPOINT') .'?$count=true&$top=1');
+        $response = Http::withHeaders(['Content-Type' => 'application/json'])
+        ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
+        ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_VNDR_BI_ENDPOINT') .'?$count=true&$top=1');
 
+        if ($response->successful()) {
             $row_count = json_decode($response->body())->{'@odata.count'};
-           
+            
             if ($row_count > 0) {
                 // Truncate Pledge History table when records returned from BI
                 PledgeHistoryVendor::truncate();
@@ -252,6 +253,14 @@ class ImportPledgeHistory extends Command
 
             }
 
+        } else {
+
+            $this->status = 'Error';
+            $this->LogMessage( $response->status() . ' - ' . $response->body() );
+
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
+        }
+
         // } catch (\Exception $ex) {
 
         //     $this->status = 'Error';
@@ -272,10 +281,11 @@ class ImportPledgeHistory extends Command
         $filter = '(yearcd eq '. $in_year .')';
 
         // try {
-            $response = Http::withHeaders(['Content-Type' => 'application/json'])
-                ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
-                ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
+        $response = Http::withHeaders(['Content-Type' => 'application/json'])
+            ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
+            ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
 
+        if ($response->successful()) {                
             $row_count = json_decode($response->body())->{'@odata.count'};
             
             $size = 10000;
@@ -373,9 +383,15 @@ class ImportPledgeHistory extends Command
                     $this->status = 'Error';
                     $this->LogMessage( $response->status() . ' - ' . $response->body() );
 
-                }
+                    throw new Exception( $response->status() . ' - ' . $response->body()   );
 
+                }
             }
+
+        } else {
+
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
+        }
 
         // } catch (\Exception $ex) {
         

--- a/app/MicrosoftGraph/SendEmailNotification.php
+++ b/app/MicrosoftGraph/SendEmailNotification.php
@@ -71,7 +71,7 @@ class SendEmailNotification
     protected function sendMailUsingSMPTServer() 
     {
 
-        $this->subject = "PECSF [". App::environment() . "] -- The Process ('" . $this->job_id  . " - ". $this->job_name . ")' was failed to complete.";
+        $this->subject = "PECSF [". App::environment() . "] -- The Process (" . $this->job_id  . " - ". $this->job_name . ") was failed to complete.";
 
         $this->body = "<p>";
         $this->body .= "Process ID   : " . $this->job_id . "</br>";


### PR DESCRIPTION
From MNP walkthrough of the interface process and the scheduled job run for the API call from ODS, the status of the job run is stored in Greenfield, and no notification is sent when the job run fails.

Schedule Job Audits logs cover import/export.


Additional improvement on the error handling.

[ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2Fixaf9A6LEkmA0OymF8HK8GUAFAIA%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)