### PR TITLE
TEST MIGARTION [jp-0033] Daily Campaign Update report - Employees that move show under correct org, but dept ID description is wrong

### DIFF
--- a/resources/views/admin-pledge/campaign/index.blade.php
+++ b/resources/views/admin-pledge/campaign/index.blade.php
@@ -178,6 +178,8 @@
                     <th>PECSF ID</th>
                     <th>Name</th>
                     <th>Business Unit</th>
+                    <th>Dept ID</th>
+                    <th>Dept Name</th>
                     <th>Region</th>
                     <th>Office City</th>
                     <th>FS Pool / Charities</th>
@@ -307,6 +309,8 @@
                     }
                 },
                 {data: 'business_unit', defaultContent: '', className: "dt-nowrap", },
+                {data: 'deptid', defaultContent: '', className: "dt-nowrap", },
+                {data: 'dept_name', defaultContent: '', className: "dt-nowrap", },
                 {data: 'pecsf_user_region.name', defaultContent: '', className: "dt-nowrap", },
                 {data: 'city', defaultContent: '', className: "dt-nowrap",
                     // render: function ( data, type, row, meta ) {

--- a/resources/views/admin-pledge/event/index.blade.php
+++ b/resources/views/admin-pledge/event/index.blade.php
@@ -173,6 +173,8 @@
                         <th>PECSF Identifier</th>
                         <th>Employee Name</th>
                         <th>Business Unit</th>
+                        <th>Dept ID</th>
+                        <th>Dept Name</th>
                         <th>Region</th>
                         <th>Office City</th>
                         <th>Event Type</th>
@@ -286,6 +288,8 @@
                 {data: 'pecsf_id', defaultContent: '' },
                 {data: 'employee_name', defaultContent: '', className: "dt-nowrap" },
                 {data: 'bu.code', defaultContent: '' },
+                {data: 'deptid', defaultContent: '', className: "dt-nowrap" },
+                {data: 'dept_name', defaultContent: '',className: "dt-nowrap" },
                 {data: 'region.name', defaultContent: '' },
                 {data: 'employment_city', defaultContent: '' },
                 {data: 'event_type', defaultContent: '',className: "dt-nowrap" },


### PR DESCRIPTION
Addition Change: add deptid and name column on Admin Annual Campaign and Event Pledges index pages

Root Cause
The depratment id and name was based on the employee job records for daily campign reporting purpose, and it doesn't kept with the pledge when create.

Solution
In order to solve reporting issue, preserve the EE's department and name when create with the transactions. the data structure changed, 2 new fields added for storing deprtid and name. The SQL statement was developed (atteched with the ticket) for updating back the existing data.

2 tickets related to this fixes:

[jp-0033] Daily Campaign Update report - Employees that move show under correct org, but dept ID description is wrong ([ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/141GZwePI0alr7agMNtLNGUAFcUG?Type=TaskLink&Channel=Link&CreatedTime=638325520128010000))
[jp-0033] Admin Pledges report - Employees that move show under correct org, but dept ID description is wrong ([ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/EPuYDV7a_0C2YT90Rd3A2mUAEVja?Type=TaskLink&Channel=Link&CreatedTime=638325519633130000))