### PR TITLE
[jp-0022] Enable system administrator signon hyperlink for TEST region

### DIFF
--- a/resources/views/vendor/adminlte/auth/login.blade.php
+++ b/resources/views/vendor/adminlte/auth/login.blade.php
@@ -57,7 +57,7 @@
             <div>Email: <a style="text-decoration:underline;" href="mailto:77000@gov.bc.ca" target="_blank" >77000@gov.bc.ca</a></div>
 
             {{-- @if (!str_contains(Request::url(), 'pecsf-test.apps.silver.devops.gov.bc.ca'))   --}}
-            @if ((Request::is('admin/login')) || (in_array(env('APP_ENV'), ['dev', 'local'])))
+            @if ((Request::is('admin/login')) || (in_array(env('APP_ENV'), ['dev', 'local', 'TEST'])))
                 <div class="py-4 small"><a class="sysadmin-login" href="">Log in as a System Administrator</a></div>
             @endif
             {{-- @endif --}}


### PR DESCRIPTION
Region:Test  
Make the "login as administrator" hyperlink also enabled in TEST region to use test signin accouts for testing purpose

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Zq9k5zSB5kGi9TM-we6JA2UACdy6?Type=TaskLink&Channel=Link&CreatedTime=638290049601450000)