### PR TITLE
[jp-bugfix-0050] Duplicating a non-active FSP, results in the default FSP not remaining selected

### DIFF
--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -1020,7 +1020,7 @@ class AnnualCampaignController extends Controller
                 $pos = $fspools->search(function ($item, $key) use($pledge){
                     return $item->region_id ==  $pledge->region_id;
                 });
-                if (!$pos) {
+                if (!($pos >= 0)) {
                     $msg = "The Regional Pool you've selected is not available in the current campaign. Click here to see available regional pools, or alternatively you can select a different years choices from your donor history";
                 }
 
@@ -1054,7 +1054,7 @@ class AnnualCampaignController extends Controller
                 $pos = $fspools->search(function ($item, $key) use($hist_region){
                     return $item->region_id ==  $hist_region->id;
                 });
-                if (!$pos) {
+                if (!($pos >= 0)) {
                     $msg = "The Regional Pool you've selected is not available in the current campaign. Click 'Continue' to see available regional pools, or alternatively you can select a different years choices from your donor history";
                 }
 


### PR DESCRIPTION
Additional change for new bug report: 

**Inconsistent checking on the FS Pool since the Pop up warning box popped up when duplicating but jump to last step for displaying the summary page.**

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ZNJg_lIm60qf042Bb9SleGUAJAQz?Type=TaskLink&Channel=Link&CreatedTime=638272187387910000)