### PR TITLE
(TEST MIGRATION) [jp-0033] Daily Campaign Update report - Employees that move show under correct org, but dept ID description is wrong

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -286,7 +286,7 @@ class CampaignPledgeController extends Controller
                 // $tgb_reg_district =  $user->primary_job ? $user->primary_job->tgb_reg_district : null;
                 $city = City::where('city', trim( $request->user_office_city )  )->first();
                 $tgb_reg_district = $city ? $city->TGB_REG_DISTRICT : $user->primary_job->tgb_reg_district;
-                $detpid = $user->primary_job ? $user->primary_job->deptid : null;
+                $deptid = $user->primary_job ? $user->primary_job->deptid : null;
                 $dept_name = $user->primary_job ? $user->primary_job->dept_name : null;
             } else {
                 $org = Organization::where('id', $request->organization_id)->first();


### PR DESCRIPTION
Additional Change (2nd): typo on the variable name caused failure on the new pledge creation under admin section

Root Cause
The depratment id and name was based on the employee job records for daily campign reporting purpose, and it doesn't kept with the pledge when create.

Solution
In order to solve reporting issue, preserve the EE's department and name when create with the transactions. the data structure changed, 2 new fields added for storing deprtid and name. The SQL statement was developed (atteched with the ticket) for updating back the existing data.

2 tickets related to this fixes:

[jp-0033] Daily Campaign Update report - Employees that move show under correct org, but dept ID description is wrong ([ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/141GZwePI0alr7agMNtLNGUAFcUG?Type=TaskLink&Channel=Link&CreatedTime=638325520128010000))
[jp-0033] Admin Pledges report - Employees that move show under correct org, but dept ID description is wrong ([ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/EPuYDV7a_0C2YT90Rd3A2mUAEVja?Type=TaskLink&Channel=Link&CreatedTime=638325519633130000))