### PR TITLE
[jp-bugfix-0029] '301 Moved Permanently' error happened on Admin Donate Now and Sepcial Campaign Pledges 

### DIFF
--- a/app/Http/Controllers/Admin/DonateNowPledgeController.php
+++ b/app/Http/Controllers/Admin/DonateNowPledgeController.php
@@ -207,13 +207,20 @@ class DonateNowPledgeController extends Controller
      */
     public function store(DonateNowPledgeRequest $request)
     {
+
+        $gov_organization = Organization::where('code', 'GOV')->first();
         $user = User::where('id', $request->user_id )->first();
 
         // Create a new Pledge
         $last_seqno = DonateNowPledge::where('organization_id', $request->organization_id)
-                        ->where('emplid', $user->emplid)
-                        // ->where('user_id', $request->user_id)
-                        ->where('pecsf_id', $request->pecsf_id)
+                        ->when( $request->organization_id == $gov_organization->id, function($query) use($user){
+                            $query->where('emplid', $user->emplid)
+                                  ->whereNull('pecsf_id');
+                        })
+                        ->when( $request->organization_id != $gov_organization->id, function($query) use($request){
+                            $query->whereNull('emplid')
+                                  ->where('pecsf_id', $request->pecsf_id);
+                        })
                         ->where('yearcd', $request->yearcd)
                         ->max('seqno');
 

--- a/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
@@ -203,13 +203,19 @@ class SpecialCampaignPledgeController extends Controller
     public function store(SpecialCampaignPledgeRequest $request)
     {
 
+        $gov_organization = Organization::where('code', 'GOV')->first();
         $user = User::where('id', $request->user_id )->first();
         
         // Create a new Pledge
         $last_seqno = SpecialCampaignPledge::where('organization_id', $request->organization_id)
-                        ->where('emplid', $user->emplid)
-                        // ->where('user_id', $request->user_id)
-                        ->where('pecsf_id', $request->pecsf_id)
+                        ->when( $request->organization_id == $gov_organization->id, function($query) use($user){
+                            $query->where('emplid', $user->emplid)
+                                ->whereNull('pecsf_id');
+                        })
+                        ->when( $request->organization_id != $gov_organization->id, function($query) use($request){
+                            $query->whereNull('emplid')
+                                ->where('pecsf_id', $request->pecsf_id);
+                        })
                         ->where('yearcd', $request->yearcd)
                         ->max('seqno');
 


### PR DESCRIPTION
During performing some high-level unit tests, the '301 Moved Permanently' error happened when creating on Donate Now and Special Campaign pledges under administration area

Addition change: fix bug related to non-Gov users can't create a new pledge

[ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FabmbPT6q2kulakC1wtz-yWUANl3D%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)