### PR TITLE
[jp-bugfix-0044] Loading 2021-2023 Inactive employee job data into PECSF

### DIFF
--- a/database/seeders/EmployeeJobInactive2021_2023JSON.php
+++ b/database/seeders/EmployeeJobInactive2021_2023JSON.php
@@ -39,6 +39,14 @@ class EmployeeJobInactive2021_2023JSON extends Seeder
 
         foreach ($missed_jobs as $key => $job) {
 
+            $old_job = \App\Models\EmployeeJob::where('emplid',  $job->emplid)
+                                ->where('empl_rcd', $job->empl_rcd)
+                                ->first();
+
+            if ($old_job) {
+                continue;
+            }
+
             $new_job = \App\Models\EmployeeJob::updateOrCreate([
                 'emplid' => $job->emplid,
                 'empl_rcd' => $job->empl_rcd,

--- a/database/seeders/EmployeeJobJSONSeeder.php
+++ b/database/seeders/EmployeeJobJSONSeeder.php
@@ -34,6 +34,14 @@ class EmployeeJobJSONSeeder extends Seeder
 
         foreach ($in_jobs as $job) {
 
+            $old_job = \App\Models\EmployeeJob::where('emplid',  $job->emplid)
+                           ->where('empl_rcd', $job->empl_rcd)
+                            ->first();
+
+            if ($old_job) {
+                continue;
+            }
+
             $total_count += 1;
 
             $new_job = EmployeeJob::updateOrCreate([

--- a/database/seeders/EmployeeJobMissing.php
+++ b/database/seeders/EmployeeJobMissing.php
@@ -24,6 +24,14 @@ class EmployeeJobMissing extends Seeder
 
         foreach ($missed_jobs as $row) {
 
+            $old_job = \App\Models\EmployeeJob::where('emplid',  $row->employee_id)
+                           ->where('empl_rcd', $row->empl_record)
+                            ->first();
+
+            if ($old_job) {
+                continue;
+            }
+
              // $regional_district = RegionalDistrict::where('tgb_reg_district', $row->tgb_reg_district)->first();
 
             \App\Models\EmployeeJob::updateOrCreate([

--- a/database/seeders/EmployeeJobMissing255JSON.php
+++ b/database/seeders/EmployeeJobMissing255JSON.php
@@ -39,6 +39,15 @@ class EmployeeJobMissing255JSON extends Seeder
 
         foreach ($missed_jobs as $key => $job) {
 
+            $old_job = \App\Models\EmployeeJob::where('emplid',  $job->EMPLID)
+                            ->where('empl_rcd', $job->EMPL_RCD)
+                            ->first();
+
+            if ($old_job) {
+                continue;
+            }
+
+
             $new_job = \App\Models\EmployeeJob::updateOrCreate([
                 'emplid' => $job->EMPLID,
                 'empl_rcd' => $job->EMPL_RCD,


### PR DESCRIPTION
Addition Change: make sure no duplication create)

There are some missig employee job data from BI, they have Pledge History from BI. Justin provides the employee job data in excel spreadhseet format for loading into PECSF.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/tlbT8qvyck2LT6FpCGMjjWUAICSi?Type=TaskLink&Channel=Link&CreatedTime=638258341844310000)