### PR TITLE
[jp-0026] Browser back button displays blank screen when clicked while modal is open

### DIFF
--- a/resources/views/admin-pledge/campaign/wizard.blade.php
+++ b/resources/views/admin-pledge/campaign/wizard.blade.php
@@ -332,6 +332,7 @@ $(function () {
                 $(".cancel").trigger("click");
             } else {
                 history.pushState(null, null, location.href);
+                $('.modal').modal('hide');
                 $(".back").trigger("click");
             }
         }

--- a/resources/views/annual-campaign/wizard.blade.php
+++ b/resources/views/annual-campaign/wizard.blade.php
@@ -296,6 +296,7 @@ $(function () {
                 $(".cancel").trigger("click");
             } else {
                 history.pushState(null, null, location.href);
+                $('.modal').modal('hide');
                 $(".back").trigger("click");
             }
         }

--- a/resources/views/donate-now/wizard.blade.php
+++ b/resources/views/donate-now/wizard.blade.php
@@ -299,6 +299,7 @@ $(function () {
                 $(".cancel").trigger("click");
             } else {
                 history.pushState(null, null, location.href);
+                $('.modal').modal('hide');
                 $(".back").trigger("click");
             }
         }


### PR DESCRIPTION
Issue if for all the modals that opens - 
- View details (CRA charities)
- info icon for FSP
Steps to reproduce: 
- Open the modal
- Click the browser back button
- Notice that the black screen remains on the screen until the refresh button is clicked

Sept 5 - enhancement done on programs, close all modal box when the browser back button triggered
-- Annual Campaign (Self service)
-- Donate Now (Self-Service)
-- Annual Campaign (Admin)

[Ticket ](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/-HSeEvzf0kKOaqn3h2TlcWUAO8dK?Type=TaskLink&Channel=Link&CreatedTime=638295257267390000)

