### PR TITLE
[jp-0005] Enable/Disable user signon during system maintenance 

### DIFF
--- a/app/Http/Controllers/System/SystemSettingController.php
+++ b/app/Http/Controllers/System/SystemSettingController.php
@@ -51,7 +51,7 @@ class SystemSettingController extends Controller
 
             $validator = Validator::make(request()->all(), [
                 // 'system_lockdown_start'      => 'required|date_format:Y-m-d\TH:i|after:' . date(DATE_ATOM, strtoTime("-10 min")),
-                'system_lockdown_start'      => 'required|date_format:Y-m-d\TH:i|after:' . now()->format('Y-m-d 00:00'),
+                'system_lockdown_start'      => 'required|date_format:Y-m-d\TH:i',
                 'system_lockdown_end'        => 'required|date_format:Y-m-d\TH:i|after:system_lockdown_start',
             ],[
 


### PR DESCRIPTION
Additional change: (Allow start date on any date)

Scenario
In production region. better to lock out all the users except administrator before go love. Lock down the system based on the global flag to control when the user can logon.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/0gX0b_UO1UmPOf0QmPwESmUAOCKI?Type=TaskLink&Channel=Link&CreatedTime=638237809842910000)