### PR TITLE
[jp-0039] Change the text from Amount to Percentage on Summary Page

### DIFF
--- a/resources/views/annual-campaign/partials/summary-distribution.blade.php
+++ b/resources/views/annual-campaign/partials/summary-distribution.blade.php
@@ -38,7 +38,7 @@
                     <th style="width:18%;">Donation Type</th>
                     <th style="width:62%;">Benefitting Charity</th>
                     <th style="width:10%;">Frequency</th>
-                    <th style="width:10%;text-align:right;">Amount</th>
+                    <th style="width:10%;text-align:right;" class="percentage-amount-head-title">Percentage</th>
                 </tr>
                 @foreach ($charities as $charity)
                 <tr>
@@ -55,14 +55,14 @@
                     <td style="width:130px" class="by-percent ">
                         <div class="input-group input-group-sm mb-3" style="flex-direction:column">
                             <input type="hidden" class="form-control form-control-sm percent-input float-right text-right" name="{{$keyCase}}Percent[{{ $charity['id'] }}]" value='{{$charity["$key_-percentage-distribution"]}}' disabled>
-                            <label class="float-right text-right">{{ number_format($charity["$key_-percentage-distribution"],2) }}%</label>
+                            <span class="float-right text-right">{{ number_format($charity["$key_-percentage-distribution"],2) }}%</span>
                         </div>
                     </td>
                     @endif
                     <td style="width:130px" class="by-amount d-none">
                         <div class="input-group input-group-sm mb-3" style="flex-direction:column">
                             <input type="hidden" class="form-control form-control-sm amount-input float-right text-right"  name="{{$keyCase}}Amount[{{ $charity['id'] }}]" value='{{$charity["$key_-amount-distribution"]}}' disabled>
-                            <label class="float-right text-right"> ${{ number_format( $charity["$key_-amount-distribution"] * $multiplier,2) }}</label>
+                            <span class="float-right text-right"> ${{ number_format( $charity["$key_-amount-distribution"] * $multiplier,2) }}</span>
                         </div>
                     </td>
                 </tr>

--- a/resources/views/annual-campaign/partials/summary.blade.php
+++ b/resources/views/annual-campaign/partials/summary.blade.php
@@ -109,10 +109,12 @@ $(function () {
             $("body").find("#step-summary-area .by-amount").removeClass("d-none");
             $("body").find("#step-summary-area .by-percent").addClass("d-none");
             $("body").find("#step-summary-area .percent-amount-text").html("Distribute by Percentage");
+            $('.percentage-amount-head-title').html('Amount');
         } else {
             $("body").find("#step-summary-area .by-percent").removeClass("d-none");
             $("body").find("#step-summary-area .by-amount").addClass("d-none");
             $("body").find("#step-summary-area .percent-amount-text").html("Distribute by Dollar Amount");
+            $('.percentage-amount-head-title').html('Percentage');
         }
         $("#step-summary-area .percent-input").change();
         $("#step-summary-area .amount-input").change();


### PR DESCRIPTION
Req1 - In the donation summary page, when the option Percentage is selected, the column title must be changed from "Amount" to "Percentage". 
Req2 - Can we make the data in column Percentage/Amount to not bold, since the text in other columns are not bold.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/X2MZDq39aEupPaQ3DWogRWUAP6YM?Type=TaskLink&Channel=Link&CreatedTime=638328289702680000)