### PR TITLE
TEST MIGRATION [jp-0033] Daily Campaign Update report - Employees that move show und…er correct org, but dept ID description is wrong

### DIFF
--- a/app/Exports/PledgesExport.php
+++ b/app/Exports/PledgesExport.php
@@ -211,8 +211,8 @@ class PledgesExport implements FromQuery, WithHeadings, WithMapping, WithEvents
                             END as name
                             ,pledges.business_unit  
                             ,pledges.tgb_reg_district
-                            ,employee_jobs.deptid
-                            ,employee_jobs.dept_name
+                            ,pledges.deptid
+                            ,pledges.dept_name
                             ,CASE WHEN organizations.code = 'GOV'
                                     THEN employee_jobs.office_city
                                     ELSE pledges.city
@@ -320,14 +320,8 @@ class PledgesExport implements FromQuery, WithHeadings, WithMapping, WithEvents
                             END
                             ,(select code from business_units where id = bank_deposit_forms.business_unit limit 1)
                             ,regions.code
-                            ,CASE WHEN organization_code = 'GOV' 
-                                THEN employee_jobs.deptid
-                                ELSE null
-                            END
-                            ,CASE WHEN organization_code = 'GOV'  
-                                THEN employee_jobs.dept_name
-                                ELSE null
-                            END
+                            ,bank_deposit_forms.deptid
+                            ,bank_deposit_forms.dept_name
                             ,CASE WHEN bank_deposit_forms.organization_code = 'GOV'
                                 THEN employee_jobs.office_city
                                 ELSE bank_deposit_forms.address_city

--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -286,6 +286,8 @@ class CampaignPledgeController extends Controller
                 // $tgb_reg_district =  $user->primary_job ? $user->primary_job->tgb_reg_district : null;
                 $city = City::where('city', trim( $request->user_office_city )  )->first();
                 $tgb_reg_district = $city ? $city->TGB_REG_DISTRICT : $user->primary_job->tgb_reg_district;
