### PR TITLE
[jp-0036] Duplicate a pledge - match not found

### DIFF
--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -205,13 +205,8 @@ class AnnualCampaignController extends Controller
                     $_ids = $pledge->charities->pluck(['charity_id'])->toArray();
                     $last_selected_charities = $_ids;
 
-                    $_charities = Charity::whereIn('charities.id', $_ids)
-                                    ->leftJoin('pledge_charities', 'charities.id', 'pledge_charities.charity_id')
-                                    ->where('pledge_charities.pledge_id', $pledge->id)
-                                    ->whereNull('pledge_charities.deleted_at')
-                                    ->distinct()
-                                    ->select(['charities.id', 'charity_name as text', 'pledge_charities.additional as program_name'])
-                                    ->get();          
+                    $_charities = Charity::whereIn('id', $_ids )
+                        ->get(['id', 'charity_name as text']);
 
                     foreach ($_charities as $charity) {
                         $pledge_charity = $pledge->charities->where('charity_id', $charity->id)->first();


### PR DESCRIPTION
Root cause:
Disucss with Nancy and found the issue when click on the duplicate pledge button, the root cuase related to the recent change in "[jz-008]CRA charity list option - FSP selection has program pre-filled", the changes for in the "create" section is not workibng for old BI data (campiagn year 2022 or before). 

Solution: rollback this portioin of the change to the original for now. And also there is no need to prefill the program name for the dupliucated pledge.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/5N5SMLck0EW95RLPa-oPt2UAB-nE?Type=TaskLink&Channel=Link&CreatedTime=638326540675220000)
