### PR TITLE
(TEST MIGRATION) [jp-bugfix-0047] Indiviudal flag to enable/disable inbound/outbound schedule process 

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -34,29 +34,34 @@ class Kernel extends ConsoleKernel
         // $schedule->command('generate:report')->hourly();
         // $schedule->command('que')->everyMinute();
 
-        if (env('TASK_SCHEDULING_ENABLED')) 
+        // **************************
+        // *** Outbound Processes ***
+        // **************************
+
+        if (env('TASK_SCHEDULING_OUTBOUND_PSFT_ENABLED')) 
         { 
-
-                // **************************
-                // *** Outbound Processes ***
-                // **************************
-
                 // Note: The export processes are only execute in TEST and Production  
                 $schedule->command('command:ExportPledgesToPSFT')
                         ->dailyAt('0:15')
                         ->environments(['TEST', 'prod'])
                         ->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
-                        
+        }
+
+        if (env('TASK_SCHEDULING_OUTBOUND_BI_ENABLED')) 
+        {
                 $schedule->command('command:ExportDatabaseToBI')
                         ->weekdays()
                         ->at('0:30')
                         ->environments(['TEST', 'prod'])
                         ->appendOutputTo(storage_path('logs/ExportDatabaseToBI.log'));
 
+        }
 
-                // **************************
-                // *** Inbound  Processes ***
-                // **************************
+        // **************************
+        // *** Inbound  Processes ***
+        // **************************
+        if (env('TASK_SCHEDULING_INBOUND_ENABLED')) 
+        { 
 
                 // Foundation table
                 $schedule->command('command:ImportPayCalendar')


### PR DESCRIPTION
In order to have individual control on the schedule process, 2 seperate flag setting in .env to control out inbound and outbound schedule process.

TASK_SCHEDULING_INBOUND_ENABLED=true
TASK_SCHEDULING_OUTBOUND_PSFT_ENABLED=false
TASK_SCHEDULING_OUTBOUND_BI_ENABLED=false

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/UymKl8yKR02JEk3cUVBBtmUAFxsT?Type=TaskLink&Channel=Link&CreatedTime=638265981829070000)