### PR TITLE
TEST migration -- Dev - System Notification in the Event of Data Interface Errors [jp-0002]

### DIFF
--- a/app/Console/Commands/ExportDatabaseToBI.php
+++ b/app/Console/Commands/ExportDatabaseToBI.php
@@ -245,6 +245,8 @@ class ExportDatabaseToBI extends Command
                 $this->status = 'Error';
                 $this->LogMessage( $response->status() . ' - ' . $response->body() );
 
+                throw new Exception( $response->status() . ' - ' . $response->body()   );
+
                 $this->failure += 1;
                 return false;
             }

--- a/app/Console/Commands/ExportDatabaseToBI.php
+++ b/app/Console/Commands/ExportDatabaseToBI.php
@@ -38,6 +38,7 @@ class ExportDatabaseToBI extends Command
 
     ];
  
+    protected $task;
     protected $success;
     protected $failure;
     protected $message;
@@ -117,69 +118,93 @@ class ExportDatabaseToBI extends Command
         ]);
 
         $this->task = $task;
+
+        try {
          
-        // Get the latest success job 
-        $last_job = ScheduleJobAudit::where('job_name', $job_name)
-                      ->where('status','Completed')
-                      ->orderBy('end_time', 'desc')->first();
+            // Get the latest success job 
+            $last_job = ScheduleJobAudit::where('job_name', $job_name)
+                        ->where('status','Completed')
+                        ->orderBy('end_time', 'desc')->first();
 
 
-        $last_start_time = $last_job ? $last_job->start_time : '2000-01-01' ; 
+            $last_start_time = $last_job ? $last_job->start_time : '2000-01-01' ; 
 
-        $this->LogMessage("Table '{$table_name}' Detail to BI (Datawarehouse) start on " . now() );
-        $this->Logmessage("");
-        $this->Logmessage("Table Name                   : '{$table_name}' ");
-        $this->LogMessage("The Last send completed time : " . $last_start_time);
-        $this->LogMessage("The schedule Job id          : " . $task->id);
-        $this->LogMessage("The command name             : " . $job_name);
-        
-        // Main Process for each table 
-        $sql = DB::table($table_name)
-            ->when( $last_job && $delta_field, function($q) use($last_start_time, $delta_field, $hidden_fields ) {
-                return $q->where($delta_field, '>=', $last_start_time);
-            })
-            ->orderBy('id');
+            $this->LogMessage("Table '{$table_name}' Detail to BI (Datawarehouse) start on " . now() );
+            $this->Logmessage("");
+            $this->Logmessage("Table Name                   : '{$table_name}' ");
+            $this->LogMessage("The Last send completed time : " . $last_start_time);
+            $this->LogMessage("The schedule Job id          : " . $task->id);
+            $this->LogMessage("The command name             : " . $job_name);
             
-        // Chucking
-        $row_count = 0;
-        $sql->chunk(5000, function($chuck) use($task, $table_name, $hidden_fields, $last_job, &$row_count, &$n) {
-            $this->LogMessage( "Sending table '{$table_name}' batch (5000) - " . ++$n );
+            // Main Process for each table 
+            $sql = DB::table($table_name)
+                ->when( $last_job && $delta_field, function($q) use($last_start_time, $delta_field, $hidden_fields ) {
+                    return $q->where($delta_field, '>=', $last_start_time);
+                })
+                ->orderBy('id');
+                
+            // Chucking
+            $row_count = 0;
+            $sql->chunk(5000, function($chuck) use($task, $table_name, $hidden_fields, $last_job, &$row_count, &$n) {
+                $this->LogMessage( "Sending table '{$table_name}' batch (5000) - " . ++$n );
 
-            //$chuck->makeHidden(['password', 'remember_token']);
-            if ($hidden_fields) {
-                foreach($chuck as $item) {
-                    foreach($hidden_fields as $hidden_field) {
-                        // unset($item->password);
-                        unset($item->$hidden_field);
+                //$chuck->makeHidden(['password', 'remember_token']);
+                if ($hidden_fields) {
+                    foreach($chuck as $item) {
+                        foreach($hidden_fields as $hidden_field) {
+                            // unset($item->password);
+                            unset($item->$hidden_field);
+                        }
+
                     }
-
                 }
-            }
 
-            $pushdata = new stdClass();
-            $pushdata->table_name = $table_name;
-            $pushdata->table_data = json_encode($chuck);
-            $pushdata->delta_ind = $last_job ? "1" : "0";
-         
-            $result = $this->sendData( $pushdata );
-            if ($result) {
-                // Log to the table
-                foreach($chuck as $row)  {
-                    ExportAuditLog::create([
-                        'schedule_job_name' => $task->job_name,
-                        'schedule_job_id' => $task->id,
-                        'to_application' => 'BI',
-                        'table_name' => $table_name,
-                        'row_id' => $row->id,
-                        'row_values' => json_encode($row),
-                    ]);
-
-                    $row_count += 1;
-                }
-            }
+                $pushdata = new stdClass();
+                $pushdata->table_name = $table_name;
+                $pushdata->table_data = json_encode($chuck);
+                $pushdata->delta_ind = $last_job ? "1" : "0";
             
-            unset($pushdata);
-        });
+                $result = $this->sendData( $pushdata );
+                if ($result) {
+                    // Log to the table
+                    foreach($chuck as $row)  {
+                        ExportAuditLog::create([
+                            'schedule_job_name' => $task->job_name,
+                            'schedule_job_id' => $task->id,
+                            'to_application' => 'BI',
+                            'table_name' => $table_name,
+                            'row_id' => $row->id,
+                            'row_values' => json_encode($row),
+                        ]);
+
+                        $row_count += 1;
+                    }
+                }
+                
+                unset($pushdata);
+            });
+
+        } catch (\Exception $ex) {
+
+            // log message in system
+            if ($this->task) {
+                $this->task->status = 'Error';
+                $this->task->end_time = Carbon::now();
+                $this->task->message = $this->task->message . PHP_EOL . $ex->getMessage() . PHP_EOL;
+                $this->task->save();
+            }
+
+            // send out email notification
+            $notify = new \App\MicrosoftGraph\SendEmailNotification();
+            $notify->job_id =  $this->task ? $this->task->id : null;
+            $notify->job_name =  $job_name;
+            $notify->error_message = $ex->getMessage();
+            $notify->send(); 
+
+            // write message to the log  
+            throw new Exception($ex);
+
+        }    
 
         $this->LogMessage("" );
         $this->LogMessage("Success (No of Batch ) - " . $this->success);
@@ -202,7 +227,7 @@ class ExportDatabaseToBI extends Command
     
     protected function sendData($pushdata) {
 
-        try {
+        // try {
 
             $response = Http::withBasicAuth(
                 env('ODS_USERNAME'),
@@ -224,14 +249,14 @@ class ExportDatabaseToBI extends Command
                 return false;
             }
         
-        } catch (\Exception $ex) {
+        // } catch (\Exception $ex) {
 
-            // log message in system
-            $this->status = 'Error';
-            $this->LogMessage( $ex->getMessage() );
+        //     // log message in system
+        //     $this->status = 'Error';
+        //     $this->LogMessage( $ex->getMessage() );
 
-            throw new Exception($ex);
-        }
+        //     throw new Exception($ex);
+        // }
 
     }
 

--- a/app/Console/Commands/ExportPledgesToPSFT.php
+++ b/app/Console/Commands/ExportPledgesToPSFT.php
@@ -555,9 +555,11 @@ class ExportPledgesToPSFT extends Command
         } else {
 
             // log message in system
-            $this->status = 'Error';
+            // $this->status = 'Error';
             $this->LogMessage( "(Error) - Data - " . json_encode($pushdata) );
             $this->LogMessage( "        - " . $response->status() . ' - ' . $response->body() );
+            
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
 
             $this->failure += 1;
 

--- a/app/Console/Commands/ExportPledgesToPSFT.php
+++ b/app/Console/Commands/ExportPledgesToPSFT.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Carbon\Carbon;
+use Exception;
 use App\Models\User;
 use App\Models\Pledge;
 use App\Models\PayCalendar;
@@ -36,6 +37,7 @@ class ExportPledgesToPSFT extends Command
     protected $description = 'Sending pledge transactions to PeopleSoft via ODS';
 
     /* Source Type is HCM */
+    protected $task;
     protected $message;
     protected $status;
     protected $bypass_rule_for_testing_purpose;
@@ -75,40 +77,63 @@ class ExportPledgesToPSFT extends Command
             $this->bypass_rule_for_testing_purpose = true;
         }
 
-        $this->task = ScheduleJobAudit::Create([
-            'job_name' => $this->signature,
-            'start_time' => Carbon::now(),
-            'status' => 'Processing',
-        ]);
+        try {
+
+            $this->task = ScheduleJobAudit::Create([
+                'job_name' => $this->signature,
+                'start_time' => Carbon::now(),
+                'status' => 'Processing',
+            ]);
 
 
-        $this->LogMessage("Process run on " . today()->format('Y-m-d'));
-        if (!(App::environment('prod'))) {
-            $this->LogMessage("Bypass Rule (when to send to PSFT) for testing purpose is " . ($this->bypass_rule_for_testing_purpose ? 'Yes' : 'No'));
-        }
-        $this->LogMessage( "" );        
+            $this->LogMessage("Process run on " . today()->format('Y-m-d'));
+            if (!(App::environment('prod'))) {
+                $this->LogMessage("Bypass Rule (when to send to PSFT) for testing purpose is " . ($this->bypass_rule_for_testing_purpose ? 'Yes' : 'No'));
+            }
+            $this->LogMessage( "" );        
 
-        // Step 1 : Send Campiagn Type data to PeopleSoft access endpoint 
-        $this->LogMessage( now() );        
-        $this->LogMessage("1) Sending Annual Campaign Type pledge data to PeopleSoft");
-        $this->sendCampaignDonationToPeopleSoft();
-        
-        // Step 2 : Send Donate Now Pledge data to PeopleSoft access endpoint 
-        $this->LogMessage( "" );        
-        $this->LogMessage("2) Sending Donate Now Type pledge data to PeopleSoft");
-        $this->sendDonateNowToPeopleSoft();
+            // Step 1 : Send Campiagn Type data to PeopleSoft access endpoint 
+            $this->LogMessage( now() );        
+            $this->LogMessage("1) Sending Annual Campaign Type pledge data to PeopleSoft");
+            $this->sendCampaignDonationToPeopleSoft();
+            
+            // Step 2 : Send Donate Now Pledge data to PeopleSoft access endpoint 
+            $this->LogMessage( "" );        
+            $this->LogMessage("2) Sending Donate Now Type pledge data to PeopleSoft");
+            $this->sendDonateNowToPeopleSoft();
 
-        // Step 3 : Send Special Campaign Pledge data to PeopleSoft access endpoint 
-        $this->LogMessage( "" );        
-        $this->LogMessage("3) Sending Special Campaign Type pledge data to PeopleSoft");
-        $this->sendSpecialCampaignToPeopleSoft();
+            // Step 3 : Send Special Campaign Pledge data to PeopleSoft access endpoint 
+            $this->LogMessage( "" );        
+            $this->LogMessage("3) Sending Special Campaign Type pledge data to PeopleSoft");
+            $this->sendSpecialCampaignToPeopleSoft();
 
-        // Update the Task Audit log
-        $this->task->end_time = Carbon::now();
-        $this->task->status = $this->status;
-        $this->task->message = $this->message;
-        $this->task->save();
+            // Update the Task Audit log
+            $this->task->end_time = Carbon::now();
+            $this->task->status = $this->status;
+            $this->task->message = $this->message;
+            $this->task->save();
 
+        } catch (\Exception $ex) {
+
+            // log message in system
+            if ($this->task) {
+                $this->task->status = 'Error';
+                $this->task->end_time = Carbon::now();
+                $this->task->message = $ex->getMessage() . PHP_EOL;
+                $this->task->save();
+            }
+
+            // send out email notification
+            $notify = new \App\MicrosoftGraph\SendEmailNotification();
+            $notify->job_id =  $this->task ? $this->task->id : null;
+            $notify->job_name =  $this->signature;
+            $notify->error_message = $ex->getMessage();
+            $notify->send(); 
+
+            // write message to the log  
+            throw new Exception($ex);
+
+        }        
 
             
     }
