### PR TITLE
(MASTER) [jp-0034] Employee name field is pulling outdated information

### DIFF
--- a/app/Console/Commands/SyncUserProfile.php
+++ b/app/Console/Commands/SyncUserProfile.php
@@ -203,6 +203,7 @@ class SyncUserProfile extends Command
                     }
 
                     if ( (strtolower(trim($user->idir)) == strtolower(trim($employee->idir))) &&
+                         (trim($user->name) == ($employee->first_name . ' ' . $employee->last_name)) &&
                          (trim($user->email) == $target_email ) && 
                          ($user->source_type == self::SOURCE_TYPE) &&   
                          ($user->emplid == $employee->emplid) &&
@@ -215,6 +216,7 @@ class SyncUserProfile extends Command
                             $user->emplid = $employee->emplid;
                             $user->email  = $target_email;
                             $user->idir = $employee->idir;
+                            $user->name = $employee->first_name . ' ' . $employee->last_name;
                             $user->last_sync_at = $new_sync_at;
                             $user->acctlock = $acctlock;  
                             $user->save();


### PR DESCRIPTION
Feedback from a user:
Employee changed their name in July. Update is not reflected in the PECSF system.
Impacted user:
Beaumont, Bambi (ID - 132987). Showing as Bambi Spyker.

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/mytasks?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2FtaskListType%2FsmartList%2FSL_AssignedToMe%2Fplan%2FZOb3bFXcakWu8Gl2Zd_PuGUAFIJt%2Ftask%2FppZZdGGmJEuXhs0n18cb3WUAJMG1%22%7D)

Oct 10 - UserProfile Sync process doesn't update the user name when changed in employee job. As of today, there are about 210 EE's name wasn't updated.

select A.emplid, A.name, B.first_name, B.last_name from users A, employee_jobs B
where A.emplid = B.emplid
and source_type = 'HCM'
and A.name <> CONCAT(B.first_name, ' ' ,B.last_name);

for example
ID name in users first & last name in Employee Job
132987      Bambi Spyker      Bambi Beaumont