### PR TITLE
[jp-0001] S40(09) DEV - Daily Campaign Update - Part 2 

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -255,29 +255,49 @@ class ChallengeController extends Controller
 
         $setting = Setting::first();
 
-        $final_date_options = DailyCampaign::select('as_of_date')
-                                    ->where('campaign_year', $campaign_year)
-                                    ->where(function($query) use($setting) {
-                                        return $query->where('as_of_date', '>=', $setting->campaign_final_date->format('Y-m-d'));
-                                    })
-                                    // ->where('as_of_date', '<>', today() )
-                                    ->distinct()
-                                    ->orderBy('as_of_date', 'desc')
-                                    ->pluck('as_of_date');
+        $final_date_options = [];
+        $date_options = [];
+        $dept_date_options = [];
 
-        
+        if (today() >= $setting->campaign_final_date) {
 
-        $date_options = DailyCampaign::select('as_of_date')
-                        ->where('campaign_year', $campaign_year)
-                        ->where(function($query) use($setting) {
-                            return $query->WhereBetween('as_of_date',[$setting->campaign_start_date->format('Y-m-d'), $setting->campaign_end_date->format('Y-m-d')]);
-                        })
-                        // ->where('as_of_date', '<>', today() )
-                        ->distinct()
-                        ->orderBy('as_of_date', 'desc')
-                        ->pluck('as_of_date');
+            $final_date_options = DailyCampaign::select('as_of_date')
+                                        ->where('campaign_year', $campaign_year)
+                                        ->where(function($query) use($setting) {
+                                            return $query->where('as_of_date', '=', $setting->campaign_final_date->format('Y-m-d'));
+                                        })
+                                        // ->where('as_of_date', '<>', today() )
+                                        ->distinct()
+                                        ->orderBy('as_of_date', 'desc')
+                                        ->pluck('as_of_date');
 
-        return view('challenge.daily_campaign', compact('final_date_options', 'date_options'));
+            $dept_date_options = DailyCampaign::select('as_of_date')
+                                        ->where('campaign_year', $campaign_year)
+                                        ->where('daily_type', 2)
+                                        ->where(function($query) use($setting) {
+                                            return $query->where('as_of_date', '=', $setting->campaign_end_date->format('Y-m-d'));
+                                        })
+                                        // ->where('as_of_date', '<>', today() )
+                                        ->distinct()
+                                        ->orderBy('as_of_date', 'desc')
+                                        ->pluck('as_of_date');
+
+        } else {
+
+            $date_options = DailyCampaign::select('as_of_date')
+                            ->where('campaign_year', $campaign_year)
+                            ->where(function($query) use($setting) {
+                                return $query->WhereBetween('as_of_date',[$setting->campaign_start_date->format('Y-m-d'), $setting->campaign_end_date->format('Y-m-d')]);
+                            })
+                            // ->where('as_of_date', '<>', today() )
+                            ->distinct()
+                            ->orderBy('as_of_date', 'desc')
+                            ->pluck('as_of_date');
+        }
+
+        // dd( [ $final_date_options , $date_options , $dept_date_options ]);
+
+        return view('challenge.daily_campaign', compact('final_date_options', 'date_options', 'dept_date_options'));
     }
 
     public function download(Request $request)

--- a/resources/views/challenge/daily_campaign.blade.php
+++ b/resources/views/challenge/daily_campaign.blade.php
@@ -55,6 +55,10 @@
                 </label>
                 <select class="form-control" id="start_date" name="start_date">
                     <option value=""></option>
+                    dept_date_options
+                    @foreach ($dept_date_options as $date) 
+                        <option final="2" value="{{ $date }}">{{ $date }}</option>
+                    @endforeach
                     @foreach ($final_date_options as $date) 
                         <option final="1" value="{{ $date }}">{{ $date }}</option>
                     @endforeach
@@ -91,11 +95,15 @@ $(function() {
         // oTable.ajax.reload();
         if ((this.value) == 'department') {
             $('select[name="start_date"] option[final="1"]').hide();
+            $('select[name="start_date"] option[final="2"]').show();
         } else {
             $('select[name="start_date"] option[final="1"]').show();
+            $('select[name="start_date"] option[final="2"]').hide();
         }
 
     });
+
+    $( 'select[name="sort"]' ).trigger( "change" );
 
 });            
 


### PR DESCRIPTION
Changes 49th -- update final date logic in the Daily Campaign Report date option

The daily campaign update will be a more detailed view of stats, accessible for anyone who using the PECSF app. These are updated daily during a PECSF campaign (typically, mid/late Sept to early Nov) and once final totals have been announced (late January).

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2F2lqkNB58wEuqiMkpBLGjtWUANfWQ%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)