### PR TITLE
S40(09) DEV - Daily Campaign Update - Part 2 (24th -- s41(17) Challenge page historical ordering)

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -121,7 +121,7 @@ class ChallengeController extends Controller
                                     ) * 100) - COALESCE((select participation_rate from historical_challenge_pages where year = ?
                                         -- and historical_challenge_pages.organization_name = A.organization_name
                                         and historical_challenge_pages.business_unit_code = A.business_unit_code
-                                        ),0) desc
+                                        ),0)
                                         
                         SQL;
 
@@ -147,7 +147,7 @@ class ChallengeController extends Controller
                                                                 and D1.as_of_date <= ?
                                                                 )     
                             and eligible_employee_count >= 5
-                            order by participation_rate desc, abs(change_rate) desc;     
+                            order by participation_rate desc, abs(change_rate);     
                         SQL;
 
                         $challenges = DB::select($sql, $parameters);
@@ -170,7 +170,7 @@ class ChallengeController extends Controller
                       from historical_challenge_pages, (SELECT @row_number:=0) AS temp
                      where year = ?                      
                        and donors >= 5
-                     order by participation_rate desc, abs(`change`) desc;     
+                     order by participation_rate desc, abs(`change`);     
                 SQL;
                 
                 $challenges = DB::select($sql, $parameters);

--- a/resources/views/challenge/index.blade.php
+++ b/resources/views/challenge/index.blade.php
@@ -1,13 +1,5 @@
-@php
-    function ordinal($number) {
-        $ends = array('th','st','nd','rd','th','th','th','th','th','th');
-        if ((($number % 100) >= 11) && (($number%100) <= 13))
-            return $number. 'th';
-        else
-            return $number. $ends[$number % 10];
-    }
-@endphp
 @extends('adminlte::page')
+
 @section('content_header')
 <div class="mt-3">
 <h1>Challenge</h1>
@@ -26,8 +18,8 @@
     If you have questions about PECSF statistics, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca?subject=Challenge%20page">PECSF@gov.bc.ca</a>.</h6>
 </div>
 @endsection
-@section('content')
 
+@section('content')
 
 <div class="card">
     <div class="card-body">
@@ -216,6 +208,10 @@ $(function() {
         serverSide: true,
         select: true,
         paging: false,
+        "initComplete": function(settings, json) {
+            min_height = $(".wrapper").height();
+            $(".main-sidebar").css('min-height', min_height);
+        },
         ajax: {
             url: '{!! route('challenge.index') !!}',
             data: function (data) {


### PR DESCRIPTION
Additional Change: Display order on historial challenge data, e.g. change rate is lower than GCPE so SDPR should come before GCPE.


[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2FtaskListType%2FsmartList%2FSL_AssignedToMe%2Fplan%2FZOb3bFXcakWu8Gl2Zd_PuGUAFIJt%2Ftask%2FGYHfdec1HkGX68ealYy0jWUAI3ks%22%7D)