### PR TITLE
[jp-bugfix-0032] Lock users from using the environments

### DIFF
--- a/app/Http/Controllers/System/UserMaintenanceController.php
+++ b/app/Http/Controllers/System/UserMaintenanceController.php
@@ -53,7 +53,7 @@ class UserMaintenanceController extends Controller
                         ->when($request->emplid, function($query) use($request) {
                             return $query->where('employee_jobs.emplid', 'like', $request->emplid.'%');
                         })
-                        ->when($request->acctlock, function($query) use($request) {
+                        ->when($request->acctlock != '' , function($query) use($request) {
                             return $query->where('users.acctlock', $request->acctlock);
                         })
                         ->when($request->organization_id, function($query) use($request) {


### PR DESCRIPTION
Right now, any users who is not a part of the team can access the environment if they have the site of that environment which can become a threat due to security concerns. We want to limit the access of the environments to users from our team and the testing accounts only. Other users must not be able to login. 
Environments to be blocked: 
- Dev
- Test
- Prod
Test accounts: 
Name	EmplID	login ID	Login Password	idir
1) K Dunn	000422	employee11@example.com	employee11@123	patdunn
2) Terry Jones - Admin	000413	employee12@example.com	employee12@123	tejones
3) Wendy Vander Kuyl	000743	employee13@example.com	employee13@123	wmvander
4) Helene Beauchesne	000749	employee14@example.com	employee14@123	hbeauche
5) Anthony Button	000754	employee15@example.com	employee15@123	tbutton
6) Harinder Gill	000773	employee16@example.com	employee16@123	hsgill
7) Karen Basara	000804	employee17@example.com	employee17@123	kbasara
8) L Sexton	003901	employee21@example.com	employee21@123	dsexton
9) Alasdair Ring	004033	employee22@example.com	employee22@123	airing
10) Ashley Davis	191495	employee23@example.com	employee23@123	adavis
11) Jesus Pulido-Castanon	191494	employee24@example.com	employee24@123	jpulidoc
12) Bayan Khorsandnia	191492	employee25@example.com	employee25@123	bkhorsan
13) Deepika Inaniya	191491	employee26@example.com	employee26@123	dinaniya
14) supervisor@example.com - supervisor@123 
15) employee1@example.com - employee1@123

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/lB6KjdbXv0u_tyVy176pXGUANq_q?Type=TaskLink&Channel=Link&CreatedTime=638241068949950000)