### PR TITLE
(TEST Migration) [jp-0030] Alphabetize FSP entries by charity name (1 more page needs …

### DIFF
--- a/resources/views/donations/partials/event-detail-modal.blade.php
+++ b/resources/views/donations/partials/event-detail-modal.blade.php
@@ -74,7 +74,9 @@
     </thead>
     <tbody>
         @if ($pledge->regional_pool_id)
-            @foreach($pledge->fund_supported_pool->charities as $pool_charity)
+            @php $pool_charities = $pledge->fund_supported_pool->charities->sortBy('charity.charity_name') 
+            @endphp  
+            @foreach($pool_charities as $pool_charity)
                 <tr>
                     <td scope="row">{{ $loop->index +1 }}</td>
                     <td>


### PR DESCRIPTION
Oct 4 - the following areas are changed for display the charity by charity name (sorting sequence):

Pool detail in Annual Campaign
Summary Page in Annual Campaign
Pool detail in Donate Now
Pool detail in eForm
Pool detail in eForm (Administration)
Pool detail in submission Queue (Administration)
Fund Support Pool maintenance page
Donation Page (changes on Oct 12 also)
Oct 11 - Test validated. Assigning the ticket back to James to add the change to the following places as well.
1)Admin->Create a campaign pledge (Summary page)
2)Admin->View campaign pledge

Oct 12: Three more pages are changed for display in alphabetical order (ready for re-test)
8. Admin Annual Campaign -- summary page
9. Admin Annual Campaign -- show
10. Donation Page

Oct 13 - Steffi validated. The following places still needs to be fixed:
Approved E-form when displayed in the donation history -> View details does not show sorted charities (Submitted. cheque to Capital)
Oct 13 - JP updated the donation history page to show the FS Pool charities in alphetical order

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/7BD5TafWSU-i7I6lzklcCWUAFjNl?Type=TaskLink&Channel=Link&CreatedTime=638328324604880000)