### PR TITLE
[jz-004] Admin: Edit e-form bug fixes and enhancements

### DIFF
--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -1,3 +1,14 @@
+<style>
+.modal-body {
+    overflow-y: auto; /* Add a vertical scrollbar when content overflows */
+}
+
+
+.modal-body{
+    max-height: 80vh; /* Set a maximum height for the modal content */
+}
+</style>    
+
 @extends('adminlte::page')
 @section('content_header')
     <div class="d-flex mt-3">
@@ -43,7 +54,7 @@
         </div>
     </div>
 
-    <div class="modal fade" id="edit-event-modal">
+    <div class="modal fade" id="edit-event-modal" tabindex="-1" >
         <div class="modal-dialog custom-modal">
             <div class="modal-content">
                 <div class="modal-header">
@@ -56,7 +67,7 @@
                     <!-- content will be load here -->
                     <button class="btn btn-primary edit">Edit</button>
                     <div id="edit-event-modal-body">
-                        @include('volunteering.partials.form')
+                        @include('admin-pledge.submission-queue.partials.form')
                     </div>
                 </div>
                 <div class="modal-footer">
@@ -65,6 +76,7 @@
             </div>
         </div>
     </div>
+    @include('admin-pledge.submission-queue.partials.reginal-pool')
     <div class="modal fade" id="lock-event-modal">
         <div class="modal-dialog modal-md">
             <div class="modal-content">
@@ -283,7 +295,9 @@
                             if(data[0].organization_code == "GOV"){
                                 $("#bcgovid *,#bcgovid").show();
                                 $("#bcgovid").show();
-                                $("#pecsfid").hide();
+                                if($("#event_type").val().toLowerCase() == "cheque one-time donation" || $("#event_type").val().toLowerCase() == "cash one-time donation"){
+                                    $("#pecsfid *,#pecsfid").show();
+                                }
                             }else{
                                 $("#pecsfid").html($("#pecsfid").html());
                                 $("#pecsfid *,#pecsfid").show();
@@ -294,7 +308,6 @@
                     }
 
                     $('#edit-event-modal').modal('show');
-                    console.log(data);
                 },"json");
         });
 
@@ -324,45 +337,44 @@
                         '<i class="fa fa-thumbs-up"></i> Approve!',
                     confirmButtonAriaLabel: 'Approved!',
                     cancelButtonText:
-                        '<i class="fa fa-thumbs-down"></i>',
-                    cancelButtonAriaLabel: 'Thumbs down'
+                        '<i class="fa fa-thumbs-down"></i> Maybe later',
+                    cancelButtonAriaLabel: 'Maybe later.'
                 }).then((result) => {
-                 if (result.isConfirmed) {
-                     $(this).parents("tr").remove();
-                     $.post("/admin-pledge/status",
-                         {
-                             submission_id: $("#submission_id").val(),
-                             status: 1
-                         },
-                         function (data, status) {
+                    if (result.isConfirmed) {
+                        $(this).parents("tr").remove();
+                        $.post("/admin-pledge/status",
+                            {
+                                submission_id: $("#submission_id").val(),
+                                status: 1
+                            },
+                            function (data, status) {
 
-                             Swal.fire({
-                                 title: '<strong>Success!</strong>',
-                                 icon: 'info',
-                                 html:
-                                     'The Event was successfully approved and can be viewed in the main list',
-                                 showCloseButton: true,
-                                 showCancelButton: true,
-                                 focusConfirm: false,
-                                 confirmButtonText:
-                                     '<i class="fa fa-thumbs-up"></i> Go To list',
-                                 confirmButtonAriaLabel: 'Go To list',
-                                 cancelButtonText:
-                                     'Close',
-                                 cancelButtonAriaLabel: 'Close'
-                             }).then((result) => {
-                                 if (result.isConfirmed) {
-                                     window.location.href = "/admin-pledge/maintain-event";
-                                 }
-                             });
-                         });
-                 } else {
-
-
-                     $(".status").val(0).trigger("change");
-
-                 }
-             });
+                                Swal.fire({
+                                    title: '<strong>Success!</strong>',
+                                    icon: 'info',
+                                    html:
+                                        'The Event was successfully approved and can be viewed in the main list',
+                                    showCloseButton: true,
+                                    showCancelButton: true,
+                                    focusConfirm: false,
+                                    confirmButtonText:
+                                        '<i class="fa fa-thumbs-up"></i> Go To list',
+                                    confirmButtonAriaLabel: 'Go To list',
+                                    cancelButtonText:
+                                        'Close',
+                                    cancelButtonAriaLabel: 'Close'
+                                }).then((result) => {
+                                    if (result.isConfirmed) {
+                                        window.location.href = "/admin-pledge/maintain-event";
+                                    }
+                                });
+                            });                            
+                    } else {
+                        $(".status").val(0).trigger("change");
+                    }
+                    $('.modal').modal('hide');
+                    window.location.href = "/admin-pledge/submission-queue";                    
+                });
 
                }
 
