### PR TITLE
[jp-bugfix-0029] '301 Moved Permanently' error happened on Admin Donate Now and Sepcial Campaign Pledges

### DIFF
--- a/resources/views/admin-pledge/donate-now/create-edit.blade.php
+++ b/resources/views/admin-pledge/donate-now/create-edit.blade.php
@@ -663,7 +663,7 @@ $(function () {
                 // method: "PUT",
                 //     url:  '/settings/business-units/' + id,
                 method: "POST",
-                url: "/admin-pledge/donate-now/{{ $pledge->id ? $pledge->id : '' }}", 
+                url: "/admin-pledge/donate-now{{ $pledge->id ? '/'.$pledge->id : '' }}", 
                 //data: form.serialize(), 
                 @if ($is_new_pledge) 
                     data: form.find(':not(input[name=_method])').serialize(),  // serializes the form's elements exclude _method.

--- a/resources/views/admin-pledge/special-campaign/create-edit.blade.php
+++ b/resources/views/admin-pledge/special-campaign/create-edit.blade.php
@@ -684,7 +684,7 @@ console.log( index + ' - ' + select_year + ' - ' + start_year + ' - '  + end_yea
                 // method: "PUT",
                 //     url:  '/settings/business-units/' + id,
                 method: "POST",
-                url: "/admin-pledge/special-campaign/{{ $pledge->id ? $pledge->id : '' }}", 
+                url: "/admin-pledge/special-campaign{{ $pledge->id ? '/'.$pledge->id : '' }}", 
                 //data: form.serialize(), 
                 @if ($is_new_pledge) 
                     data: form.find(':not(input[name=_method])').serialize(),  // serializes the form's elements exclude _method.


### PR DESCRIPTION
During performing some high-level unit tests, the '301 Moved Permanently' error happened when creating on Donate Now and Special Campaign pledges under administration area

[ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FabmbPT6q2kulakC1wtz-yWUANl3D%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)