### PR TITLE
[jp-bugfix-0031] Fix error when display campaign year record with invalid created_by_id

### DIFF
--- a/resources/views/admin-campaign/campaignyears/show.blade.php
+++ b/resources/views/admin-campaign/campaignyears/show.blade.php
@@ -73,7 +73,7 @@
                 <div class="row no-gutters">
                     <div class="col-3">
                         <p>Created by: 
-                            {{ $campaign_year->created_by->name }} </p>
+                            {{  isset($campaign_year->created_by) ? $campaign_year->created_by->name : '' }} </p>
                     </div>
                     <div class="col-3">
                         <p>Created at: 


### PR DESCRIPTION
Bug 
When open a campaign years setting display page (show) to review the auditing information, the error message displayed, those are record contain invalid created_by_id from initial setup.

Jun 30 - Fix the program to aviod the error on the transaction contains bad data .

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/h22vdUMQSUylloJhYzND32UAAudX?Type=TaskLink&Channel=Link&CreatedTime=638237849658280000)