### PR TITLE
[jp-0018]  GTX / Snowplow -- separate collector for lower and Production regions

### DIFF
--- a/resources/views/vendor/adminlte/master.blade.php
+++ b/resources/views/vendor/adminlte/master.blade.php
@@ -236,7 +236,7 @@
         };p[i].q=p[i].q||[];n=l.createElement(o);g=l.getElementsByTagName(o)[0];n.async=1;
         n.src=w;g.parentNode.insertBefore(n,g)}}(window,document,"script","https://www2.gov.bc.ca/StaticWebResources/static/sp/sp-2-14-0.js","snowplow"));
         
-        var collector = 'spt.apps.gov.bc.ca';
+        var collector = '{{ env('SNOWPLOW_COLLECTOR') }}';
         window.snowplow('newTracker','rt',collector, {
         appId: 'Snowplow_standalone_PSA',
         cookieLifetime: 86400 * 548,


### PR DESCRIPTION
Per DevOps Team request, seperate the GTX / Snowplow to track site visitors and provide analytics  for lower and production regions.

To make an adjustment to the dev / test Snowplow code. They want us to use the dev pipeline in dev/test to verify, then implement on prod after. What we need to ajust is just 

"spt" (prod) to "spm" (dev): 
var collector = 'spm.apps.gov.bc.ca';

Note: new environment variable were added in .env file and the program will get from there per region

SNOWPLOW_COLLECTOR=spm.apps.gov.bc.ca

On openshift, all region was added the new configuration

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ZzYnm6WimU6p1LFUXTPGqmUAGy5a?Type=TaskLink&Channel=Link&CreatedTime=638285950474650000)