### PR TITLE
[jp-0001] S40(09) DEV - Daily Campaign Update - Part 2 

### DIFF
--- a/resources/views/challenge/daily_campaign.blade.php
+++ b/resources/views/challenge/daily_campaign.blade.php
@@ -12,15 +12,18 @@
 
 <h1 class="mt-2">Daily Campaign</h1>
 
-<div class="mt-3 btn-group btn-group-lg" role="group" aria-label="Basic example">
-    <button type="button" class="btn btn-secondary" onclick="window.location.href='{{ route('challenge.index') }}';">
-            <span class="mx-2 px-5">Leaderboard</span>
-    </button>
-    <button type="button" class="btn btn-dark mx-0 px-0"></button>
-    <button type="button" class="btn btn-success"  onclick="window.location.href='{{ route('challenge.daily_campaign') }}';">
-            <span class="px-2">Daily Campaign Update<span>
-    </button>
-</div>
+<ul class="mt-3 menu nav nav-pills" id="pills-tab">
+    <li class="nav-item nav-center-4">
+        <a  class="nav-link"
+           href="{{ route('challenge.index') }}" role="tab" aria-controls="pills-home" aria-selected="false">
+            Leaderboard</a>
+    </li>
+    <li class="nav-item nav-center-4">
+        <a  class="nav-link active disabled"
+           href="{{  route('challenge.daily_campaign') }}" role="tab" aria-controls="pills-profile" aria-selected="true">
+            Daily Campaign Update</a>
+    </li>
+</ul>
     
 @endsection
 @section('content')

--- a/resources/views/challenge/index.blade.php
+++ b/resources/views/challenge/index.blade.php
@@ -4,15 +4,17 @@
 <div class="mt-3">
 <h1>Challenge</h1>
 
-<div class="mt-3 btn-group btn-group-lg" role="group" aria-label="Basic example">
-    <button type="button" class="btn btn-success">
-            <span class="mx-2 px-5">Leaderboard</span>
-    </button>
-    <button type="button" class="btn btn-dark mx-0 px-0"></button>
-    <button type="button" class="btn btn-secondary"  onclick="window.location.href='{{ route('challenge.daily_campaign') }}';">
-            <span class="px-2">Daily Campaign Update<span>
-    </button>
-</div>
+<ul class="mt-3 menu nav nav-pills" id="pills-tab">
+    <li class="nav-item nav-center-4">
+        <a  class="nav-link active disabled"
+           href="{{ route('challenge.index') }}" role="tab" aria-controls="pills-home" aria-selected="true">
+            Leaderboard</a>
+    </li>
+    <li class="nav-item nav-center-4">
+        <a class="nav-link" href="{{  route('challenge.daily_campaign') }}" role="tab" aria-controls="pills-profile" aria-selected="false">
+            Daily Campaign Update</a>
+    </li>
+</ul>
 
 <h6 class="mt-3">Visit this page daily during the PECSF campaign to see updated statistics, including organization participation rates!<br>
     If you have questions about PECSF statistics, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca?subject=Challenge%20page">PECSF@gov.bc.ca</a>.</h6>


### PR DESCRIPTION

40th change -- reverse the tabs design on Challenge and Daily Campiagn pages 

The daily campaign update will be a more detailed view of stats, accessible for anyone who using the PECSF app. These are updated daily during a PECSF campaign (typically, mid/late Sept to early Nov) and once final totals have been announced (late January).

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2F2lqkNB58wEuqiMkpBLGjtWUANfWQ%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)
