### PR TITLE
[jp-0035] Donation history shows % even if users select $ for distribution

### DIFF
--- a/resources/views/donations/partials/pledge-detail-modal.blade.php
+++ b/resources/views/donations/partials/pledge-detail-modal.blade.php
@@ -70,7 +70,7 @@
                         <p>{{ $pledge_charity->additional  }}</p>
                     </td>
                     <td  style="text-align:right;">{{ number_format($pledge_charity->percentage,2) }}%</td>
-                    <td  style="text-align:right;">${{ number_format($total_amount * $pledge_charity->percentage / 100, 2) }}</td>
+                    <td  style="text-align:right;">${{ number_format($pledge_charity->amount, 2) }}</td>
                 </tr>
             @endforeach
         @endif


### PR DESCRIPTION
Root cause:
 Chat with Nancy and found out that the inconsistent figure show on donation page and the annual campaign pledge entry page. Fixed the program to display inconsistently.   

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/742X46xpBk2b7s2eBZGi8WUAFHXQ?Type=TaskLink&Channel=Link&CreatedTime=638326393288860000)