### PR TITLE
(TEST MIGRATION) [jp-0013] Adjust the schedule process start time

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -42,7 +42,7 @@ class Kernel extends ConsoleKernel
         { 
                 // Note: The export processes are only execute in TEST and Production  
                 $schedule->command('command:ExportPledgesToPSFT')
-                        ->dailyAt('0:15')
+                        ->dailyAt('1:00')
                         ->environments(['TEST', 'prod'])
                         ->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
         }
@@ -51,7 +51,7 @@ class Kernel extends ConsoleKernel
         {
                 $schedule->command('command:ExportDatabaseToBI')
                         ->weekdays()
-                        ->at('0:30')
+                        ->at('1:15')
                         ->environments(['TEST', 'prod'])
                         ->appendOutputTo(storage_path('logs/ExportDatabaseToBI.log'));
 


### PR DESCRIPTION
Database backup was changed from 9:00am to 0:00 everyday now. The 1st schedule process have to move to 1:00am instead.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/5R_RgS8mlEC2FS2aJyrThWUAJpJE?Type=TaskLink&Channel=Link&CreatedTime=638273882386890000)