### PR TITLE
[jp-0030] Alphabetize FSP entries by charity name

### DIFF
--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -780,6 +780,7 @@ class AnnualCampaignController extends Controller
             $pool_id = $request->regional_pool_id;
             $pool = FSPool::where('id', $pool_id)->first();
             $pool_charities = $pool ? $pool->charities : [];
+            $pool_charities = $pool_charities->sortBy('charity.charity_name');
 
             $frequency = $request->frequency;
 
@@ -1001,7 +1002,7 @@ class AnnualCampaignController extends Controller
         if ($request->ajax()) {
             $pool = FSPool::where('id', $id)->first();
             $charities = $pool ? $pool->charities : [];
-
+            $charities = $charities->sortBy('charity.charity_name');
             return view('annual-campaign.partials.pool-detail', compact('charities') )->render();
         } else {
             return redirect('/');

--- a/app/Http/Controllers/DonateNowController.php
+++ b/app/Http/Controllers/DonateNowController.php
@@ -440,6 +440,7 @@ class DonateNowController extends Controller
         if ($request->ajax()) {
             $pool = FSPool::where('id', $id)->first();
             $charities = $pool ? $pool->charities : [];
+            $charities = $charities->sortBy('charity.charity_name');
             return view('donate-now.partials.pool-detail', compact('charities') )->render();
         } else {
             return redirect('/');

--- a/resources/views/admin-campaign/fund-supported-pools/edit.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/edit.blade.php
@@ -86,10 +86,10 @@
                             </tr>
                         </thead> --}}
                         <tbody id="accordion">
-                            @foreach (old('charities', $pool->charities->pluck('charity_id') ) as $index => $oldCharity)
+                            @foreach (old('charities', $charities->pluck('charity_id') ) as $index => $oldCharity)
                             <tr id="charity{{ $index }}">
                                 @if (count($errors) == 0)
-                                    @php ( $pool_charity = $pool->charities[$index] )                                    
+                                    @php ( $pool_charity = $charities[$index] )                                    
                                 @else
                                     @php ( $pool_charity = new \App\Models\FSPoolCharity )                                    
                                 @endif
@@ -111,7 +111,7 @@
                             --}}
                             </tr>
                             @endforeach
-                            <tr id="charity{{ count(old('charities', $pool->charities->pluck('charity_id') )) }}"></tr>
+                            <tr id="charity{{ count(old('charities', $charities->pluck('charity_id') )) }}"></tr>
                         </tbody>
                     </table>
 

--- a/resources/views/admin-campaign/fund-supported-pools/partials/edit-pool-charity.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/partials/edit-pool-charity.blade.php
@@ -158,7 +158,8 @@
                         <input type="file" class="form-control-file @error('images.'.$index) is-invalid @enderror" 
                                 onchange="loadFile(event)" name="images[]" value="{{ old('images.'.$index) }}"> --}}
                         @error( 'images.'.$index )
-                            <span class="invalid-feedback">{{ $message }}</span>
+                            <span class="invalid-feedback"></span>
+                            <h6 class="text-danger">{{ $message }}</h6>
                         @enderror
                     </div>
                 </div>

--- a/resources/views/admin-campaign/fund-supported-pools/show.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/show.blade.php
@@ -69,9 +69,10 @@
                             </tr>
                         </thead> --}}
                         <tbody id="accordion">
-                            @foreach ( $pool->charities->pluck('charity_id') as $index => $oldCharity)
+                            @foreach ( $charities->pluck('charity_id') as $index => $oldCharity)
+
                             <tr id="charity{{ $index }}">
-                                @php ( $pool_charity = $pool->charities[$index] )                                    
+                                @php ( $pool_charity = $charities[$index] )                                    
                                 @include('admin-campaign.fund-supported-pools.partials.show-pool-charity', ['index'=> $index, 'charity' => $oldCharity, 'pool_charity' => $pool_charity ])
                             {{-- <tr>
                                 <td>
@@ -90,7 +91,7 @@
                             --}}
                             </tr>
                             @endforeach
-                            <tr id="charity{{ count(old('charities', $pool->charities->pluck('charity_id') )) }}"></tr>
+                            <tr id="charity{{ count(old('charities', $charities->pluck('charity_id') )) }}"></tr>
                         </tbody>
                     </table>
 


### PR DESCRIPTION
Oct 4 - the following areas are changed for display the charity by charity name (sorting sequence):
1. Pool detail in Annual Campaign
2. Summary Page in Annual Campaign
3. Pool detail in Donate Now
4. Pool detail in eForm
5. Pool detail in eForm (Administration)
6. Pool detail in submission Queue (Administration)
7. Fund Support Pool maintainenance page

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/7BD5TafWSU-i7I6lzklcCWUAFjNl?Type=TaskLink&Channel=Link&CreatedTime=638320512603020000)