@@ -395,11 +407,9 @@
             $('#lock-event-modal').modal("hide");
         });
 
-        $(document).ready(function() {
-            $(".closeModalBtn").click(function() {
-                $("#regionalPoolModal").modal("hide"); // Close the modal with ID "myModal"
+        $(".closeModalBtn").click(function() {
+                $("#regionalPoolModal").modal("hide"); 
             });
-        });
 
     </script>
     @include('admin-pledge.submission-queue.partials.add-event-js')

--- a/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
@@ -47,7 +47,7 @@ $("#pool_filter").parents(".form-group").hide();
             $("#pecsfid").show();
 
             $("#bcgovid").find("input").val("");
-            $("#employee_name").val("");
+            //$("#employee_name").val("");
 
         }
         else if($(this).val()=="Gaming"){
@@ -63,7 +63,7 @@ $("#pool_filter").parents(".form-group").hide();
             $("#pecsfid").show();
 
             $("#bcgovid").find("input").val("");
-            $("#employee_name").val("");
+            //$("#employee_name").val("");
         }
         else{
             if($("[name='organization_code']").val() == "GOV"){
@@ -71,14 +71,28 @@ $("#pool_filter").parents(".form-group").hide();
                 $("#event_type>option[value='Fundraiser']").prop('disabled',false);
                 $("#event_type>option[value='Gaming']").prop('disabled',false);
 
-                $("#pecsfid").find("input").hide();
-                $("#bcgovid").find("input").show();
-                $("#pecsfid").find("label").hide();
-                $("#bcgovid").find("label").show();
-                $("#bcgovid").show();
-                $("#employeename").show();
+                if($("#event_type").val().toLowerCase() == "cheque one-time donation" || $("#event_type").val().toLowerCase() == "cash one-time donation"){
+                    $("#pecsfid").find("input").show();
+                    $("#bcgovid").find("input").show();
+                    $("#pecsfid").find("label").show();
+                    $("#bcgovid").find("label").show();
+                    $("#bcgovid").show();
+                    $("#employeename").show();
+                    $("#pecsfid").show();
 
-                $("#pecsfid").find("input").val("");
+                    //$("#pecsfid").find("input").val("");
+                } else {
+                    $("#pecsfid").find("input").hide();
+                    $("#bcgovid").find("input").show();
+                    $("#pecsfid").find("label").hide();
+                    $("#bcgovid").find("label").show();
+                    $("#bcgovid").show();
+                    $("#employeename").show();
+
+                    //$("#pecsfid").find("input").val("");
+                }    
+
+                
 
             }
             else if($("[name='organization_code']").val() == "RET"){
@@ -96,6 +110,9 @@ $("#pool_filter").parents(".form-group").hide();
                 $("#event_type>option[value='Gaming']").prop('disabled',true);
                 if($("#event_type").val().toLowerCase() == "cheque one-time donation" || $("#event_type").val().toLowerCase() == "cash one-time donation"){
                     $("#employeename").show();
+                    $("#pecsfid").find("input").show();
+                    $("#pecsfid").find("label").show();
+                    $("#pecsfid").show();
                 }
             }
             else{
@@ -109,7 +126,7 @@ $("#pool_filter").parents(".form-group").hide();
                 $("#pecsfid").show();
                 $("#employeename").show();
 
-                $("#bcgovid").find("input").val("");
+                //$("#bcgovid").find("input").val("");
                 
             }
 

--- a/resources/views/admin-pledge/submission-queue/partials/form.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/form.blade.php
@@ -1,0 +1,422 @@
+<form id="bank_deposit_form" action="{{ route("bank_deposit_form") }}" method="POST"
+      enctype="multipart/form-data">
+    @csrf
+    <br>
+
+    <input type="hidden" name="form_id" id="form_id" value="0" />
+
+    <div class="form-row" style="left: 5px;
+    position: relative;width:100%;border-top-left-radius:5px;border-top-right-radius:5px;background:#1a5a96;color:#fff;padding-left:15px;padding-top:10px;">
+        <h2>Event bank deposit form</h2>
+    </div>
+    <div class="card" style="border-radius:0px;">
+        <div class="card-body">
+    <div class="form-row">
+        <div class="form-group col-md-4">
+            <label for="organization_code">Organization</label>
+            <select type="text" class="form-control " name="organization_code" id="organization_code" placeholder="">
+            <option value="" selected="selected">Choose an Organization</option>
+
+            </select>
+            <span class="organization_code_errors errors">
+                          @error('organization_code')
+                            <span class="invalid-feedback">{{  $message  }}</span>
+                          @enderror
+            </span>
+        </div>
+        <div class="form-group col-md-4">
+            <label for="form_submitter">Form submitter</label>
+            <!--<div id="form_submitter">{{$current_user->name}}</div>-->
+            <input type="text" disabled class="form-control" value="{{$current_user->name}}" />
+
+            <input type="hidden" disabled value="{{$current_user->id}}" name="form_submitter" />
+
+            <span class="form_submitter_errors errors">
+                       @error('form_submitter')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+        <div class="form-group col-md-4">
+            <label for="campaign_year">Campaign year</label>
+            <!--<div id="campaign_year">{{$campaign_year->calendar_year - 1}}</div>-->
+            <input type="text" disabled class="form-control" value="{{$campaign_year->calendar_year - 1}}" />
+            <input type="hidden"  value="{{$campaign_year->id}}" name="campaign_year" />
+            <span class="campaign_year_errors errors">
+                       @error('form_submitter')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+    </div>
+<br>
+    <div class="form-row form-header">
+            <h3 class="blue">Donation or event details</h3>
+    </div>
+
+    <div class="form-row form-body">
+        <div class="form-group col-md-6">
+            <label for="description">Donation or event name</label>
+            <input class="form-control" type="text" name="description" id="description" />
+            <span>Include Event Name-Date (DD/MM/YYYY) - Name of Coordinator<br>For Cash or Cheque, write CASH or Cheque – Cheque #</span>
+            <span class="description_errors errors">
+                       @error('description')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+        </div>
+
+        <div class="form-group col-md-3 event_type">
+            <label for="event_type">Donation or event type</label>
+            <select class="form-control" type="text" id="event_type" name="event_type">
+                <option value="">Select an event type</option>
+                <option value="Cash One-Time Donation">Cash one-time donation</option>
+                <option value="Cheque One-Time Donation">Cheque one-time donation</option>
+                <option value="Fundraiser">Fundraiser</option>
+                <option value="Gaming">Gaming</option>
+            </select>
+            <span class="event_type_errors errors">
+                       @error('form_submitter')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+        <div class="form-group col-md-3 sub_type">
+            <label for="sub_type">Sub type</label>
+            <select class="form-control" type="text" id="sub_type" name="sub_type">
+                <option value="false">Disabled</option>
+            </select>
+            <span class="sub_type_errors errors">
+                       @error('form_submitter')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+        <div class="form-group col-md-3">
+            <label for="sub_type">Deposit date</label>
+            <input class="form-control" type="date" id="deposit_date" name="deposit_date">
+            <span class="deposit_date_errors errors">
+                       @error('form_submitter')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+        <div class="form-group col-md-3">
+            <label for="sub_type">Deposit amount ($)</label>
+            <input class="form-control" type="text" id="deposit_amount" name="deposit_amount" />
+
+            <span class="deposit_amount_errors errors">
+                       @error('form_submitter')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+        <div id="pecsfid" class="form-group col-md-3" style="">
+            <label for="pecsf_id">PECSF ID</label>
+            <input class="form-control" type="text" name="pecsf_id" id="pecsf_id" />
+            <span class="pecsf_id_errors errors">
+                       @error('pecsf_id')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+        </div>
+        
+        <div id="bcgovid" class="form-group col-md-3" style="display:none;">
+            <label for="bc_gov_id">Employee ID</label>
+            <input class="form-control" type="text" name="bc_gov_id" id="bc_gov_id" />
+            <span class="bc_gov_id_errors errors">
+                       @error('bc_gov_id')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+        </div>
+
+        <div id="employeename" class="form-group col-md-3" style="">
+            <label for="employee_name">Employee Name</label>
+            <input class="form-control" type="text" name="employee_name" id="employee_name" />
+            <span class="employee_name_errors errors">
+                       @error('employee_name')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+        </div>
+
+
+    </div>
+<br>
+
+
+
+    <div class="form-row form-header">
+            <h3 class="blue">Work location</h3>
+    </div>
+    <div class="form-row form-body">
+
+        <div class="form-group col-md-4">
+            <label for="event_type">Employment city</label>
+            <select onchange="$('#region').val($('[code='+this.options[this.selectedIndex].attributes[0].value+']').attr('value')).trigger('change');" class="form-control search_icon" type="text" id="employment_city" name="employment_city" >
+                <option value="">Select a city</option>
+                @foreach($cities as $city)
+                    <option region="{{$city->TGB_REG_DISTRICT}}" value="{{$city->city}}">{{$city->city}}</option>
+                    @endforeach
+            </select>
+
+            <span class="employment_city_errors errors">
+                       @error('employment_city')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+        <div class="form-group col-md-4">
+            <label for="region">Region</label>
+            <select class="form-control search_icon" id="region" name="region">
+                <option value="">Select a region</option>
+            @foreach($regions as $region)
+                    <option  code="{{$region->code}}" value="{{$region->id}}">{{$region->name}}</option>
+                @endforeach
+            </select>
+            <span class="region_errors errors">
+                       @error('region')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+        <div class="form-group col-md-4">
+            <label for="sub_type">Business unit</label>
+            <select class="form-control search_icon" id="business_unit" name="business_unit">
+                <option value="">Select a business unit</option>
+            @foreach($business_units as $bu)
+                    @if(!empty($bu->name))
+                    <option value="{{$bu->id}}">{{$bu->name}}</option>
+                    @endif
+                @endforeach
+            </select>
+            <span class="business_unit_errors errors">
+                       @error('business_unit')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+
+    </div>
+    <br>
+    <div class="form-row form-header address_hook" style="display:none;">
+            <h3 class="blue">Mailing address for charitable receipt</h3>
+    </div>
+
+    <div class="form-row form-body address_hook" style="display:none;">
+        <span style="padding:10px;">A charitable donation receipt will be issued for cash and cheque donations in February following the calendar year in which the donation is received.</span>
+
+        <div class="form-group col-md-12" id="address_line_1" style="">
+            <label for="event_type">Address line 1</label>
+            <input class="form-control" type="text" id="address_1" name="address_1"/>
+
+            <span class="address_1_errors errors">
+                       @error('address_1')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+
+        <div class="form-group col-md-4">
+            <label for="sub_type">City</label>
+
+            <select class="form-control search_icon" type="text" id="city" name="city" >
+                <option value="">Select a city</option>
+            @foreach($cities as $city)
+                <option value="{{$city->city}}" province="{{$city->province}}">{{$city->city}}</option>
+            @endforeach
+
+            </select>
+            <span class="city_errors errors">
+                       @error('city')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+        <div class="form-group col-md-4">
+            <label for="sub_type">Province</label>
+            <select class="form-control" type="text" id="province" name="province">
+                <option value="">Select a  province</option>
+                <option value="British Columbia">British columbia</option>
+                <option value="Ontario">Ontario</option>
+            </select>
+            <span class="province_errors errors">
+                       @error('province')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+        <div class="form-group col-md-4">
+            <label for="sub_type">Postal Code</label>
+            <input class="form-control" type="text" id="postal_code" name="postal_code" />
+            <span class="postal_code_errors errors">
+                       @error('postal_code')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                    @enderror
+                  </span>
+
+        </div>
+
+    </div>
+<br>
+    <br>
+    <div class="form-row form-header">
+            <h3 class="blue">Charity selections and distribution</h3>
+    </div>
+
+    <div class="form-row p-3" style="border-left:#ccc 1px solid;border-right:#ccc 1px solid;">
+        <div class="form-group col-md-12">
+            <input type="radio" checked id="charity_selection_1" name="charity_selection" value="fsp" />
+            <label class="blue" for="charity_selection_1">Fund supported pool</label>
+            <span class="charity_selection_errors errors">
+                       @error('charity_selection')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                            @enderror
+                        </span>
+
+            <br>
+            <span style="padding:20px;">
+    By choosing this option your donation will support the current Fund Supported Pool of regional programs. Click on the tiles to learn about the programs in each regional pool.
+</span>
+        </div>
+
+
+        @foreach( $pools as $pool )
+            <div class="form-group col-md-2 form-pool">
+
+                <div style="width:100%;" class="BC-Gov-SecondaryButton card h-100 {{ $pool->id == $regional_pool_id ? 'active' : '' }}" data-id="pool{{ $pool->id }}">
+                    {{-- <img src="https://picsum.photos/200" class="card-img-top" alt="..."
+                             width="50" height="50"> --}}
+                    <div class="card-body m-1 p-2">
+
+                        <div class="form-check float-left">
+                            <input class="form-check-input" type="radio" name="regional_pool_id" id="pool{{ $pool->id }}"
+                                   value="{{ $pool->id }}" {{ $pool->id == $regional_pool_id ? 'checked' : '' }}>
+
+                        </div>
+                        <br>
+
+                        <label style="font-weight:bold;font-size:16px;text-align: center;
+    width: 100%;" class="form-check-label pl-3" for="xxxpool{{ $pool->id }}">
+                            {{ $pool->region->name }}
+                        </label>
+                        <span style="font-size:16px;font-weight:bold;text-decoration:underline;width:100%;text-align:center;display:block" class="more-info bottom-center" data-id="{{ $pool->id }}"
+                              data-name="{{ $pool->region->name }}" data-source="" data-type="" data-yearcd="{{date("Y",strtotime($pool->start_date))}}">View Details</span>
+                    </div>
+
+
+                </div>
+
+            </div>
+        @endforeach
+
+        @for($i=0;$i<((count($pools)%6) );$i++)
+            <div class="form-group col-md-2 form-pool">
+
+
+
+            </div>
+            @endfor
+    </div>
+            <div class="form-row p-3"style="border-left:#ccc 1px solid;border-right:#ccc 1px solid;border-bottom:#ccc 1px solid;border-radius:5px;">
+
+        <div class="form-group col-md-6">
+            <input type="radio" id="charity_selection_2" name="charity_selection" value="dc" />
+            <label class="blue" for="charity_selection_2">Donor choice</label>
+        </div>
+        <div class="form-group  org_hook col-md-6">
+            <a href="https://apps.cra-arc.gc.ca/ebci/hacc/srch/pub/dsplyBscSrch?request_locale=en" target="_blank"><img class="float-right" style="width:26px;height:26px;position:relative;top:-4px;" src="{{asset("img/icons/external_link.png")}}"></img><h5 class="blue float-right">View CRA Charity List</h5></a>
+        </div>
+        <div class="form-group col-md-12">
+            <p>By choosing this option you can support up to 10 Canada Revenue Agency (CRA) registered charitable organizations.
+                Our system uses the official name of the charity registered with the CRA. You can use the View CRA Charity List link to confirm if the organization you would like to support is registered. You can also support a specific branch or program name.</p>
+
+        </div>
+        @include('donate.partials.choose-charity')
+
+
+
+
+        </div>
+            <br>
+
+
+
+
+            <div class="form-row form-header">
+                            <h3 class="blue">File(s)</h3>
+
+
+                <span class="pl-3 attachment_errors errors">
+
+                       @error('attachments')
+                        <span class="invalid-feedback">{{  $message  }}</span>
+                            @enderror
+                        </span>
+            </div>
+
+            <div class="form-row form-body">
+
+                <div class="col-md-12"> <span style="display:block;padding:10px;">Drag and Drop or Browse to attach your completed PECSF Event Bank Deposit Form attachment (pdf,xls,xlsx,csv,png,jpg,jpeg) with bank receipt.</span>
+                    </div>
+
+
+                <div style="padding:8px;" class="upload-area form-group col-md-3">
+
+
+                    <i style="color:#1a5a96;" class="fas fa-file-upload fa-5x"></i>
+                    <br>
+                    <br>
+                    <a onclick="$('#attachment_input_1').click();" style="background:#fff;border:none;font-weight:bold;color:#000;text-align:center;" id="upload-area-text" for="attachment_input_1">Drag and Drop Or <u>Browse</u> Files</a>
+                    <input style="display:none" id="attachment_input_1" name="attachments[]" type="file" />
+                </div>
+                <table id="attachments" class=" form-group col-md-6">
+
+                </table>
+            </div>
+
+    </div>
+
+
+
+
+
+
+
+<br>
+    <br>
+    <input type="submit" style="margin-left:20px;"   class="col-md-2 btn btn-primary" value="Submit" />
+    <br>
+    <br>
+    <p style="padding:20px;">Once information has been submitted to PECSF Administration, no further changes are possible through eForm. Please contact pecsf@gov.bc.ca</p>
+
+        <h5 style="padding-left:20px;">Freedom of Information and Protection of Privacy Act</h5>
+    <p style="padding:20px;">
+
+        Personal information on this form is collected by the BC Public Service Agency for the purposes of processing and reporting your charitable contributions to the Community Fund and for program evaluation and improvement under sections 26 (c) and (e) of the Freedom of Information and Protection of Privacy Act.
+
+        Questions about the collection of your personal information can be directed to the Campaign Manager, Provincial Employees Community Services Fund at 250 356-1736 or <a href="mailto:PECSF@gov.bc.ca">PECSF@gov.bc.ca</a>.  </p>
+        </div>
+
+</form>
+

--- a/resources/views/admin-pledge/submission-queue/partials/reginal-pool.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/reginal-pool.blade.php
@@ -1,0 +1,21 @@
+
+<!-- Modal -->
+<div class="modal fade" id="regionalPoolModal" tabindex="-2" role="dialog" aria-labelledby="pledgeDetailModalTitle" aria-hidden="true">
+    <div class="modal-dialog modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header bg-primary">
+                <h5 class="modal-title" id="pledgeDetailModalTitle">Regional Charity Pool
+                    <span class=""></span></h5>
+                <button type="button" class="close closeModalBtn" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body pledgeDetail">
+            </div>
+            <div class="modal-footer">
+                <button type="button" style="color:#000;" class="btn btn-outline-primary closeModalBtn">Close</button>
+            </div>
+        </div>
+    </div>
+</div>
+


### PR DESCRIPTION
1.  replace the Thumps-down button with ‘Maybe later’ 
2.  When the thumps-down button is clicked, it gives a blank white page
3. After the white screen is displayed, if we close the modal and again click on the View details button for any pledge, it still gives the white screen
4. Click on view details -> Edit -> View details for the FSP -> When the FSP details open up -> Close it -> Now if we scroll up and down, the edit form page does not scroll and the background scrolls up and down 
5. For gov cash and cheque only, please add the PECSF id field besides the employee name so that user can enter the PECSF id 
6. Nice to have: It will be nice to have if we can store the emp id and name field locally so that for any event, if we change the event from cash/cheque to gaming/fundraiser and back to cash/cheque, the em id and name field will not appear blank? 