### PR TITLE
[jp-bugfix-0037] update 'User Maintenance Page' to handle user without emplid or org id 

### DIFF
--- a/app/Http/Controllers/System/UserMaintenanceController.php
+++ b/app/Http/Controllers/System/UserMaintenanceController.php
@@ -41,7 +41,10 @@ class UserMaintenanceController extends Controller
                     'employee_jobs.tgb_reg_district',
                     'regions.name as region_name',
                     'employee_jobs.city')
-                        ->leftJoin('employee_jobs', 'employee_jobs.emplid', '=', 'users.emplid')
+                        ->leftJoin('employee_jobs', function($join) {
+                            $join->on('employee_jobs.organization_id', '=', 'users.organization_id')
+                                 ->on('employee_jobs.emplid', '=', 'users.emplid');
+                        })
                         ->where( function($query) {
                             $query->where('employee_jobs.empl_rcd', '=', function($q) {
                                     $q->from('employee_jobs as J2') 


### PR DESCRIPTION
Purpose: Need to update the 'User Maintenance Page' to handle the user without emplid and org id (sql need to join with oragnization_id)

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/pwE8hc6j0ESBtdN0Z4mlZWUAMRGz?Type=TaskLink&Channel=Link&CreatedTime=638248870617070000)