### PR TITLE
[jp-0017] Daily Campaign Update – Able to Download Dept after end date

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -348,12 +348,19 @@ class ChallengeController extends Controller
     public function download(Request $request)
     {
         
-        $campaign_year = today()->year;
+        $campaign_year = Setting::challenge_page_campaign_year();
+        $setting = Setting::first();
 
-        $as_of_date = DailyCampaign::where('campaign_year', $campaign_year)    
-                            ->where('as_of_date', '<=', today() ) 
-                            ->max('as_of_date');
-        $as_of_date = $request->start_date ? $request->start_date : $as_of_date;
+        $sort = $request->sort;
+        $as_of_date = $request->start_date ?? today()->format('Y-m-d');
+
+        if ( $as_of_date >= $setting->campaign_end_date->format('Y-m-d')) {
+            if ($sort == 'department')  {
+                $as_of_date = $setting->campaign_end_date->format('Y-m-d');
+            } else {
+                $as_of_date = $setting->campaign_final_date->format('Y-m-d');
+            }
+        }
 
         switch ($request->sort) {
             case 'region': 

--- a/resources/views/challenge/daily_campaign.blade.php
+++ b/resources/views/challenge/daily_campaign.blade.php
@@ -96,11 +96,17 @@ $(function() {
         if ((this.value) == 'department') {
             $('select[name="start_date"] option[final="1"]').hide();
             $('select[name="start_date"] option[final="2"]').show();
+
+            choice = '';    // Always reset to blank
+
         } else {
             $('select[name="start_date"] option[final="1"]').show();
             $('select[name="start_date"] option[final="2"]').hide();
+
+            choice = $('select[name="start_date"]').find('option:checked').val();
         }
 
+        $('#start_date').val( choice ).change();
     });
 
     $( 'select[name="sort"]' ).trigger( "change" );


### PR DESCRIPTION
To fix the default last date that a user can download a daily campaign update report for “By Department” should be the “end” date.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Brq3tMzJ7kecCsu325AhwmUANT6S?Type=TaskLink&Channel=Link&CreatedTime=638285757563800000)