### PR TITLE
(MASTER) [jp-0027] Test eligible employee numbers in PROD (fixed employee job data issues)

### DIFF
--- a/app/Models/EmployeeJobStaging.php
+++ b/app/Models/EmployeeJobStaging.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EmployeeJobStaging extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'organization_id', 'emplid', 'empl_rcd', 'effdt', 'effseq', 
+        'empl_status', 'empl_class', 'empl_ctg', 'job_indicator',
+        'position_number', 'position_title', 'appointment_status', 
+        'first_name', 'last_name', 'name', 'email', 'guid', 'idir', 
+        'business_unit', 'business_unit_id',  'deptid', 'dept_name', 'tgb_reg_district', 'region_id', 
+        'office_address1', 'office_address2', 'office_city', 'office_stateprovince', 'office_country', 'office_postal',
+        'address1', 'address2', 'city', 'stateprovince', 'country', 'postal',
+        'organization', 'level1_program', 'level2_division', 'level3_branch', 'level4', 
+        'supervisor_emplid', 'supervisor_name', 'supervisor_email', 
+         'date_updated', 'date_deleted', 'created_by_id', 'updated_by_id'
+    ];
+    
+}

--- a/database/migrations/2023_09_05_160415_create_employee_job_stagings_table.php
+++ b/database/migrations/2023_09_05_160415_create_employee_job_stagings_table.php
@@ -1,0 +1,92 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('employee_job_stagings', function (Blueprint $table) {
+            $table->id();
+
+            $table->bigInteger('organization_id')->nullable();
+            $table->string('emplid');
+            $table->integer('empl_rcd');
+            $table->date('effdt');
+            $table->integer('effseq');
+            
+            $table->string('empl_status')->nullable();
+            $table->string('empl_class')->nullable();
+            $table->string('empl_ctg')->nullable();
+            $table->string('job_indicator')->nullable();
+
+            $table->string('position_number')->nullable();
+            $table->string('position_title')->nullable();
+            $table->string('appointment_status')->nullable();
+
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('name')->nullable();
+            $table->string('email')->nullable();
+            $table->string('guid')->nullable();
+            $table->string('idir')->nullable();
+
+            $table->string('business_unit')->nullable();
+            $table->bigInteger('business_unit_id')->nullable();
+            $table->string('deptid')->nullable();
+            $table->string('dept_name')->nullable();
+            $table->string('tgb_reg_district')->nullable();
+            $table->bigInteger('region_id')->nullable();
+
+            $table->string('office_address1')->nullable();
+            $table->string('office_address2')->nullable();
+            $table->string('office_city')->nullable();
+            $table->string('office_stateprovince')->nullable();
+            $table->string('office_country')->nullable();
+            $table->string('office_postal')->nullable();
+            $table->string('address1')->nullable();
+            $table->string('address2')->nullable();
+            $table->string('city')->nullable();
+            $table->string('stateprovince')->nullable();
+            $table->string('country')->nullable();
+            $table->string('postal')->nullable();
+
+            $table->string('organization')->nullable();
+            $table->string('level1_program')->nullable();
+            $table->string('level2_division')->nullable();
+            $table->string('level3_branch')->nullable();
+            $table->string('level4')->nullable();
+
+            $table->string('supervisor_emplid')->nullable();
+            $table->string('supervisor_name')->nullable();
+            $table->string('supervisor_email')->nullable();
+
+            $table->timestamp('date_updated')->nullable();
+            $table->timestamp('date_deleted')->nullable();
+
+            $table->bigInteger('created_by_id')->nullable();
+            $table->bigInteger('updated_by_id')->nullable();
+
+            $table->timestamps();
+
+            $table->index(['emplid', 'empl_rcd']); 
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('employee_job_stagings');
+    }
+};


### PR DESCRIPTION
Issues
Eligible employee numbers in challenge page and eligible ee report are:
Missing entries with Sept 1 eft dates
Missing entries with future layoffs
Includes entries for terminated/retired ees

Sept 5 -- Couple of issues:
a) for data conversion, the old employee job carried forward but no longer exists in BI interface data anymore. Those job record should be marked as 'Terminated'.
b) Per audit, the couple of business units were update on Sept 1 after the eligible employee snapshot took on 4:30am
c) some new or recent update job data doesn't pass to Greenfield until Sept 5, 2023. That why eligible doesn't has those records.

Changes
New staging table created for temporialy storing the BI job data for comparing purpose, use it for comparing whether the job data is exists or not, If no longer exists, mark it to 'terminated'.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/PCMx4uaNkkW4hJJNT20cemUAGBke?Type=TaskLink&Channel=Link&CreatedTime=638295703596720000)