### PR TITLE
s41(19) DEV - PSFT integration -- conditionally allow send transaction immediately to PSFT [jp-bugfix-0012]

### DIFF
--- a/app/Console/Commands/ExportPledgesToPSFT.php
+++ b/app/Console/Commands/ExportPledgesToPSFT.php
@@ -295,7 +295,7 @@ class ExportPledgesToPSFT extends Command
         $pledgeData = DonateNowPledge::join('organizations', 'donate_now_pledges.organization_id', 'organizations.id')
                             ->where('organizations.code', 'GOV')
                             ->whereNull('donate_now_pledges.ods_export_status')
-                            ->whereNull('donate_now_pledges.cancelled')
+                            ->whereNull('donate_now_pledges.cancelled_at')
                             ->select('donate_now_pledges.*')
                             ->orderBy('donate_now_pledges.id')->get();
 
@@ -410,7 +410,7 @@ class ExportPledgesToPSFT extends Command
         $pledgeData = SpecialCampaignPledge::join('organizations', 'special_campaign_pledges.organization_id', 'organizations.id')
                             ->where('organizations.code', 'GOV')
                             ->whereNull('special_campaign_pledges.ods_export_status')
-                            ->whereNull('special_campaign_pledges.cancelled')
+                            ->whereNull('special_campaign_pledges.cancelled_at')
                             ->select('special_campaign_pledges.*')
                             ->orderBy('special_campaign_pledges.id')
                             ->get();


### PR DESCRIPTION
For allow sending transaction on lower region, update the program, allow to send transactions to PSFT immediately on the lower region conditionally with a flag called --now=1

Addition change: Fix a bug -- the cancelled pledge still sent out to PSFT. 

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FdvBz8hF1MEO5dAWWe7t0tWUAI956%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)

