### PR TITLE
[jp-bugfix-0030] Dev - Avoid too many log update during the import charities process 

### DIFF
--- a/app/Http/Controllers/Admin/CharityListMaintenanceController.php
+++ b/app/Http/Controllers/Admin/CharityListMaintenanceController.php
@@ -170,7 +170,7 @@ class CharityListMaintenanceController extends Controller
             $process = \App\Models\ProcessHistory::where('id', $id)->first();
 
             if ($process->status == 'Processing') {
-                $process->message = Storage::disk('local')->get('staging/charities_import_' .  $id);
+                $process->message = Storage::disk('logs')->get('charities_import_' .  $id . '.log');
             }
 
             return response()->json($process);

--- a/app/Imports/CharitiesImport.php
+++ b/app/Imports/CharitiesImport.php
@@ -292,9 +292,8 @@ class CharitiesImport implements ToCollection, WithStartRow, WithChunkReading, W
         $this->history->message .= $message;
 
         // log to the file to share with the front end
-        Storage::disk('local')->put('staging/charities_import_' .  $this->history_id, $this->history->message);
+        Storage::disk('logs')->put('charities_import_' .  $this->history_id . '.log', $this->history->message);
 
     }
-
 
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -55,6 +55,11 @@ return [
             'root' => storage_path('framework/sessions'),
             'url' => env('APP_URL').'/storage/sessions',
         ],
+        'logs' => [
+            'driver' => 'local',
+            'root' => storage_path('logs'),
+            'url' => env('APP_URL').'/storage/logs',
+        ],
         's3' => [
             'driver' => 's3',
             'key' => env('AWS_ACCESS_KEY_ID'),


### PR DESCRIPTION
Addition change: store the log file in logs folder.

The import charities process run for about 20 mins and could have many rows inserts into the log table when there is lots of changes. Better to avoid too frequency update on the database and generate a huge transaction log.

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FXZbSjAEuvES8gqK_l9ytMWUAAcO8%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)