### PR TITLE
TEST MIGRATION [jp-0031] Remove the extra line showing up in the donations flow

### DIFF
--- a/resources/views/annual-campaign/wizard.blade.php
+++ b/resources/views/annual-campaign/wizard.blade.php
@@ -629,7 +629,7 @@ $(function () {
 
 </script>
 
-// Page 2 -- charities
+{{-- // Page 2 -- charities --}}
 @include('annual-campaign.partials.choose-charity-js')
 <script type="x-tmpl" id="organization-tmpl">
     @include('annual-campaign.partials.add-charity', ['index' => 'XXX', 'charity' => 'YYY'] )
@@ -638,7 +638,7 @@ $(function () {
     $(".org_hook").show();
 </script>
 
-// Page 4 -- distribution
+{{--  // Page 4 -- distribution --}}
 @include('annual-campaign.partials.distribution-js')
 
 <script>


### PR DESCRIPTION
There is an extra line showing up at the bottom of all pages of the donations flow as / Page 2 -- charities // Page 4 -- distribution
The screenshot is attached for reference

Oct 5 - fix wrong comment line on HTML area.

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2FtaskListType%2FsmartList%2FSL_AssignedToMe%2Fplan%2FZOb3bFXcakWu8Gl2Zd_PuGUAFIJt%2Ftask%2F03El3lk-LE65UWddZU87LWUANZfY%22%7D)