@@ -517,41 +542,27 @@ class ExportPledgesToPSFT extends Command
 
     protected function sendData($pushdata) {
 
-        try {
+        $response = Http::withBasicAuth(
+            env('ODS_USERNAME'),
+            env('ODS_TOKEN')
+        )->withBody( json_encode($pushdata), 'application/json')
+        ->post( env('ODS_OUTBOUND_PLEDGE_PSFT_ENDPOINT') );
 
-            $response = Http::withBasicAuth(
-                env('ODS_USERNAME'),
-                env('ODS_TOKEN')
-            )->withBody( json_encode($pushdata), 'application/json')
-            ->post( env('ODS_OUTBOUND_PLEDGE_PSFT_ENDPOINT') );
+        if ($response->successful()) {
+            $this->success += 1;
+            return true;
 
-            if ($response->successful()) {
-                $this->success += 1;
-                return true;
-
-            } else {
-
-                // log message in system
-                $this->status = 'Error';
-                $this->LogMessage( "(Error) - Data - " . json_encode($pushdata) );
-                $this->LogMessage( "        - " . $response->status() . ' - ' . $response->body() );
-
-                $this->failure += 1;
-
-                return false;
-            }
-
-        } catch (\Exception $ex) {
+        } else {
 
             // log message in system
             $this->status = 'Error';
-            $this->LogMessage( "(Error) - " . json_encode($pushdata) );
-            $this->LogMessage( "          " - $ex->getMessage() );
-            
-            throw new Exception($ex);
+            $this->LogMessage( "(Error) - Data - " . json_encode($pushdata) );
+            $this->LogMessage( "        - " . $response->status() . ' - ' . $response->body() );
 
+            $this->failure += 1;
+
+            return false;
         }
-
       
     }
 

--- a/app/Console/Commands/ImportDepartments.php
+++ b/app/Console/Commands/ImportDepartments.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Carbon\Carbon;
+use Exception;
 use App\Models\Department;
 
 use App\Models\BusinessUnit;
@@ -27,6 +28,7 @@ class ImportDepartments extends Command
     protected $description = 'Load Departments from BI';
 
     /* attributes for share in the command */
+    protected $task;
     protected $message;
     protected $status;
 
@@ -52,23 +54,48 @@ class ImportDepartments extends Command
     public function handle()
     {
 
-        $this->task = ScheduleJobAudit::Create([
-                'job_name' => $this->signature,
-                'start_time' => Carbon::now(),
-                'status' => 'Processing',
-        ]);
+        try {
 
-        $this->LogMessage( now() );
-        $this->LogMessage("Task-- Update/Create - Department");
-        $this->UpdateDepartment();
+            $this->task = ScheduleJobAudit::Create([
+                    'job_name' => $this->signature,
+                    'start_time' => Carbon::now(),
+                    'status' => 'Processing',
+            ]);
 
-        $this->LogMessage( now() );
+            $this->LogMessage( now() );
+            $this->LogMessage("Task-- Update/Create - Department");
+            $this->UpdateDepartment();
 
-        // Update the Task Audit log
-        $this->task->end_time = Carbon::now();
-        $this->task->status = $this->status;
-        $this->task->message = $this->message;
-        $this->task->save();
+            $this->LogMessage( now() );
+
+            // Update the Task Audit log
+            $this->task->end_time = Carbon::now();
+            $this->task->status = $this->status;
+            $this->task->message = $this->message;
+            $this->task->save();
+
+        
+        } catch (\Exception $ex) {
+
+            // log message in system
+            if ($this->task) {
+                $this->task->status = 'Error';
+                $this->task->end_time = Carbon::now();
+                $this->task->message .= $ex->getMessage() . PHP_EOL;
+                $this->task->save();
+            }
+
+            // send out email notification
+            $notify = new \App\MicrosoftGraph\SendEmailNotification();
+            $notify->job_id =  $this->task ? $this->task->id : null;
+            $notify->job_name =  $this->signature;
+            $notify->error_message = $ex->getMessage();
+            $notify->send(); 
+
+            // write message to the log  
+            throw new Exception($ex);
+
+        }
 
         return 0;
     }
@@ -80,62 +107,54 @@ class ImportDepartments extends Command
         $created_count = 0;
         $updated_count = 0;
 
-        try {
-            $response = Http::withHeaders(['Content-Type' => 'application/json'])
-                ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
-                ->get(env('ODS_INBOUND_REPORT_DEPARTMENTS_BI_ENDPOINT'));
+        $response = Http::withHeaders(['Content-Type' => 'application/json'])
+            ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
+            ->get(env('ODS_INBOUND_REPORT_DEPARTMENTS_BI_ENDPOINT'));
 
-            if ($response->successful()) {
-                $size = 1000;
-                $data = json_decode($response->body())->value;
-                $batches = array_chunk($data, $size);
+        if ($response->successful()) {
+            $size = 1000;
+            $data = json_decode($response->body())->value;
+            $batches = array_chunk($data, $size);
 
-                foreach ($batches as $key => $batch) {
-                    $this->LogMessage( '    -- each batch ('.$size.') $key - '. $key );
-                    foreach ($batch as $row) {
+            foreach ($batches as $key => $batch) {
+                $this->LogMessage( '    -- each batch ('.$size.') $key - '. $key );
+                foreach ($batch as $row) {
 
-                        $business_unit = BusinessUnit::where('code', $row->business_unit_code)->first();
+                    $business_unit = BusinessUnit::where('code', $row->business_unit_code)->first();
 
-                        $rec = Department::updateOrCreate([
-                            'bi_department_id' => $row->department_id,
-                        ], [
-                            'department_name' => $row->department_name,
-                            'group' => $row->group,
-                            'yearcd' => $row->yearcd,
-                            'business_unit_code'=> $row->business_unit_code,
-                            'business_unit_name' => $row->business_unit_name,
-                            'business_unit_id' => $business_unit ? $business_unit->id : null,
-                        ]);
+                    $rec = Department::updateOrCreate([
+                        'bi_department_id' => $row->department_id,
+                    ], [
+                        'department_name' => $row->department_name,
+                        'group' => $row->group,
+                        'yearcd' => $row->yearcd,
+                        'business_unit_code'=> $row->business_unit_code,
+                        'business_unit_name' => $row->business_unit_name,
+                        'business_unit_id' => $business_unit ? $business_unit->id : null,
+                    ]);
 
-                        $total_count += 1;
+                    $total_count += 1;
 
-                        if ($rec->wasRecentlyCreated) {
-                            $created_count += 1;
-                        } elseif ($rec->wasChanged() ) {
-                            $updated_count += 1;
-                        } else {
-                            // No Action
-                        }
-
+                    if ($rec->wasRecentlyCreated) {
+                        $created_count += 1;
+                    } elseif ($rec->wasChanged() ) {
+                        $updated_count += 1;
+                    } else {
+                        // No Action
                     }
+
                 }
-
-                $this->LogMessage('    Total Row count     : ' . $total_count  );
-                $this->LogMessage('    Total Created count : ' . $created_count  );
-                $this->LogMessage('    Total Updated count : ' . $updated_count  );
-
-            } else {
-                $this->status = 'Error';
-                $this->LogMessage( $response->status() . ' - ' . $response->body() );
             }
-        } catch (\Exception $ex) {
 
-            // write to log message
+            $this->LogMessage('    Total Row count     : ' . $total_count  );
+            $this->LogMessage('    Total Created count : ' . $created_count  );
+            $this->LogMessage('    Total Updated count : ' . $updated_count  );
+
+        } else {
             $this->status = 'Error';
-            $this->LogMessage( $ex->getMessage() );
-
-            return 1;
+            $this->LogMessage( $response->status() . ' - ' . $response->body() );
         }
+
     }
 
     protected function LogMessage($text)

--- a/app/Console/Commands/ImportDepartments.php
+++ b/app/Console/Commands/ImportDepartments.php
@@ -153,6 +153,8 @@ class ImportDepartments extends Command
         } else {
             $this->status = 'Error';
             $this->LogMessage( $response->status() . ' - ' . $response->body() );
+            
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
         }
 
     }

--- a/app/Console/Commands/ImportEmployeeJob.php
+++ b/app/Console/Commands/ImportEmployeeJob.php
@@ -140,20 +140,20 @@ class ImportEmployeeJob extends Command
         $filter = "";  // Disabled the filter due to process timimg issue
         $orderBy = 'EMPLID asc, EMPL_RCD asc, EFFDT desc, EFFSEQ desc, date_updated desc';
 
-        try {
+        // try {
             // Validate the value...
             $response = Http::withHeaders(['Content-Type' => 'application/json'])
                 ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
                 ->get(env('ODS_INBOUND_REPORT_EMPLOYEE_DEMO_BI_ENDPOINT').'?$count=true&$top=1'.
                                 '&$filter='.$filter.'&$orderBy='.$orderBy);
-        } catch (\Exception $ex) {
+        // } catch (\Exception $ex) {
 
-            // write to log message 
-            $this->status = 'Error';
-            $this->LogMessage( $ex->getMessage() );
+        //     // write to log message 
+        //     $this->status = 'Error';
+        //     $this->LogMessage( $ex->getMessage() );
 
-            return 1;
-        }
+        //     return 1;
+        // }
 
         $row_count = json_decode($response->body())->{'@odata.count'};
         $this->total_count = $row_count;
@@ -312,6 +312,8 @@ class ImportEmployeeJob extends Command
                     // write to log message 
                     $this->status = 'Error';
                     $this->LogMessage( 'Status: ' . $response->status() . ' Response Body: ' .  $response->body() );
+                    
+                    throw new Exception( $response->status() . ' - ' . $response->body()   );
 
                 }
 

--- a/app/Console/Commands/ImportNonGovPledgeHistory.php
+++ b/app/Console/Commands/ImportNonGovPledgeHistory.php
@@ -213,6 +213,8 @@ class ImportNonGovPledgeHistory extends Command
 
                     $this->status = 'Error';
                     $this->LogMessage( $response->status() . ' - ' . $response->body() );
+                    
+                    throw new Exception( $response->status() . ' - ' . $response->body()   );
 
                 }
 

