### PR TITLE
Differentiate the environments for users [jp-bugfix-0024]

### DIFF
--- a/resources/views/vendor/adminlte/partials/navbar/menu-item-dropdown-user-menu.blade.php
+++ b/resources/views/vendor/adminlte/partials/navbar/menu-item-dropdown-user-menu.blade.php
@@ -1,0 +1,120 @@
+@php( $logout_url = View::getSection('logout_url') ?? config('adminlte.logout_url', 'logout') )
+@php( $profile_url = View::getSection('profile_url') ?? config('adminlte.profile_url', 'logout') )
+
+@if (config('adminlte.usermenu_profile_url', false))
+    @php( $profile_url = Auth::user()->adminlte_profile_url() )
+@endif
+
+@if (config('adminlte.use_route_url', false))
+    @php( $profile_url = $profile_url ? route($profile_url) : '' )
+    @php( $logout_url = $logout_url ? route($logout_url) : '' )
+@else
+    @php( $profile_url = $profile_url ? url($profile_url) : '' )
+    @php( $logout_url = $logout_url ? url($logout_url) : '' )
+@endif
+
+@if ( env('APP_ENV') != 'prod')
+    <li class="pt-2 px-5 mr-5 border text-white rounded 
+        @switch (env('APP_ENV')) 
+            @case ('dev') 
+                bg-secondary
+                @break;
+            @case ('TEST') 
+                bg-danger 
+                @break;
+            @case ('local') 
+                bg-dark
+                @break;
+            @default
+                bg-info
+        @endswitch 
+    ">
+        <span class="h5 font-weight-bold">> > > &nbsp;
+            @switch (env('APP_ENV')) 
+                @case ('dev') 
+                    DEVELOPMENT ENVIRONMENT
+                    @break;
+                @case ('TEST') 
+                    TEST ENVIRONMENT
+                    @break; 
+                @case ('local') 
+                    LOCAL ENVIRONMENT
+                    @break;
+                @default
+                    {{ strtoupper(env('APP_ENV')) }} ENVIRONMENT </span>
+            @endswitch
+        &nbsp; < < <
+        <span>
+    </li>
+@endif    
+
+<li class="nav-item dropdown user-menu">
+    {{-- User menu toggler --}}
+    <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown">
+        @if(config('adminlte.usermenu_image'))
+            <img src="{{ Auth::user()->adminlte_image() }}"
+                 class="user-image img-circle elevation-2"
+                 alt="{{ Auth::user()->name }}">
+        @endif
+        <span @if(config('adminlte.usermenu_image')) class="d-none d-md-inline" @endif>
+            {{ Auth::user()->name }}
+        </span>
+    </a>
+
+    {{-- User menu dropdown --}}
+    <ul class="dropdown-menu dropdown-menu-lg dropdown-menu-right">
+
+        {{-- User menu header --}}
+        @if(!View::hasSection('usermenu_header') && config('adminlte.usermenu_header'))
+            <li class="user-header {{ config('adminlte.usermenu_header_class', 'bg-primary') }}
+                @if(!config('adminlte.usermenu_image')) h-auto @endif">
+                @if(config('adminlte.usermenu_image'))
+                    <img src="{{ Auth::user()->adminlte_image() }}"
+                         class="img-circle elevation-2"
+                         alt="{{ Auth::user()->name }}">
+                @endif
+                <p class="@if(!config('adminlte.usermenu_image')) mt-0 @endif">
+                    {{ Auth::user()->name }}
+                    @if(config('adminlte.usermenu_desc'))
+                        <small>{{ Auth::user()->adminlte_desc() }}</small>
+                    @endif
+                </p>
+            </li>
+        @else
+            @yield('usermenu_header')
+        @endif
+
+        {{-- Configured user menu links --}}
+        @each('adminlte::partials.navbar.dropdown-item', $adminlte->menu("navbar-user"), 'item')
+
+        {{-- User menu body --}}
+        @hasSection('usermenu_body')
+            <li class="user-body">
+                @yield('usermenu_body')
+            </li>
+        @endif
+
+        {{-- User menu footer --}}
+        <li class="user-footer">
+            @if($profile_url)
+                <a href="{{ $profile_url }}" class="btn btn-default btn-flat">
+                    <i class="fa fa-fw fa-user text-lightblue"></i>
+                    {{ __('adminlte::menu.profile') }}
+                </a>
+            @endif
+            <a class="btn btn-default btn-flat float-right @if(!$profile_url) btn-block @endif"
+               href="#" onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
+                <i class="fa fa-fw fa-power-off text-red"></i>
+                {{ __('adminlte::adminlte.log_out') }}
+            </a>
+            <form id="logout-form" action="{{ $logout_url }}" method="POST" style="display: none;">
+                @if(config('adminlte.logout_method'))
+                    {{ method_field(config('adminlte.logout_method')) }}
+                @endif
+                {{ csrf_field() }}
+            </form>
+        </li>
+
+    </ul>
+
+</li>


### PR DESCRIPTION
we must display something like a label on the environments so that the users can differentiate them looking at the screen instead of the URL

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2F_Su9IaUAe0qDM31dQ7OSOmUAE3K_%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)