+                $detpid = $user->primary_job ? $user->primary_job->deptid : null;
+                $dept_name = $user->primary_job ? $user->primary_job->dept_name : null;
             } else {
                 $org = Organization::where('id', $request->organization_id)->first();
                 $business_unit = $org ? $org->bu_code : null;
@@ -305,6 +307,8 @@ class CampaignPledgeController extends Controller
 
                 'business_unit' => $business_unit,
                 'tgb_reg_district' => $tgb_reg_district,
+                'deptid' => $deptid,
+                'dept_name' => $dept_name,
 
                 'campaign_year_id' => $request->campaign_year_id,
                 'type' => $request->pool_option,

--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -391,13 +391,16 @@ class AnnualCampaignController extends Controller
         $office_city = $user->primary_job ? $user->primary_job->office_city : null;
         $city = City::where('city', trim( $office_city )  )->first();
         $tgb_reg_district = $city ? $city->TGB_REG_DISTRICT : $user->primary_job->tgb_reg_district ;
+        $deptid = $user->primary_job ? $user->primary_job->deptid : null;
+        $dept_name = $user->primary_job ? $user->primary_job->dept_name : null;
 
         $old_pledge = Pledge::where('organization_id', $user->organization_id ? $user->organization_id : $organization->id)
                             ->where('emplid', $user->emplid)
                             ->where('campaign_year_id', $request->campaign_year_id)
                             ->first();
         $created_by_id = $old_pledge ? $old_pledge->created_by_id :  Auth::id();                           
-
+        $deptid = $old_pledge ? $old_pledge->deptid : $deptid;              // deptid -- no update when edit  
+        $dept_name = $old_pledge ? $old_pledge->dept_name : $dept_name;     // dept_name -- no update when edit 
 
         $pledge = Pledge::updateOrCreate([
             'organization_id' => $user->organization_id ? $user->organization_id : $organization->id,
@@ -410,6 +413,8 @@ class AnnualCampaignController extends Controller
             'business_unit' => $business_unit,
             'tgb_reg_district' => $tgb_reg_district,
             'city' => $office_city,
+            'deptid' => $deptid,
+            'dept_name' => $dept_name,
 
             'type' => $input['pool_option'],
             'region_id' => $input['pool_option'] == 'P' ? $pool->region_id : null,

--- a/app/Models/BankDepositForm.php
+++ b/app/Models/BankDepositForm.php
@@ -33,6 +33,8 @@ class BankDepositForm extends Model implements Auditable
         'bc_gov_id',
         'pecsf_id',
         'business_unit',
+        'deptid',
+        'dept_name',
         'approved',
         'created_at',
         'update_at',

--- a/app/Models/Pledge.php
+++ b/app/Models/Pledge.php
@@ -26,6 +26,8 @@ class Pledge extends Model implements Auditable
 
         'business_unit',
         'tgb_reg_district',
+        'deptid',
+        'dept_name',
 
         'campaign_year_id',
         'type',

--- a/database/migrations/2023_10_09_202426_add_dept_fields_in_table_pledges.php
+++ b/database/migrations/2023_10_09_202426_add_dept_fields_in_table_pledges.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('pledges', function (Blueprint $table) {
+            //
+            $table->string('deptid')->nullable()->after('tgb_reg_district');
+            $table->string('dept_name')->nullable()->after('deptid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('pledges', function (Blueprint $table) {
+            //
+            $table->dropColumn('deptid');
+            $table->dropColumn('dept_name');
+        });
+    }
+};

--- a/database/migrations/2023_10_09_210528_add_dept_fields_in_table_bank_deposit_forms.php
+++ b/database/migrations/2023_10_09_210528_add_dept_fields_in_table_bank_deposit_forms.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('bank_deposit_forms', function (Blueprint $table) {
+            //
+            $table->string('deptid')->nullable()->after('business_unit');
+            $table->string('dept_name')->nullable()->after('deptid');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('bank_deposit_forms', function (Blueprint $table) {
+            //
+            $table->dropColumn('deptid');
+            $table->dropColumn('dept_name');
+        });
+    }
+};

--- a/database/migrations/2023_10_09_221933_modify_11th_daily_campaign_view.php
+++ b/database/migrations/2023_10_09_221933_modify_11th_daily_campaign_view.php
@@ -1,0 +1,234 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+        DB::statement($this->dropView());
+        DB::statement($this->create_New_View());
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+        DB::statement($this->dropView());
+        DB::statement($this->create_Old_View());
+    }
+
+        /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    private function create_New_View(): string
+    {
+        return <<<SQL
+
+            CREATE VIEW daily_campaign_view AS
+
+            -- Pledge (Gov)
+                (select 'pledges' COLLATE utf8mb4_unicode_ci as type,               
+                pledges.id as tran_id, 
+                case when business_units.linked_bu_code = 'BC022' and pledges.dept_name like 'GCPE%'
+                        then 'BGCPE'
+                        else business_units.linked_bu_code
+                end as business_unit_code, pledges.tgb_reg_district, 
+                pledges.deptid, pledges.dept_name,
+                    1 as donors, pledges.goal_amount as dollars,
+                    (select calendar_year - 1 from campaign_years where pledges.campaign_year_id = campaign_years.id) as campaign_year,
+                    organizations.code as organization_code, pledges.emplid, pledges.pecsf_id,
+                    pledges.created_at
+                from pledges
+                left outer join organizations on pledges.organization_id = organizations.id 
+                left outer join business_units on pledges.business_unit = business_units.code and business_units.deleted_at is null
+                where organizations.code = 'GOV'
+                    and pledges.deleted_at is null)
+            union all   
+            -- Pledge (Non Gov)
+                (select 'pledges' as type, 
+                    pledges.id, 
+                    business_units.linked_bu_code, pledges.tgb_reg_district, 
+                    null,null, 
+                    1 as donors, pledges.goal_amount as dollars,   
+                    (select calendar_year - 1 from campaign_years where pledges.campaign_year_id = campaign_years.id) as campaign_year,
+                    organizations.code, pledges.emplid, pledges.pecsf_id,
+                    pledges.created_at
+                from pledges 
+                left outer join organizations on pledges.organization_id = organizations.id and organizations.deleted_at is null
+                left outer join business_units on organizations.bu_code = business_units.code and business_units.deleted_at is null
+                left outer join cities on pledges.city = cities.city 
+                where 1=1 
+                    and organizations.code <> 'GOV'
+                    and pledges.deleted_at is null)
+            -- eForm (Gov)   
+            union all    
+                (select 'eform' as type, 
+                    bank_deposit_forms.id, 
+                    case when business_units.linked_bu_code = 'BC022' and bank_deposit_forms.dept_name like 'GCPE%'
+                        then 'BGCPE'
+                        else business_units.linked_bu_code
+                    end,
+                (select code from regions where regions.id = bank_deposit_forms.region_id),  
+                bank_deposit_forms.deptid, bank_deposit_forms.dept_name,
+                    case when event_type in ('Fundraiser', 'Gaming') then 0 else 1 end,  bank_deposit_forms.deposit_amount as dollars,   
+                    (select calendar_year - 1 from campaign_years where bank_deposit_forms.campaign_year_id = campaign_years.id) as campaign_year,
+                    bank_deposit_forms.organization_code, bank_deposit_forms.bc_gov_id, bank_deposit_forms.pecsf_id,
+                    bank_deposit_forms.created_at
+                from bank_deposit_forms 
+                left outer join business_units on business_units.id = bank_deposit_forms.business_unit and business_units.deleted_at is null                                                
+                left outer join organizations on bank_deposit_forms.organization_code = organizations.code and organizations.deleted_at is null
+                where organizations.code = 'GOV'
+                    and bank_deposit_forms.organization_code = 'GOV'
+                    and bank_deposit_forms.approved = 1
+                    and bank_deposit_forms.deleted_at is null)
+            -- eForm (non-Gov)   
+            union all    
+                (select 'eform' as type, 
+                    bank_deposit_forms.id, 
+                    business_units.linked_bu_code, 
+                    (select code from regions where regions.id = bank_deposit_forms.region_id),  department_id, null,
+                    case when event_type in ('Fundraiser', 'Gaming') then 0 else 1 end,  bank_deposit_forms.deposit_amount as dollars,   
+                    (select calendar_year - 1 from campaign_years where bank_deposit_forms.campaign_year_id = campaign_years.id) as campaign_year,
+                    organization_code, bank_deposit_forms.bc_gov_id, bank_deposit_forms.pecsf_id,
+                    bank_deposit_forms.created_at
+                from bank_deposit_forms 
+                left outer join organizations on bank_deposit_forms.organization_code = organizations.code and organizations.deleted_at is null
+                left outer join business_units on business_units.code = organizations.bu_code and business_units.deleted_at is null
+                where bank_deposit_forms.organization_code <> 'GOV'
+                    and bank_deposit_forms.approved = 1
+                    and bank_deposit_forms.deleted_at is null)
+
+            SQL;
+
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    private function dropView(): string
+    {
+        return <<<SQL
+
+            DROP VIEW IF EXISTS daily_campaign_view;
+
+            SQL;
+
+    }
+
+
+    private function create_Old_View(): string
+    {
+
+        return <<<SQL
+
+            CREATE VIEW daily_campaign_view AS
+
+            -- Pledge (Gov)
+                (select 'pledges' COLLATE utf8mb4_unicode_ci as type,               
+                pledges.id as tran_id, 
+                case when business_units.linked_bu_code = 'BC022' and employee_jobs.dept_name like 'GCPE%'
+                        then 'BGCPE'
+                        else business_units.linked_bu_code
+                end as business_unit_code, pledges.tgb_reg_district, 
+                employee_jobs.deptid, employee_jobs.dept_name,
+                    1 as donors, pledges.goal_amount as dollars,
+                    (select calendar_year - 1 from campaign_years where pledges.campaign_year_id = campaign_years.id) as campaign_year,
+                    organizations.code as organization_code, pledges.emplid, pledges.pecsf_id,
+                    pledges.created_at
+                from pledges
+                left outer join organizations on pledges.organization_id = organizations.id 
+                left outer join business_units on pledges.business_unit = business_units.code and business_units.deleted_at is null
+                left outer join employee_jobs on organizations.id = employee_jobs.organization_id and pledges.emplid = employee_jobs.emplid
+                where (employee_jobs.empl_rcd = (select min(J2.empl_rcd) from employee_jobs as J2
+                                                where J2.emplid = employee_jobs.emplid) 
+                        or employee_jobs.empl_rcd is null)                    
+                    and organizations.code = 'GOV'
+                    and pledges.deleted_at is null)
+            union all   
+            -- Pledge (Non Gov)
+                (select 'pledges' as type, 
+                    pledges.id, 
+                    business_units.linked_bu_code, pledges.tgb_reg_district, 
+                    null,null, 
+                    1 as donors, pledges.goal_amount as dollars,   
+                    (select calendar_year - 1 from campaign_years where pledges.campaign_year_id = campaign_years.id) as campaign_year,
+                    organizations.code, pledges.emplid, pledges.pecsf_id,
+                    pledges.created_at
+                from pledges 
+                left outer join organizations on pledges.organization_id = organizations.id and organizations.deleted_at is null
+                left outer join business_units on organizations.bu_code = business_units.code and business_units.deleted_at is null
+                left outer join cities on pledges.city = cities.city 
+                where 1=1 
+                    and organizations.code <> 'GOV'
+                    and pledges.deleted_at is null)
+            -- eForm (Gov)   
+            union all    
+                (select 'eform' as type, 
+                    bank_deposit_forms.id, 
+                    case when business_units.linked_bu_code = 'BC022' and employee_jobs.dept_name like 'GCPE%'
+                        then 'BGCPE'
+                        else business_units.linked_bu_code
+                    end,
+                (select code from regions where regions.id = bank_deposit_forms.region_id),  
+                    employee_jobs.deptid, employee_jobs.dept_name,
+                    case when event_type in ('Fundraiser', 'Gaming') then 0 else 1 end,  bank_deposit_forms.deposit_amount as dollars,   
+                    (select calendar_year - 1 from campaign_years where bank_deposit_forms.campaign_year_id = campaign_years.id) as campaign_year,
+                    bank_deposit_forms.organization_code, bank_deposit_forms.bc_gov_id, bank_deposit_forms.pecsf_id,
+                    bank_deposit_forms.created_at
+                from bank_deposit_forms 
+                left outer join business_units on business_units.id = bank_deposit_forms.business_unit and business_units.deleted_at is null                                                
+                -- left outer join eligible_employee_details on bank_deposit_forms.organization_code = eligible_employee_details.organization_code 
+                --                 and bank_deposit_forms.bc_gov_id = eligible_employee_details.emplid
+                -- where as_of_date = (select max(as_of_date) from  eligible_employee_details e1 
+                --                         where 1 = 1 
+                --                         and e1.year = YEAR( CURDATE() ) 
+                --                         and e1.as_of_date <= CURDATE())
+                left outer join organizations on bank_deposit_forms.organization_code = organizations.code and organizations.deleted_at is null
+                left outer join employee_jobs on organizations.id = employee_jobs.organization_id
+                                            and bank_deposit_forms.bc_gov_id = employee_jobs.emplid
+                where (employee_jobs.empl_rcd = (select min(J2.empl_rcd) from employee_jobs as J2
+                                                where J2.emplid = employee_jobs.emplid) 
+                        or employee_jobs.empl_rcd is null)                    
+                    and organizations.code = 'GOV'
+                    and bank_deposit_forms.organization_code = 'GOV'
+                    and bank_deposit_forms.approved = 1
+                    and bank_deposit_forms.deleted_at is null)
+            -- eForm (non-Gov)   
+            union all    
+                (select 'eform' as type, 
+                    bank_deposit_forms.id, 
+                    business_units.linked_bu_code, 
+                    (select code from regions where regions.id = bank_deposit_forms.region_id),  department_id, null,
+                    case when event_type in ('Fundraiser', 'Gaming') then 0 else 1 end,  bank_deposit_forms.deposit_amount as dollars,   
+                    (select calendar_year - 1 from campaign_years where bank_deposit_forms.campaign_year_id = campaign_years.id) as campaign_year,
+                    organization_code, bank_deposit_forms.bc_gov_id, bank_deposit_forms.pecsf_id,
+                    bank_deposit_forms.created_at
+                from bank_deposit_forms 
+                left outer join organizations on bank_deposit_forms.organization_code = organizations.code and organizations.deleted_at is null
+                left outer join business_units on business_units.code = organizations.bu_code and business_units.deleted_at is null
+                where bank_deposit_forms.organization_code <> 'GOV'
+                    and bank_deposit_forms.approved = 1
+                    and bank_deposit_forms.deleted_at is null)
+
+            SQL;
+
+    }
+
+};


### PR DESCRIPTION
Root Cause
The depratment id and name was based on the employee job records for daily campign reporting purpose, and it doesn't kept with the pledge when create.

Solution
In order to solve reporting issue, preserve the EE's department and name when create with the transactions. the data structure changed, 2 new fields added for storing deprtid and name. The SQL statement was developed (atteched with the ticket) for updating back the existing data.

2 tickets related to this fixes:

[jp-0033] Daily Campaign Update report - Employees that move show under correct org, but dept ID description is wrong ([ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/141GZwePI0alr7agMNtLNGUAFcUG?Type=TaskLink&Channel=Link&CreatedTime=638325520128010000))
[jp-0033] Admin Pledges report - Employees that move show under correct org, but dept ID description is wrong ([ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/EPuYDV7a_0C2YT90Rd3A2mUAEVja?Type=TaskLink&Channel=Link&CreatedTime=638325519633130000))