--- a/app/Console/Commands/ImportNonGovPledgeHistory.php
+++ b/app/Console/Commands/ImportNonGovPledgeHistory.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use stdClass;
 use Carbon\Carbon;
+use Exception;
 use Illuminate\Console\Command;
 use App\Models\ScheduleJobAudit;
 use Illuminate\Support\Facades\DB;
@@ -27,10 +28,11 @@ class ImportNonGovPledgeHistory extends Command
      */
     protected $description = 'Import the Non Gov Pledge History data from BI';
 
-        /* Variable for logging */
-        protected $message;
-        protected $status;
-        protected $row_count;
+    /* Variable for logging */
+    protected $task;
+    protected $message;
+    protected $status;
+    protected $row_count;
 
     /**
      * Create a new command instance.
@@ -54,34 +56,58 @@ class ImportNonGovPledgeHistory extends Command
      */
     public function handle()
     {
-        // Determine the start year
-        $last_task = ScheduleJobAudit::where('job_name', $this->signature)
-                            ->where('status', 'Completed')
-                            ->first();
 
-        $start_year = 2005;
-        if ($last_task) {
-            $start_year = (now()->month <= 3) ? now()->year - 2 : now()->year - 1;
-        }
+        try {
 
+            $this->task = ScheduleJobAudit::Create([
+                'job_name' => $this->signature,
+                'start_time' => Carbon::now(),
+                'status' => 'Processing',
+            ]);
 
-        $this->task = ScheduleJobAudit::Create([
-            'job_name' => $this->signature,
-            'start_time' => Carbon::now(),
-            'status' => 'Processing',
-        ]);
+            // Determine the start year
+            $last_task = ScheduleJobAudit::where('job_name', $this->signature)
+                                ->where('status', 'Completed')
+                                ->first();
+
+            $start_year = 2005;
+            if ($last_task) {
+                $start_year = (now()->month <= 3) ? now()->year - 2 : now()->year - 1;
+            }
+
+            $this->LogMessage( now() );    
+            $this->LogMessage("Step - 1 : Create - Non-Gov Pledge History");
+            for ($yr = $start_year; $yr <= now()->year; $yr++) {
+                $this->UpdateNonGovPledgeHistory($yr);
+            }
+
+            $this->LogMessage( now() );    
+            $this->LogMessage("Step - 2 : Create - Non-Gov Pledge History Summary");
+            $this->UpdatePledgeHistorySummary();
+
+            $this->LogMessage( now() );    
         
-        $this->LogMessage( now() );    
-        $this->LogMessage("Step - 1 : Create - Non-Gov Pledge History");
-        for ($yr = $start_year; $yr <= now()->year; $yr++) {
-            $this->UpdateNonGovPledgeHistory($yr);
+        } catch (\Exception $ex) {
+
+            // log message in system
+            if ($this->task) {
+                $this->task->status = 'Error';
+                $this->task->end_time = Carbon::now();
+                $this->task->message = $ex->getMessage() . PHP_EOL;
+                $this->task->save();
+            }
+
+            // send out email notification
+            $notify = new \App\MicrosoftGraph\SendEmailNotification();
+            $notify->job_id =  $this->task ? $this->task->id : null;
+            $notify->job_name =  $this->signature;
+            $notify->error_message = $ex->getMessage();
+            $notify->send(); 
+
+            // write message to the log  
+            throw new Exception($ex);
+
         }
-
-        $this->LogMessage( now() );    
-        $this->LogMessage("Step - 2 : Create - Non-Gov Pledge History Summary");
-        $this->UpdatePledgeHistorySummary();
-
-        $this->LogMessage( now() );    
 
         // Update the Task Audit log
         $this->task->end_time = Carbon::now();
@@ -102,7 +128,7 @@ class ImportNonGovPledgeHistory extends Command
         $this->LogMessage( 'Loading pledge history data for '. $in_year);
         $filter = '(yearcd eq '. $in_year .')';
                 
-        try {
+        // try {
             $response = Http::withHeaders(['Content-Type' => 'application/json'])
                 ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
                 ->get(env('ODS_INBOUND_REPORT_NON_GOV_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
@@ -192,15 +218,15 @@ class ImportNonGovPledgeHistory extends Command
 
             }
 
-        } catch (\Exception $ex) {
+        // } catch (\Exception $ex) {
 
-            // write to log message 
-            $this->status = 'Error';
-            $this->LogMessage( $ex->getMessage() );
+        //     // write to log message 
+        //     $this->status = 'Error';
+        //     $this->LogMessage( $ex->getMessage() );
 
-            return 1;
+        //     return 1;
 
-        }
+        // }
 
     }
 

--- a/app/Console/Commands/ImportNonGovPledgeHistory.php
+++ b/app/Console/Commands/ImportNonGovPledgeHistory.php
@@ -129,9 +129,11 @@ class ImportNonGovPledgeHistory extends Command
         $filter = '(yearcd eq '. $in_year .')';
                 
         // try {
-            $response = Http::withHeaders(['Content-Type' => 'application/json'])
-                ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
-                ->get(env('ODS_INBOUND_REPORT_NON_GOV_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
+        $response = Http::withHeaders(['Content-Type' => 'application/json'])
+            ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
+            ->get(env('ODS_INBOUND_REPORT_NON_GOV_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
+
+        if ($response->successful()) {
 
             $row_count = json_decode($response->body())->{'@odata.count'};
             
@@ -219,6 +221,15 @@ class ImportNonGovPledgeHistory extends Command
                 }
 
             }
+
+        } else {
+
+            $this->status = 'Error';
+            $this->LogMessage( $response->status() . ' - ' . $response->body() );
+            
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
+
+        }
 
         // } catch (\Exception $ex) {
 

--- a/app/Console/Commands/ImportPledgeHistory.php
+++ b/app/Console/Commands/ImportPledgeHistory.php
@@ -186,12 +186,13 @@ class ImportPledgeHistory extends Command
     {
 
         // try {
-            $response = Http::withHeaders(['Content-Type' => 'application/json'])
-            ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
-            ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_VNDR_BI_ENDPOINT') .'?$count=true&$top=1');
+        $response = Http::withHeaders(['Content-Type' => 'application/json'])
+        ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
+        ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_VNDR_BI_ENDPOINT') .'?$count=true&$top=1');
 
+        if ($response->successful()) {
             $row_count = json_decode($response->body())->{'@odata.count'};
-           
+            
             if ($row_count > 0) {
                 // Truncate Pledge History table when records returned from BI
                 PledgeHistoryVendor::truncate();
@@ -252,6 +253,14 @@ class ImportPledgeHistory extends Command
 
             }
 
+        } else {
+
+            $this->status = 'Error';
+            $this->LogMessage( $response->status() . ' - ' . $response->body() );
+
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
+        }
+
         // } catch (\Exception $ex) {
 
         //     $this->status = 'Error';
@@ -272,10 +281,11 @@ class ImportPledgeHistory extends Command
         $filter = '(yearcd eq '. $in_year .')';
 
         // try {
-            $response = Http::withHeaders(['Content-Type' => 'application/json'])
-                ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
-                ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
+        $response = Http::withHeaders(['Content-Type' => 'application/json'])
+            ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
+            ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
 
+        if ($response->successful()) {                
             $row_count = json_decode($response->body())->{'@odata.count'};
             
             $size = 10000;
@@ -373,9 +383,15 @@ class ImportPledgeHistory extends Command
                     $this->status = 'Error';
                     $this->LogMessage( $response->status() . ' - ' . $response->body() );
 
-                }
+                    throw new Exception( $response->status() . ' - ' . $response->body()   );
 
+                }
             }
+
+        } else {
+
+            throw new Exception( $response->status() . ' - ' . $response->body()   );
+        }
 
         // } catch (\Exception $ex) {
         

--- a/app/Console/Commands/ImportPledgeHistory.php
+++ b/app/Console/Commands/ImportPledgeHistory.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use Carbon\Carbon;
+use Exception;
 use App\Models\PledgeHistory;
 use Illuminate\Console\Command;
 // use App\Models\RegionalDistrict;
@@ -29,6 +30,7 @@ class ImportPledgeHistory extends Command
     protected $description = 'Import the Pledge Hostory data from BI';
 
     /* Variable for logging */
+    protected $task;
     protected $message;
     protected $status;
     protected $reload_start_year;
@@ -56,40 +58,66 @@ class ImportPledgeHistory extends Command
     public function handle()
     {
 
-        // Determine the start year
-        $last_task = ScheduleJobAudit::where('job_name', $this->signature)
-                            ->where('status', 'Completed')
-                            ->first();
+        try {
 
-        $start_year = 2005;
-        if ($last_task) {
-            $start_year = (now()->month <= 3) ? now()->year - 2 : now()->year - 1;
-        }
+            $this->task = ScheduleJobAudit::Create([
+                'job_name' => $this->signature,
+                'start_time' => Carbon::now(),
+                'status' => 'Processing',
+            ]);
 
-        $this->task = ScheduleJobAudit::Create([
-            'job_name' => $this->signature,
-            'start_time' => Carbon::now(),
-            'status' => 'Processing',
-        ]);
+            // Determine the start year
+            $last_task = ScheduleJobAudit::where('job_name', $this->signature)
+                                ->where('status', 'Completed')
+                                ->first();
 
-        // $this->LogMessage( now() );
-        // $this->LogMessage("Step - 1 : Update/Create - Region District");
-        // $this->UpdateRegionalDistrict();
+            $start_year = 2005;
+            if ($last_task) {
+                $start_year = (now()->month <= 3) ? now()->year - 2 : now()->year - 1;
+            }
+
         
-        $this->LogMessage( now() );
-        $this->LogMessage("Step - 1 : Reload - Pledge History Vendor");
-        $this->UpdatePledgeHistoryVendor();
 
-        $this->LogMessage( now() );    
-        $this->LogMessage("Step - 2 : Reload - Pledge History");
-        for ($yr = $start_year; $yr <= now()->year; $yr++) {
-            $this->UpdatePledgeHistory($yr);
+            // $this->LogMessage( now() );
+            // $this->LogMessage("Step - 1 : Update/Create - Region District");
+            // $this->UpdateRegionalDistrict();
+            
+            $this->LogMessage( now() );
+            $this->LogMessage("Step - 1 : Reload - Pledge History Vendor");
+            $this->UpdatePledgeHistoryVendor();
+
+            $this->LogMessage( now() );    
+            $this->LogMessage("Step - 2 : Reload - Pledge History");
+            for ($yr = $start_year; $yr <= now()->year; $yr++) {
+                $this->UpdatePledgeHistory($yr);
+            }
+            $this->LogMessage( now() );    
+            $this->LogMessage("Step - 3 : Reload - Pledge History Summary");
+            $this->UpdatePledgeHistorySummary();
+
+            $this->LogMessage( now() );    
+
+        } catch (\Exception $ex) {
+
+            // log message in system
+            if ($this->task) {
+                $this->task->status = 'Error';
+                $this->task->end_time = Carbon::now();
+                $this->task->message = $ex->getMessage() . PHP_EOL;
+                $this->task->save();
+            }
+
+            // send out email notification
+            $notify = new \App\MicrosoftGraph\SendEmailNotification();
+            $notify->job_id =  $this->task ? $this->task->id : null;
+            $notify->job_name =  $this->signature;
+            $notify->error_message = $ex->getMessage();
+            $notify->send(); 
+
+            // write message to the log  
+            throw new Exception($ex);
+
         }
-        $this->LogMessage( now() );    
-        $this->LogMessage("Step - 3 : Reload - Pledge History Summary");
-        $this->UpdatePledgeHistorySummary();
-
-        $this->LogMessage( now() );    
 
         // Update the Task Audit log
         $this->task->end_time = Carbon::now();
@@ -157,7 +185,7 @@ class ImportPledgeHistory extends Command
     protected function UpdatePledgeHistoryVendor() 
     {
 
-        try {
+        // try {
             $response = Http::withHeaders(['Content-Type' => 'application/json'])
             ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
             ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_VNDR_BI_ENDPOINT') .'?$count=true&$top=1');
@@ -223,14 +251,14 @@ class ImportPledgeHistory extends Command
 
             }
 
-        } catch (\Exception $ex) {
+        // } catch (\Exception $ex) {
 
-            $this->status = 'Error';
-            $this->LogMessage( $ex->getMessage() );
+        //     $this->status = 'Error';
+        //     $this->LogMessage( $ex->getMessage() );
 
-            return 1;
+        //     return 1;
 
-        }
+        // }
     }
 
 
@@ -242,7 +270,7 @@ class ImportPledgeHistory extends Command
         $this->LogMessage( 'Loading pledge history data for '. $in_year);
         $filter = '(yearcd eq '. $in_year .')';
 
-        try {
+        // try {
             $response = Http::withHeaders(['Content-Type' => 'application/json'])
                 ->withBasicAuth(env('ODS_USERNAME'),env('ODS_TOKEN'))
                 ->get(env('ODS_INBOUND_REPORT_PLEDGE_HISTORY_BI_ENDPOINT') .'?$count=true&$top=1&$filter='.$filter);
@@ -348,15 +376,15 @@ class ImportPledgeHistory extends Command
 
             }
 
-        } catch (\Exception $ex) {
+        // } catch (\Exception $ex) {
         
-            // write to log message 
-            $this->status = 'Error';
-            $this->LogMessage( $ex->getMessage() );
+        //     // write to log message 
+        //     $this->status = 'Error';
+        //     $this->LogMessage( $ex->getMessage() );
 
-            return 1;
+        //     return 1;
 
-        }
+        // }
     }
 
     protected function UpdatePledgeHistorySummary() {

--- a/app/Console/Commands/ImportPledgeHistory.php
+++ b/app/Console/Commands/ImportPledgeHistory.php
@@ -247,6 +247,7 @@ class ImportPledgeHistory extends Command
                     $this->status = 'Error';
                     $this->LogMessage( $response->status() . ' - ' . $response->body() );
 
+                    throw new Exception( $response->status() . ' - ' . $response->body()   );
                 }
 
             }

