### PR TITLE
[jp-bugfix-0030] Dev - Avoid too many log update during the import charities process

### DIFF
--- a/app/Imports/CharitiesImport.php
+++ b/app/Imports/CharitiesImport.php
@@ -293,7 +293,7 @@ class CharitiesImport implements ToCollection, WithStartRow, WithChunkReading, W
 
         $this->history->message = $this->history->message . $message;
 
-        if (time() - $this->last_refresh_time > 30) {
+        if (time() - $this->last_refresh_time > 60) {
             $this->history->save();
             $this->last_refresh_time = time();
         }


### PR DESCRIPTION
The import charities process run for about 20 mins and could have many rows inserts into the log table when there is lots of changes. Better to avoid too frequency update on the database and generate a huge transaction log.


Reduce the log update from 30 sec to 1 min

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FXZbSjAEuvES8gqK_l9ytMWUAAcO8%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)