### PR TITLE
(TEST MIGRATION) [jp-0038] eForm -- doesn't update charity information into database when save

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -310,7 +310,7 @@ class BankDepositFormController extends Controller
 
         $validator->validate();
         $regional_pool_id = ($request->charity_selection == "fsp") ? $request->regional_pool_id : null;
-
+   
         // Get deptid and name from employee primary job if bc_gov_id entered
         $deptid = null;
         $dept_name = null;
@@ -363,29 +363,38 @@ class BankDepositFormController extends Controller
         //var_dump($request->all());
 
         if($request->charity_selection == "dc"){
-            $orgName = count($request->organization_name) -1;
-            $orgCount = $orgName;
-            $count = 0;
+            // $orgName = count($request->organization_name) -1;
+            // $orgCount = $orgName;
+            // $count = 0;
             foreach($request->organization_name as $key => $org){
 
-                if($key <= ($orgCount - $request->org_count)){
-                    continue;
-                }
+                BankDepositFormOrganizations::create([
+                    'bank_deposit_form_id' => $form->id,
+                    'organization_name' => $org,
+                    'vendor_id' =>  $request->vendor_id[$key],
+                    'donation_percent' => $request->donation_percent[$key],
+                    'specific_community_or_initiative' => $request->additional[$key] ?? '', 
+                ]);
 
-                $toSave = [
-                    'organization_name' => $request->organization_name[$key],
-                    'vendor_id' => $request->vendor_id[(count($request->vendor_id) - $request->org_count) + $count],
-                    'donation_percent' => $request->donation_percent[(count($request->donation_percent) - $request->org_count) + $count],
-                    'bank_deposit_form_id' => $form->id
-                ];
+                // if($key <= ($orgCount - $request->org_count)){
+                //     continue;
+                // }
 
-                if(isset($request->additional) && !empty($request->additional)){
-                    $toSave['specific_community_or_initiative'] =  $request->additional[(count($request->additional) - $request->org_count) + $count];
-                }
+                // $toSave = [
+                //     'organization_name' => $request->organization_name[$key],
+                //     'vendor_id' => $request->vendor_id[(count($request->vendor_id) - $request->org_count) + $count],
+                //     'donation_percent' => $request->donation_percent[(count($request->donation_percent) - $request->org_count) + $count],
+                //     'bank_deposit_form_id' => $form->id
+                // ];
 
-                BankDepositFormOrganizations::create();
-                $count++;
-                $orgName--;
+                // if(isset($request->additional) && !empty($request->additional)){
+                //     $toSave['specific_community_or_initiative'] =  $request->additional[(count($request->additional) - $request->org_count) + $count];
+                // }
+
+                // BankDepositFormOrganizations::create();
+                // $count++;
+                // $orgName--;
+
             }
         }
 

--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -23,11 +23,17 @@
             <table class="table">
                 <thead>
                 <tr>
+                    <th>Tran ID</th>
                     <th>Donation Type</th>
-                    <th>Employee Id</th>
-                    <th>Name</th>
+                    {{-- <th>Submitter ID</th> --}}
+                    <th>Form Submitter Name</th>
                     <th>Deposit Amount</th>
+                    <th>Org</th>
+                    <th>PECSF ID</th>
+                    <th>EMPLID</th>
                     <th>Business Unit</th>
+                    <th>Dept ID</th>
+                    <th>Dept Name</th>
                     <th>Status</th>
                     <th></th>
                 </tr>

--- a/resources/views/admin-pledge/submission-queue/partials/result_row.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/result_row.blade.php
@@ -1,9 +1,15 @@
 <tr>
+    <td>{{$submission->bank_deposit_form_id}}</td>
     <td>{{$submission->event_type}}</td>
-    <td>{{$submission->form_submitter_id}}</td>
+    {{-- <td>{{$submission->form_submitter_id}}</td> --}}
     <td>{{$submission->name}}</td>
     <td>{{$submission->deposit_amount}}</td>
     <td>{{$submission->organization_code}}</td>
+    <td>{{$submission->pecsf_id}}</td>
+    <td>{{$submission->bc_gov_id}}</td>
+    <td>{{$submission->business_unit ? $submission->bu->name : ''}}</td>
+    <td>{{$submission->deptid}}</td>
+    <td>{{$submission->dept_name}}</td>
     <td><select class="status status{{$submission->bank_deposit_form_id}}" value="{{$submission->approved}}"  submission_id="{{$submission->bank_deposit_form_id}}"><option value="0" {{$submission->approved == 0 ? "selected" : ""}}>Pending</option><option value="1" {{$submission->approved == 1 ? "selected" : ""}}>Approved</option><option value="2" {{$submission->approved == 2 ? "selected" : ""}}>Locked</option></select></td>
     <td class="edit-event-modal" form-id="{{$submission->bank_deposit_form_id}}"><button role="button" class="btn btn-primary">View Details</button></td>
 </tr>

--- a/resources/views/volunteering/partials/add-event-js.blade.php
+++ b/resources/views/volunteering/partials/add-event-js.blade.php
@@ -324,6 +324,8 @@ var form = document.getElementById("create_pool");
     $(".max-charities-error").hide();
     $(".charity-error-hook").css("border","none")
 
+formData = new FormData();
+
 $("select").each(function(){
 if($(this).val()){
 if($(this).val().length > 0){
@@ -340,12 +342,14 @@ formData.append($(this).attr("name"), $(this).val());
 }
 }
 else if($(this).attr('type') == "file"){
-//formData.append('attachments[]',  $(this)[0].files[0]);
+    if (this.value) {
+         formData.append('attachments[]',  $(this)[0].files[0]);
+    }
 }
 else{
-    if($(this).val().length > 0){
+    // if($(this).val().length > 0){
         formData.append($(this).attr("name"), $(this).val());
-    }
+    // }
 }
 }
 });


### PR DESCRIPTION
Oct 13 - During the investigation on the ticket "View details in Event submission queue displays incorrect Charity selections and distribution", the current program was unable to save the user selected charity into the database. This is a high priority issue.

Root cause:

Incomplete code found in controller
bug in the form submission when re-submit again after validation
Affected areas
a. eForm submission (self service) - create
b. Admin Event Pledge -- create
c. Additional Columns added onto the submission queue listing page for easy identify the transaction including tran ID, emplid, pecsf ID, business unit, deptid and name etc.

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FxLhgb2hcV0uDH2-USkta4WUAObvM%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)