--- a/app/Mail/NotifyMail.php
+++ b/app/Mail/NotifyMail.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class NotifyMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public $subject, $body, $from_email;
+
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct($from_email,  $subject, $body)
+    {
+        //
+        // $this->from = $from;
+        $this->subject = $subject;
+        $this->body = $body;
+        $this->from_email = $from_email;
+        
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this->from( $this->from_email  )
+                    ->subject( $this->subject )
+                    ->view('emails.notification-template');
+    }
+}

--- a/app/MicrosoftGraph/SendEmailNotification.php
+++ b/app/MicrosoftGraph/SendEmailNotification.php
@@ -71,7 +71,7 @@ class SendEmailNotification
     protected function sendMailUsingSMPTServer() 
     {
 
-        $this->subject = "PECSF [". App::environment() . "] -- The Process ('" . $this->job_id  . " - ". $this->job_name . ")' was failed to complete.";
+        $this->subject = "PECSF [". App::environment() . "] -- The Process (" . $this->job_id  . " - ". $this->job_name . ") was failed to complete.";
 
         $this->body = "<p>";
         $this->body .= "Process ID   : " . $this->job_id . "</br>";

--- a/app/MicrosoftGraph/SendEmailNotification.php
+++ b/app/MicrosoftGraph/SendEmailNotification.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\MicrosoftGraph;
+
+use DateTime;
+use DateInterval;
+use DateTimeZone;
+use App\Models\User;
+
+use App\Mail\NotifyMail;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Mail;
+
+
+class SendEmailNotification
+{
+
+    //public $toAddresses;
+    public $toRecipients;       /* array -- email addresses */
+    public $ccRecipients;       /* array -- email addresses */
+    public $bccRecipients;      /* array -- email addresses */
+    
+    public $subject;            /* String */
+    public $body;               /* String */
+
+    public $job_id;
+    public $job_name;
+    public $error_message;
+
+    public $bodyContentType;    /* text or html, default is 'html' */
+
+    // Audit Log related
+    public $saveToLog;          /* Boolean -- true or false */
+    
+  
+    public function __construct() 
+    {
+
+        $this->toRecipients = [];
+        $this->ccRecipients = [];
+        $this->bccRecipients = [];
+
+        $this->subject = '';   
+        $this->body = '';   
+
+        $this->job_id = '';
+        $this->job_name = '';
+        $this->error_message = '';
+
+        $this->bodyContentType = 'html';
+        $this->saveToLog = true;
+
+    }
+
+    public function send() 
+    {
+        
+        $switch = env('EMAIL_NOTIFICATION_ENABLED');
+        if (!($switch)) {
+            return true;
+        }
+
+        $this->toRecipients = env('EMAIL_NOTIFICATION_EMAIL_ADDRESSES');   
+
+        return $this->sendMailUsingSMPTServer();
+
+    }
+
+    protected function sendMailUsingSMPTServer() 
+    {
+
+        $this->subject = "PECSF [". App::environment() . "] -- The Process ('" . $this->job_id  . " - ". $this->job_name . ")' was failed to complete.";
+
+        $this->body = "<p>";
+        $this->body .= "Process ID   : " . $this->job_id . "</br>";
+        $this->body .= "Process Name : " . $this->job_name  . "</br>";
+        $this->body .= "Failed at    : " . now()  . "</br>";
+        $this->body .= "</p>";
+        $this->body .= "<p>The process was failed with the following error message: </p>";
+        $this->body .= "<p>" . $this->error_message . "</p>";
+ 
+        // Send immediately
+        $from =  env('MAIL_FROM_ADDRESS');
+        $toAddresses = explode(",", $this->toRecipients);
+        $subject = $this->subject;
+        $body = $this->body;
+
+        Mail::to( $toAddresses )->send(new NotifyMail( $from, $subject, $body ));
+
+        if ($this->saveToLog) {
+            // append onto Notification log file
+            Log::channel('smtp')->info("Process (" . $this->job_id  . " - ". $this->job_name . ") failure notification message sent out to " . $this->toRecipients );
+         
+        }   
+
+        return true;
+
+    }
+
+}

--- a/config/logging.php
+++ b/config/logging.php
@@ -37,7 +37,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['single'],
+            'channels' => ['daily'],
             'ignore_exceptions' => false,
         ],
 
@@ -51,7 +51,12 @@ return [
             'driver' => 'daily',
             'path' => storage_path('logs/laravel.log'),
             'level' => env('LOG_LEVEL', 'debug'),
-            'days' => 14,
+            'days' => 28,
+        ],
+
+        'smtp' => [
+            'driver' => 'single',
+            'path' => storage_path('logs/smtp.log'),
         ],
 
         'slack' => [

--- a/resources/views/emails/notification-template.blade.php
+++ b/resources/views/emails/notification-template.blade.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{{  $subject }}</title>
+</head>
+<body>
+    {!! $body !!}    
+</body>
+</html>


### PR DESCRIPTION
From MNP walkthrough of the interface process and the scheduled job run for the API call from ODS, the status of the job run is stored in Greenfield, and no notification is sent when the job run fails.

Schedule Job Audits logs cover import/export.

Work done: send out email notification when the schedule process was failed.

[ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2Fixaf9A6LEkmA0OymF8HK8GUAFAIA%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)