### PR TITLE
[jp-0001] S40(09) DEV - Daily Campaign Update - Part 2 

### DIFF
--- a/app/Http/Controllers/Admin/ChallengeSettingsController.php
+++ b/app/Http/Controllers/Admin/ChallengeSettingsController.php
@@ -96,7 +96,7 @@ class ChallengeSettingsController extends Controller
                                     ->where('as_of_date', $request->challenge_final_date)
                                     ->first();
             if (!($challenge)) {
-                $validator->errors()->add('challenge_final_date', 'No Challenge Data for date ' . $request->$request->challenge_final_date . 
+                $validator->errors()->add('challenge_final_date', 'No Challenge Data for date ' . $request->challenge_final_date . 
                         ' yet.');
             }
 


### PR DESCRIPTION
Changes 50th : fix bug on finalize challenge page data validation)


The daily campaign update will be a more detailed view of stats, accessible for anyone who using the PECSF app. These are updated daily during a PECSF campaign (typically, mid/late Sept to early Nov) and once final totals have been announced (late January).

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2F2lqkNB58wEuqiMkpBLGjtWUANfWQ%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)