### PR TITLE
Pledges and event report issue [jp-bugfix-0027]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "spatie/laravel-permission": "^4.2",
         "yajra/laravel-datatables": "^1.5",
 
-        "phpoffice/phpspreadsheet" : "~1.28.0"
+        "maennchen/zipstream-php" : "^2.1"
     },
     "require-dev": {
         "facade/ignition": "^2.5",


### PR DESCRIPTION
Root Cause:
On server, the PHP version 8.0.29 and not compatilible with updated ZipStream packge per the vendor website information: https://github.com/PHPOffice/PhpSpreadsheet/issues/3616

Resolution:
Force the dependency back to v2 which is compatible with PHP 8.0 by requiring "maennchen/zipstream-php": "^2.4".

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2FtaskListType%2FsmartList%2FSL_AssignedToMe%2Fplan%2FZOb3bFXcakWu8Gl2Zd_PuGUAFIJt%2Ftask%2Fto9FMHaEb0qOp03-dFYYBGUABWqY%22%7D)