### PR TITLE
[jp-bugfix-0036] clean-up -- decommision old module Laravel-mix-svg-sprite

### DIFF
--- a/resources/views/vendor/adminlte/partials/sidebar/menu-item-link.blade.php
+++ b/resources/views/vendor/adminlte/partials/sidebar/menu-item-link.blade.php
@@ -1,33 +1,21 @@
-<li @if(isset($item['id'])) id="{{ $item['id'] }}" @endif class="nav-item">
+<li @isset($item['id']) id="{{ $item['id'] }}" @endisset class="nav-item">
 
-    <a class="nav-link py-3 {{ $item['class'] }} @if(isset($item['shift'])) {{ $item['shift'] }} @endif"
-       href="{{ $item['href'] }}" @if(isset($item['target'])) target="{{ $item['target'] }}" @endif
+    <a class="nav-link py-3 {{ $item['class'] }} @isset($item['shift']) {{ $item['shift'] }} @endisset"
+       href="{{ $item['href'] }}" @isset($item['target']) target="{{ $item['target'] }}" @endisset
        {!! $item['data-compiled'] ?? '' !!}>
 
-       @if ( str_contains($item['icon'], ' far ') || str_contains($item['icon'], ' fa ') )
-            <i class="{{ $item['icon'] ?? 'far fa-fw fa-circle' }} {{
-                isset($item['icon_color']) ? 'text-'.$item['icon_color'] : ''
-            }}"></i> 
-        @else
-            <i> 
-                @if (str_contains($item['icon'], 'FAQs'))
-                    <svg class="icon mr-2" style="width:24px; height: 24px; top: 0;">
-                        <use xlink:href="{{asset('img/icons/faqs.svg')}}#sprite-faqs"></use>
-                    </svg>
-                @else
-                    <svg class="icon mr-2" style="width:24px; height: 24px">
-                        <use xlink:href="{{asset('img/icons/sprite.svg')}}#sprite-{{$item['icon'] ?? 'home'}}"></use>
-                    </svg>
-                @endif 
-            </i>
-        @endif
-        {{ $item['text'] }}
+        <i class="{{ $item['icon'] ?? 'far fa-fw fa-circle' }} {{
+            isset($item['icon_color']) ? 'text-'.$item['icon_color'] : ''
+        }}"></i>
 
-            @if(isset($item['label']))
+        <p>
+            {{ $item['text'] }}
+
+            @isset($item['label'])
                 <span class="badge badge-{{ $item['label_color'] ?? 'primary' }} right">
                     {{ $item['label'] }}
                 </span>
-            @endif
+            @endisset
         </p>
 
     </a>


### PR DESCRIPTION
Laravel-mix-svg-sprite module should be decommissioned since PECSF application doesn't use teh feature -- "this webpack plugin generates a single SVG spritemap containing multiple elements from all .svg files in a directory." and also avoid some security warning.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/5lq5hmPvAkSQZx2BokxYH2UAOmsS?Type=TaskLink&Channel=Link&CreatedTime=638247993132880000)