### PR TITLE
[jp-0030] Alphabetize FSP entries by charity name (3 more pages needs to be changed also)

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -420,6 +420,7 @@ class CampaignPledgeController extends Controller
         $pool_charities= null;
         if ($pledge->type =='P') {
             $pool_charities = FSPool::asOfDate($pledge->created_at)->where('region_id', $pledge->region_id)->first()->charities;
+            $pool_charities = $pool_charities->sortBy('charity.charity_name');            
         }
 
 

--- a/resources/views/admin-pledge/campaign/partials/summary.blade.php
+++ b/resources/views/admin-pledge/campaign/partials/summary.blade.php
@@ -134,7 +134,9 @@
             <tbody>
                 @php $pay_period_sum = 0; $one_time_sum = 0; @endphp
                 @if ($pool_option  == 'P')
-                    @foreach($pool->charities as $pool_charity)
+                    @php $pool_charities = $pool->charities->sortBy('charity.charity_name') 
+                    @endphp        
+                    @foreach($pool_charities as $pool_charity)
                         <tr>
                             <td scope="row">{{ $loop->index +1 }}</td>
                             <td>

--- a/resources/views/donations/partials/pledge-detail-modal.blade.php
+++ b/resources/views/donations/partials/pledge-detail-modal.blade.php
@@ -50,7 +50,9 @@
     </thead>
     <tbody>
         @if ($pledge->type == 'P')
-            @foreach($pledge->fund_supported_pool->charities as $pool_charity)
+            @php $pool_charities = $pledge->fund_supported_pool->charities->sortBy('charity.charity_name') 
+            @endphp        
+            @foreach($pool_charities as $pool_charity)
                 <tr>
                     <td scope="row">{{ $loop->index +1 }}</td>
                     <td>


### PR DESCRIPTION
Additional changes on Oct 12: 

Three more pages also need to be changed for display in alphabetical order 
8. Admin Annual Campaign -- summary page
9. Admin Annual Campaign -- show 
10. Donation Page 

Oct 4 - the following areas are changed for display the charity by charity name (sorting sequence):

1. Pool detail in Annual Campaign
2. Summary Page in Annual Campaign
3. Pool detail in Donate Now
4. Pool detail in eForm
5. Pool detail in eForm (Administration)
6. Pool detail in submission Queue (Administration)
7. Fund Support Pool maintainenance page

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/7BD5TafWSU-i7I6lzklcCWUAFjNl?Type=TaskLink&Channel=Link&CreatedTime=638320512603020000)
