### PR TITLE
[Test migration] [jp-bugfix-0030] Dev - Avoid too many log update during the import charities process

### DIFF
--- a/app/Http/Controllers/Admin/CharityListMaintenanceController.php
+++ b/app/Http/Controllers/Admin/CharityListMaintenanceController.php
@@ -72,17 +72,17 @@ class CharityListMaintenanceController extends Controller
                 // ->addColumn('short_message', function ($process) {
                 //     return substr($process->message, 0, 255);
                 // })
-                ->addColumn('message_text', function ($process) {
-                    $more_link = ' ... <br><a class="more-link text-danger" data-id="'. $process->id .'" >click here for more detail</a>';
-                    $maxline = 3;
-                    $lines = preg_split('#\r?\n#', $process->message);
-                    if ( count($lines) > $maxline) {
-                        // return nl2br( substr($audit->message, 0, $maxline)) . $more_link;
-                        return nl2br( implode( PHP_EOL , array_slice( $lines, 0, 3) ) . $more_link );
-                    } else {   
-                        return nl2br( $process->message);
-                    }
-                })
+                // ->addColumn('message_text', function ($process) {
+                //     $more_link = ' ... <br><a class="more-link text-danger" data-id="'. $process->id .'" >click here for more detail</a>';
+                //     $maxline = 3;
+                //     $lines = preg_split('#\r?\n#', $process->message);
+                //     if ( count($lines) > $maxline) {
+                //         // return nl2br( substr($audit->message, 0, $maxline)) . $more_link;
+                //         return nl2br( implode( PHP_EOL , array_slice( $lines, 0, 3) ) . $more_link );
+                //     } else {   
+                //         return nl2br( $process->message);
+                //     }
+                // })
                 ->addColumn('action', function ($process) {
                     return '<a class="btn btn-info btn-sm  show-process" data-id="'. $process->id .'" >Show</a>';
                 })
@@ -168,6 +168,10 @@ class CharityListMaintenanceController extends Controller
         if ($request->ajax()) {
 
             $process = \App\Models\ProcessHistory::where('id', $id)->first();
+
+            if ($process->status == 'Processing') {
+                $process->message = Storage::disk('local')->get('staging/charities_import_' .  $id);
+            }
 
             return response()->json($process);
         }

--- a/app/Imports/CharitiesImport.php
+++ b/app/Imports/CharitiesImport.php
@@ -293,7 +293,7 @@ class CharitiesImport implements ToCollection, WithStartRow, WithChunkReading, W
 
         $this->history->message = $this->history->message . $message;
 
-        if (time() - $this->last_refresh_time > 30) {
+        if (time() - $this->last_refresh_time > 60) {
             $this->history->save();
             $this->last_refresh_time = time();
         }

--- a/resources/views/admin-campaign/charity-list-maintenance/index.blade.php
+++ b/resources/views/admin-campaign/charity-list-maintenance/index.blade.php
@@ -98,7 +98,7 @@
                         <th>End At</th>
                         <th>Status</th>
                         <th>Action</th>
-                        <th>Message</th>
+                        {{-- <th>Message</th> --}}
                     </tr>
                 </thead>
             </table>
@@ -232,7 +232,7 @@
                 {data: 'end_at', defaultContent: '', className: "dt-nowrap"},
                 {data: 'status', "className": "dt-center"},
                 {data: 'action'},
-                {data: 'message_text', className: "dt-nowrap"},
+                // {data: 'message_text', className: "dt-nowrap"},
             ],
             columnDefs: [
                     {


### PR DESCRIPTION
The import charities process run for about 20 mins and could have many rows inserts into the log table when there is lots of changes. Better to avoid too frequency update on the database and generate a huge transaction log.

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FXZbSjAEuvES8gqK_l9ytMWUAAcO8%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)