### PR TITLE
[jp-bugfix-0038] relocate the uploaded image folder (avoid to use public)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 /node_modules
 /public/hot
 /public/storage
-/public/img/uploads/*
 /public/charities/*
 /public/bank_deposit_form_attachments/*
 /storage/*.key

--- a/app/Console/Commands/DownloadImageFiles.php
+++ b/app/Console/Commands/DownloadImageFiles.php
@@ -117,7 +117,7 @@ class DownloadImageFiles extends Command
 
                 if ($res->getStatusCode() == 200 ) {
                     $res = $client->request('GET',  $baseUrl . $filename, 
-                        ['sink' => 'public/img/uploads/fspools/' . $filename ]
+                        ['sink' => 'storage/app/public/fspools/' . $filename ]
                     );
                 }
     

--- a/app/Http/Controllers/Admin/FundSupportedPoolController.php
+++ b/app/Http/Controllers/Admin/FundSupportedPoolController.php
@@ -14,6 +14,7 @@ use Illuminate\Validation\Rule;
 use Yajra\Datatables\Datatables;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 
 
@@ -30,7 +31,8 @@ class FundSupportedPoolController extends Controller
     {
          $this->middleware('permission:setting');
 
-         $this->image_folder = "img/uploads/fspools/";
+        //  $this->image_folder = "img/uploads/fspools/";
+        $this->image_folder = "app/public/fspools/";
     }
 
     /**
@@ -297,7 +299,10 @@ class FundSupportedPoolController extends Controller
                         $file= $upload_images[$i];
                         $filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
 
-                        $file->move(public_path( $this->image_folder ), $filename);
+                        // $file->move(public_path( $this->image_folder ), $filename);
+                        $file->storeAs(  "public/fspools" , $filename);
+
+
                     }
 
                     $pool->charities()->create([
@@ -511,6 +516,8 @@ class FundSupportedPoolController extends Controller
             for ($i=0; $i < count($charities); $i++) {
                 if ($charities[$i] != '') {
 
+                    $old_pool_charity = FSPoolCharity::where('charity_id', $charities[$i])->first();
+
                     $payload =  [
                         'percentage'    => $percentages[$i],
                         'status'        => $status[$i],
@@ -522,8 +529,21 @@ class FundSupportedPoolController extends Controller
                         'notes'         => array_key_exists($i, $notes) ? $notes[$i] :null,
                     ];
 
-                    if(!empty($upload_images[$i])){
-                        $payload['image'] = $upload_images[$i]->getClientOriginalName();
+                    if (array_key_exists($i, $upload_images)) {
+                        $file= $upload_images[$i];
+                        $new_filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
+                        $payload['image'] = $new_filename;
+
+                        // Save the new image file on folder 
+                        $file->storeAs(  "public/fspools" , $new_filename);
+
+                        // Clean up old file on the folder
+                        if ($old_pool_charity->image) {
+                            $old_filename = storage_path( $this->image_folder ) . $old_pool_charity->image;
+                            if (File::exists( $old_filename )) {
+                                File::delete( $old_filename );
+                            }
+                        }
                     }
 
                     $pool_charity = $pool->charities()->updateOrCreate([
@@ -531,23 +551,7 @@ class FundSupportedPoolController extends Controller
                     ],$payload);
 
                     // copy and delete the file in folder
-                    if (array_key_exists($i, $upload_images)) {
-                        // dd ( $request->file('images') );
-                        $file= $upload_images[$i];
-                        $new_filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
-                        $file->move(public_path( $this->image_folder ), $new_filename);
-
-                        // Clean up old file
-                        if ($pool_charity->image) {
-                            $old_filename = public_path( $this->image_folder ).$pool_charity->image;
-                            if (File::exists( $old_filename )) {
-                                File::delete( $old_filename );
-                            }
-                        }
-                        // Store the new filename in record
-                        $pool_charity->image = $new_filename;
-                        $pool_charity->save();
-                    }
+                    
 
                 }
             }
@@ -559,7 +563,7 @@ class FundSupportedPoolController extends Controller
                 array_push($dels, $charity->id);
 
                 // delete the image file from image folder
-                $filename = public_path( $this->image_folder ) . $charity->image;
+                $filename = storage_path( $this->image_folder ) . $charity->image;
                 if (File::exists( $filename )) {
                     File::delete( $filename );
                 }
@@ -621,7 +625,7 @@ class FundSupportedPoolController extends Controller
             foreach ($pool->charities as $pool_charity) {
                 // Clean up old file
                 if ($pool_charity->image) {
-                    $old_filename = public_path( $this->image_folder ).$pool_charity->image;
+                    $old_filename =  storage_path( $this->image_folder ) .$pool_charity->image;
                     if (File::exists( $old_filename )) {
                         File::delete( $old_filename );
                     }
@@ -698,8 +702,8 @@ class FundSupportedPoolController extends Controller
            $old_image = $charity->image;
            $new_image = now()->format('YmdHisu'). substr($charity->image, 12);
 
-           $old_filename = public_path( $this->image_folder ).$old_image;
-           $new_filename = public_path( $this->image_folder ).$new_image;
+           $old_filename = storage_path( $this->image_folder ).$old_image;
+           $new_filename = storage_path( $this->image_folder ).$new_image;
            if (File::exists( $old_filename )) {
                File::copy( $old_filename, $new_filename );
            }

--- a/app/Http/Controllers/Admin/SpecialCampaignSetupController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignSetupController.php
@@ -24,7 +24,8 @@ class SpecialCampaignSetupController extends Controller
     {
          $this->middleware('permission:setting');
 
-         $this->image_folder = "img/uploads/special_campaign";
+        //  $this->image_folder = "img/uploads/special_campaign";
+         $this->image_folder = "app/public/special_campaign/";
 
     }
 
@@ -94,7 +95,8 @@ class SpecialCampaignSetupController extends Controller
             // file handling
             $file = $request->file('logo_image_file');
             $filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
-            $file->move(public_path( $this->image_folder ), $filename);
+            // $file->move(public_path( $this->image_folder ), $filename);
+            $file->storeAs(  "public/special_campaign" , $filename);
             
             $special_campaign = SpecialCampaign::Create([
 
@@ -171,7 +173,8 @@ class SpecialCampaignSetupController extends Controller
             if ($request->file('logo_image_file')) {
                 $file = $request->file('logo_image_file');
                 $new_filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
-                $file->move(public_path( $this->image_folder ), $new_filename);
+                // $file->move(public_path( $this->image_folder ), $new_filename);
+                $file->storeAs(  "public/special_campaign" , $new_filename);
             }
 
             $special_campaign = SpecialCampaign::where('id', $id)->first();
@@ -181,7 +184,8 @@ class SpecialCampaignSetupController extends Controller
 
                 // Clean up old file
                 if ($special_campaign->image) {
-                    $old_filename = public_path( $this->image_folder ).'/'.$special_campaign->image;
+                    // $old_filename = public_path( $this->image_folder ).'/'.$special_campaign->image;
+                    $old_filename = storage_path( $this->image_folder ) . $special_campaign->image;
                     if (File::exists( $old_filename )) {
                         File::delete( $old_filename );
                     }
@@ -216,7 +220,8 @@ class SpecialCampaignSetupController extends Controller
 
             // Clean up old file
             if ($special_campaign->image) {
-                $old_filename = public_path( $this->image_folder ).'/'.$special_campaign->image;
+                // $old_filename = public_path( $this->image_folder ).'/'.$special_campaign->image;
+                $old_filename = storage_path( $this->image_folder ) . $special_campaign->image;
                 if (File::exists( $old_filename )) {
                     File::delete( $old_filename );
                 }

--- a/resources/views/admin-campaign/fund-supported-pools/partials/edit-pool-charity.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/partials/edit-pool-charity.blade.php
@@ -133,7 +133,8 @@
                     <input name="current_images[]" type="hidden" value="{{ $image_name  }}">
                     @if ( $image_name ) 
                     <figure>
-                        <img src="{{asset('img/uploads/fspools')}}/{{ $image_name }}" width="auto" height="150">
+                        {{-- <img src="{{asset('img/uploads/fspools')}}/{{ $image_name }}" width="auto" height="150"> --}}
+                        <img src="{{asset('storage/fspools')}}/{{ $image_name }}" width="auto" height="150"> 
                         <figcaption ><span class="font-weight-bold">Current file name: </span>{{ $image_name }}</figcaption>
                     </figure>    
                     <button class='delete-current-image-button btn btn-sm btn-outline-danger ml-4' 

--- a/resources/views/admin-campaign/fund-supported-pools/partials/show-pool-charity.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/partials/show-pool-charity.blade.php
@@ -94,7 +94,8 @@
                     <input name="current_images[]" type="hidden" value="{{ $image_name  }}">
                     @if ( $image_name ) 
                     <figure>
-                        <img src="{{asset('img/uploads/fspools')}}/{{ $image_name }}" width="auto" height="150">
+                        {{-- <img src="{{asset('img/uploads/fspools')}}/{{ $image_name }}" width="auto" height="150"> --}}
+                        <img src="{{asset('storage/fspools')}}/{{ $image_name }}" width="auto" height="150"> 
                         <figcaption ><span class="font-weight-bold">Current file name: </span>{{ $image_name }}</figcaption>
                     </figure>    
                     @endif

--- a/resources/views/admin-campaign/special-campaigns/index.blade.php
+++ b/resources/views/admin-campaign/special-campaigns/index.blade.php
@@ -443,7 +443,8 @@
                     
 
                     $("#bu-edit-model-form").find('div.remove-upload-area').show();
-                    $("#bu-edit-model-form").find(".upload-logo-image").attr('src', '{{asset("img/uploads/special_campaign")}}/'+data.image);
+                    // $("#bu-edit-model-form").find(".upload-logo-image").attr('src', '{{asset("img/uploads/special_campaign")}}/'+data.image);
+                    $("#bu-edit-model-form").find(".upload-logo-image").attr('src', '{{asset("storage/special_campaign")}}/'+data.image);
                     $("#bu-edit-model-form").find(".upload-logo-image").css("display","block");
                  
 
@@ -545,7 +546,8 @@
                     $(document).find("#bu-show-model-form [name='charity_name']").val( data.charity.charity_name);
                     $(document).find("#bu-show-model-form [name='registration_number']").val( data.charity.registration_number);
 
-                    $(document).find("#bu-show-model-form figure.logo_image img").attr('src', '{{asset("img/uploads/special_campaign")}}/'+data.image);
+                    // $(document).find("#bu-show-model-form figure.logo_image img").attr('src', '{{asset("img/uploads/special_campaign")}}/'+data.image);
+                    $(document).find("#bu-show-model-form figure.logo_image img").attr('src', '{{asset("storage/special_campaign")}}/'+data.image);
                     $(document).find("#bu-show-model-form figure.logo_image span.logo_image_filename").html( data.image );
                     $('#bu-show-modal').modal('show');
                 },

--- a/resources/views/admin-pledge/special-campaign/create-edit.blade.php
+++ b/resources/views/admin-pledge/special-campaign/create-edit.blade.php
@@ -225,7 +225,8 @@
                                         data-end_year="{{ $special_campaign->end_date->format('Y') }}">
                                     <div class="card-body">
                                         <figure class="logo_image">
-                                            <img src="{{  asset("img/uploads/special_campaign").'/'. $special_campaign->image }}" width="auto" height="80">
+                                            {{-- <img src="{{  asset("img/uploads/special_campaign").'/'. $special_campaign->image }}" width="auto" height="80"> --}}
+                                            <img src="{{  asset("storage/special_campaign").'/'. $special_campaign->image }}" width="auto" height="80">
                                         </figure> 
 
                                         <h4 class="card-text font-weight-bold">{{ $special_campaign->name }}</h4>

--- a/resources/views/annual-campaign/partials/pool-detail.blade.php
+++ b/resources/views/annual-campaign/partials/pool-detail.blade.php
@@ -3,7 +3,9 @@
     @foreach ($charities as $pool_charity)    
         <li class="list-group-item">
             <div class="row">
-                <div class="col-1"><img src="{{ asset('img/uploads/fspools/'.$pool_charity->image ) }}" 
+                <div class="col-1">
+                    {{-- <img src="{{ asset('img/uploads/fspools/'.$pool_charity->image ) }}"  --}}
+                    <img src="{{asset('storage/fspools')}}/{{ $pool_charity->image }}"
                         class="card-img-top" alt="..."
                     min-height="100"></div>
                 <div class="col-11">

--- a/resources/views/donate-now/partials/pool-detail.blade.php
+++ b/resources/views/donate-now/partials/pool-detail.blade.php
@@ -3,7 +3,9 @@
     @foreach ($charities as $pool_charity)    
         <li class="list-group-item">
             <div class="row">
-                <div class="col-1"><img src="{{ asset('img/uploads/fspools/'.$pool_charity->image ) }}" 
+                <div class="col-1">
+                        {{-- <img src="{{ asset('img/uploads/fspools/'.$pool_charity->image ) }}"  --}}
+                        <img src="{{asset('storage/fspools')}}/{{ $pool_charity->image }}" 
                         class="card-img-top" alt="..."
                     min-height="100"></div>
                 <div class="col-11">

--- a/resources/views/donate/partials/pool-detail.blade.php
+++ b/resources/views/donate/partials/pool-detail.blade.php
@@ -3,7 +3,9 @@
     @foreach ($charities as $pool_charity)    
         <li class="list-group-item">
             <div class="row">
-                <div class="col-1"><img src="{{ asset('img/uploads/fspools/'.$pool_charity->image ) }}" 
+                <div class="col-1">
+                        {{-- <img src="{{ asset('img/uploads/fspools/'.$pool_charity->image ) }}"  --}}
+                        <img src="{{asset('storage/fspools')}}/{{ $pool_charity->image }}" 
                         class="card-img-top" alt="..."
                     min-height="100"></div>
                 <div class="col-11">

--- a/resources/views/special-campaign/partials/special-campaign.blade.php
+++ b/resources/views/special-campaign/partials/special-campaign.blade.php
@@ -24,7 +24,8 @@
                 data-id="{{ $special_campaign->id }}">
             <div class="card-body">
                 <figure class="logo_image pt-2">
-                    <img src="{{  asset("img/uploads/special_campaign").'/'. $special_campaign->image }}" width="auto" height="150">
+                    {{-- <img src="{{  asset("img/uploads/special_campaign").'/'. $special_campaign->image }}" width="auto" height="150"> --}}
+                    <img src="{{  asset("storage/special_campaign").'/'. $special_campaign->image }}" width="auto" height="150">
                 </figure> 
                 <h4 class="card-text font-weight-bold">{{ $special_campaign->name }}</h4>
                 <h6 class="card-text">{{ $special_campaign->charity->charity_name  }}</h6>


### PR DESCRIPTION
July 14 - The uploaded FSPool and Special Campaign image files by admin, should be stored in the stoarge folder instead of public. This could share to multiple application servers and better security control.

Old location: public/img/uploads
new location: storage/app/public

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/W9l6V9vVOUKQvG4_XmPBAGUAGB2W?Type=TaskLink&Channel=Link&CreatedTime=638249755758110000)