### PR TITLE
(TEST MIGRATION) [jp-0001] s41(24) Challenge Page - Controls (update summary logic) 

### DIFF
--- a/app/Console/Commands/UpdateDailyCampaign.php
+++ b/app/Console/Commands/UpdateDailyCampaign.php
@@ -209,27 +209,36 @@ class UpdateDailyCampaign extends Command
             $this->LogMessage('Total rows created count : ' . sizeof($challenges)  );
 
             // Step 1B -- Update Daily Campaign Summary 
-            $this->LogMessage("");
-            $this->LogMessage("Updating daily campaign summary for campaign year " . $campaign_year); 
-            $this->LogMessage("                 Donor Count  : " . $donor_count); 
-            $this->LogMessage("                 Total Amount : " . $total_dollar); 
-            
-            DailyCampaignSummary::updateOrCreate([
-                    'campaign_year' => $campaign_year,
-            ],[
-                'as_of_date' => $as_of_date,
+            if ( (today() >= $setting->challenge_start_date && today() <= $setting->challenge_end_date) ||
+                 (today() >= $setting->challenge_final_date && 
+                    ($setting->challenge_final_date != $setting->challenge_processed_final_date) )
+            ) { 
+                $this->LogMessage("");
+                $this->LogMessage("Updating daily campaign summary for campaign year " . $campaign_year); 
+                $this->LogMessage("                 Donor Count  : " . $donor_count); 
+                $this->LogMessage("                 Total Amount : " . $total_dollar); 
                 
-                'donors' => $donor_count,
-                'dollars' => $total_dollar,
+                DailyCampaignSummary::updateOrCreate([
+                        'campaign_year' => $campaign_year,
+                ],[
+                    'as_of_date' => $as_of_date,
+                    
+                    'donors' => $donor_count,
+                    'dollars' => $total_dollar,
 
-                'created_by_id' => null,
-                'updated_by_id' => null,
-            ]);
+                    'created_by_id' => null,
+                    'updated_by_id' => null,
+                ]);
+            } else {
+                $this->LogMessage("");
+                $this->LogMessage("Note: There is no 'Daily Campaign Summary' update for campaign year " . $campaign_year); 
+            }
 
+            // Step 1C -- Update Challenge History when final date reached
             if (today() >= $setting->challenge_final_date && 
                     ($setting->challenge_final_date != $setting->challenge_processed_final_date) ) {
 
-                // Step 1C -- Update Challenge History when final date reached
+            
                 $this->LogMessage("");
                 $this->LogMessage("Finalize Challenge Page Data -- transfer to Historical challenge page for campaign year " . $campaign_year); 
 

--- a/database/seeds/2020.csv
+++ b/database/seeds/2020.csv
@@ -15,7 +15,7 @@
 ,Ministry of Attorney General,7.90%,5.60%,2.30%,371,"219709 "
 ,Ministry of Children and Family Development,7.90%,8.60%,-0.60%,402,"154847 "
 ,Ministry of Citizens' Services,25.30%,23.30%,1.90%,516,"157192 "
-,Ministry of Education ,37.30%,37.30%,0.10%,144,"41317 "
+,Ministry of Education ,37.31%,37.25%,0.06%,144,"41317 "
 ,"Ministry of Energy, Mines and Petroleum Resources",33.20%,37.40%,-4.20%,137,"43193 "
 ,Ministry of Environment and Climate Change Strategy,25.40%,25.00%,0.50%,278,"98051 "
 ,Ministry of Finance ,68.10%,70.60%,-2.50%,889,"191437 "


### PR DESCRIPTION
Changes:

1) Update summary page logic

2) Update the process for updating the daily campaign summary only today date between the start & end date or final date. (included minor fix the 2020.csv seed data)

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/GYHfdec1HkGX68ealYy0jWUAI3ks?Type=TaskLink&Channel=Link&CreatedTime=638272957859890000)