### PR TITLE
pg-bugfix-0082 Fix modal not being centered

### DIFF
--- a/resources/views/donations/partials/learn-more-modal.blade.php
+++ b/resources/views/donations/partials/learn-more-modal.blade.php
@@ -8,7 +8,7 @@
                     <span aria-hidden="true">&times;</span>
                 </button>
             </div>
-            <div id="donateGuideCarousel" class="carousel slide" data-ride="carousel" data-interval="false">
+            <div id="donateGuideCarousel" class="carousel slide w-100" data-ride="carousel" data-interval="false">
                 <div class="carousel-inner text-center" style="min-height: 550px;">
                     <div class="carousel-item active">
                         <h3 class="text-primary my-5">


### PR DESCRIPTION
Issue might have occurred due to the recent changes to ticket : pg-feature-0011 Home page: Change Slider Pattern
The content in the PECSF slides are not centre aligned now and appears to be misaligned

https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FfoyVdQCG30endTBHYkvRB2UANZw3%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D