### PR TITLE
[Test migration] S43 Dev - reposition submenu 'Security - PECSF Administrators' [jp-bugfix-0023]

### DIFF
--- a/app/Http/Controllers/Admin/AdministratorController.php
+++ b/app/Http/Controllers/Admin/AdministratorController.php
@@ -54,7 +54,7 @@ class AdministratorController extends Controller
         }
 
         // load the view and pass the sharks
-        return view('admin-campaign.administrators.index');
+        return view('system-security.administrators.index');
         
     }
 
@@ -92,7 +92,7 @@ class AdministratorController extends Controller
         $user->is_admin = 1;
         $user->save();
         
-        return redirect()->route('settings.administrators.index')
+        return redirect()->route('system.administrators.index')
             ->with('success','User ' . $user->name . ' was assigned to Administrator role.');
 
     }
@@ -157,7 +157,7 @@ class AdministratorController extends Controller
         $user->is_admin = 0;
         $user->save();
 
-        return redirect()->route('settings.administrators.index')
+        return redirect()->route('system.administrators.index')
           ->with('success','User ' . $user->name . '  was removed from Administrator role.');
 
     }

--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -296,29 +296,34 @@ return [
         ],
         [
             'text' => 'System Security',
-            'icon' => 'nav-icon fa fa-user-shield',
+            'icon' => 'nav-icon fa fa-shield-alt',
             'url'  => '/system/schedule-job-audits',
             'can'  => ['setting'],
             'active' => ['system/*'],
             'submenu' => [
                 [
                     'text' => 'Schedule Job Audits',
-                    'icon' => 'nav-icon far fa-circle',
+                    'icon' => 'nav-icon far fa-calendar-check',
                     'url'  => '/system/schedule-job-audits',
                 ],
                 [
+                    'text' => 'Administrators',
+                    'icon' => 'nav-icon fa fa-user-shield',
+                    'url'  => '/system/administrators',
+                ],
+                [
                     'text' => 'Users',
-                    'icon' => 'nav-icon far fa-circle',
+                    'icon' => 'nav-icon far fa-user',
                     'url'  => '/system/users',
                 ],
                 [
                     'text' => 'Auditing',
-                    'icon' => 'nav-icon far fa-circle',
+                    'icon' => 'nav-icon far fa-check-square',
                     'url'  => '/system/auditing',
                 ],
                 [
                     'text' => 'Access Logs',
-                    'icon' => 'nav-icon far fa-circle',
+                    'icon' => 'nav-icon far fa-id-card',
                     'url'  => '/system/access-logs',
                 ],
 

--- a/resources/views/admin-campaign/partials/tabs.blade.php
+++ b/resources/views/admin-campaign/partials/tabs.blade.php
@@ -95,10 +95,6 @@
     </li>
 
     <li class="nav-item">
-          <a class="nav-link {{ str_contains( Route::current()->getName(), 'settings.administrators') ? 'active' : ''}}"
-                href="{{ route('settings.administrators.index') }}">PECSF Administrators</a>
-    </li>
-    <li class="nav-item">
         <a class="nav-link {{ str_contains( Route::current()->getName(), 'settings.challenge') ? 'active' : ''}}"
            href="{{ route('settings.challenge') }}">Challenge Updates</a>
     </li>

--- a/resources/views/system-security/administrators/index.blade.php
+++ b/resources/views/system-security/administrators/index.blade.php
@@ -1,7 +1,7 @@
 @extends('adminlte::page')
 @section('content_header')
 
-    @include('admin-campaign.partials.tabs')
+    @include('system-security.partials.tabs')
     <div class="d-flex mt-3">
         <h4>Security - PECSF Administrators</h4>
         <div class="flex-fill"></div>
@@ -31,7 +31,7 @@
                 <h4></h4>
                 <div class="px-4">
                     
-                    <form action="{{ route('settings.administrators.store') }}" class="form-inline" method="post">
+                    <form action="{{ route('system.administrators.store') }}" class="form-inline" method="post">
                         @csrf
                         <div class="row g-3 align-items-center">
                             <div class="col-auto">
@@ -150,7 +150,7 @@
             select: true,
             'order': [[1, 'asc']],
             ajax: {
-                url: '{!! route('settings.administrators.store') !!}',
+                url: '{!! route('system.administrators.store') !!}',
                 data: function (d) {
                 },
                 error: function(xhr, resp, text) {
@@ -185,7 +185,7 @@
 
         $('#user_id').select2({
             ajax: {
-                url: '/settings/administrators/users'
+                url: '/system/administrators/users'
                 , dataType: 'json'
                 , delay: 250
                 , data: function(params) {
@@ -227,7 +227,7 @@
             }).then((result) => {
                 /* Read more about isConfirmed, isDenied below */
                 if (result.isConfirmed) {
-                    $('#delete-administrator-form').attr('action', '/settings/administrators/' + id );
+                    $('#delete-administrator-form').attr('action', '/system/administrators/' + id );
                     $('#delete-administrator-form').submit();
                 } else if (result.isCancelledDenied) {
                     // Do nothing

--- a/resources/views/system-security/partials/tabs.blade.php
+++ b/resources/views/system-security/partials/tabs.blade.php
@@ -9,6 +9,16 @@
         href="{{ route('system.auditing.index') }}">Auditing</a>
     </li> --}}
 
+    <li class="nav-item">
+      <a class="nav-link {{ str_contains( Route::current()->getName(), 'system.administrators') ? 'active' : ''}}"
+            href="{{ route('system.administrators.index') }}">Administrators</a>
+    </li>
+
+    <li class="nav-item">
+      <a class="nav-link  {{ str_contains( Route::current()->getName(), 'system.users') ? 'active' : ''}}"
+        href="{{ route('system.users.index') }}">Users</a>
+    </li>
+
     <li class="nav-item dropdown">
       @php $active =  ( str_contains(Route::current()->getName(), 'system.auditing') ||
                         str_contains(Route::current()->getName(), 'system.export-audits')
@@ -21,11 +31,6 @@
         <a class="dropdown-item {{ str_contains( Route::current()->getName(), 'system.export-audits') ? 'active' : ''}}"
             href="{{ route('system.export-audits.index') }}">Export Audit Log</a>
       </div>
-    </li>
-
-    <li class="nav-item">
-      <a class="nav-link  {{ str_contains( Route::current()->getName(), 'system.users') ? 'active' : ''}}"
-        href="{{ route('system.users.index') }}">Users</a>
     </li>
 
     <li class="nav-item">

--- a/routes/web.php
+++ b/routes/web.php
@@ -241,20 +241,6 @@ Route::middleware(['auth'])->prefix('settings')->name('settings.')->group(functi
     Route::post('/fund-supported-pools/duplicate/{id}', [FundSupportedPoolController::class,'duplicate'])->name('fund-suppported-pools.duplicate');
     Route::resource('/fund-supported-pools', FundSupportedPoolController::class);
 
-
-    // Administrators
-    Route::resource('/administrators', AdministratorController::class)->only(['index','store', 'destroy']);
-    Route::get('/administrators/users', [AdministratorController::class,'getUsers'])->name('administrators.users');
-    // Route::get('/administrators/{administrator}/delete', [AdministratorController::class,'destroy']);
-
-
-    // Access Log
-    Route::get('/access-logs', [AccessLogController::class, 'index'])->name('access_logs');
-    Route::get('/access-logs-user-detail/{id}', [AccessLogController::class, 'show']);
-
-    // Schedule Job Audit
-    Route::resource('/schedule-job-audits', ScheduleJobAuditController::class)->only(['index','show', 'destroy']);
-
     // Challenge Settings
     Route::get('/', [SettingsController::class,'index'])->name('others');
     Route::get('/challenge', [ChallengeSettingsController::class,'index'])->name('challenge');
@@ -271,6 +257,8 @@ Route::middleware(['auth'])->prefix('admin-pledge')->name('admin-pledge.')->grou
     Route::get('/campaign-users', [CampaignPledgeController::class,'getUsers'])->name('administrators.users');
     Route::get('/campaign-nongov-user', [CampaignPledgeController::class,'getNonGovUserDetail'])->name('administrators.nongovuser');
     Route::get('/campaign-pledgeid', [CampaignPledgeController::class,'getCampaignPledgeID'])->name('administrators.pledgeid');
+
+    // Event Pledges
     Route::resource('/maintain-event', MaintainEventPledgeController::class)->only(['index']);
     Route::resource('/submission-queue', EventSubmissionQueueController::class)->only(['status','details','index']);
     Route::get('/details', [EventSubmissionQueueController::class,"details"])->name('details');
@@ -340,6 +328,10 @@ Route::middleware(['auth'])->prefix('system')->name('system.')->group(function()
     // Schedule Job Audit
     Route::resource('/schedule-job-audits', ScheduleJobAuditController::class)->only(['index','show', 'destroy']);
 
+    // Administrators
+    Route::resource('/administrators', AdministratorController::class)->only(['index','store', 'destroy']);
+    Route::get('/administrators/users', [AdministratorController::class,'getUsers'])->name('administrators.users');
+
     // Users Maintenance
     Route::post('/users/{id}/lock', [UserMaintenanceController::class,'lockUser'])->name('users.lock');
     Route::post('/users/{id}/unlock', [UserMaintenanceController::class,'unlockUser'])->name('users.unlock');
@@ -359,7 +351,4 @@ Route::middleware(['auth'])->prefix('system')->name('system.')->group(function()
     // Upload and download file (seed)
     Route::resource('/upload-files', UploadFileController::class)->only(['index','store','show']);
 
-
-
 });
-


### PR DESCRIPTION
Per agreed, submenu 'Security - PECSF Administrators' should be grouped under 'System Security' menu

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FZwUZUA-mu0O0dBAbnl0wgWUAA8zE%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)