### PR TITLE
(MASTER) [jp-0029] Browser back button when clicked while e-form modal is opened leaves user to the previous page

### DIFF
--- a/resources/views/volunteering/forms.blade.php
+++ b/resources/views/volunteering/forms.blade.php
@@ -91,7 +91,7 @@
                                 <button type="button" id="complete-btn" value="Refresh" class="form-control btn btn-primary" data-dismiss="modal" aria-label="Close">Complete eForm</button>
                             </div>
                             <div class="col-md-2">
-                                <button type="button" id="complete-btn" value="Refresh" class="form-control btn btn-secondary" onclick="window.location='/';">Cancel</button>
+                                <button type="button" id="cancel-btn" value="Refresh" class="form-control btn btn-secondary" onclick="window.location='/';">Cancel</button>
                             </div>
                         </div>
 
@@ -104,7 +104,25 @@
 
     @push('js')
 <script>
+    
+$(function () {
+
+    // treat browser back button like the 'back' button in this wizard page
+    history.pushState(null, null, this.location.href);
+    window.addEventListener('popstate', function(event) {
+        url = this.location.href;
+        if (url.indexOf('bank_deposit_form')) {
+            if ($('.modal').hasClass('show')) {
+                history.pushState(null, null, location.href);
+                $('.modal').modal('hide');
+            } else {
+                $("#cancel-btn").trigger("click");
+            }
+        }
+    });
+
     $("#info-modal").modal();
+});
 
 </script>
         <script src="{{ asset('vendor/select2/js/select2.min.js') }}" ></script>


### PR DESCRIPTION
If user navigates from Home page to Volunteering -> e-form -> FSP -> info icon. Once modal is opened, click the browser back button.
Issue: User is navigated to the Home page
Expected: User must be left of the Volunteering -> eform

Keeping this ticket for future as James will work on it after coming back from vacation

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2Fl_Hubfx3EEq1bcL1jV70TWUALGo_%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)