### PR TITLE
[TEST MIGRATE][jz-009]Admin -> Event Submission Queue issues

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -298,11 +298,11 @@ class BankDepositFormController extends Controller
                     }
                 }
                 if(!$fileFound){
-                    $validator->errors()->add('attachment','Atleast one attachment is required.');
+                    $validator->errors()->add('attachment','At least one attachment is required.');
                 }
             }
             else{
-                $validator->errors()->add('attachment','Atleast one attachment is required.');
+                $validator->errors()->add('attachment','At least one attachment is required.');
             }
 
             if($request->pecsf_id){
@@ -511,7 +511,7 @@ class BankDepositFormController extends Controller
                     for($i=(count(request("donation_percent")) -1);$i >= (count(request("donation_percent")) - $request->org_count);$i--){
                         if(empty(request("organization_name")[$i]))
                         {
-                            $validator->errors()->add('organization_name.'.$i,'The Organization name is required.');
+                            $validator->errors()->add('organization_name.'.$i+1,'The Organization name is required.');
                         }
                         if(empty(request('vendor_id')[$i])){
 
@@ -519,11 +519,11 @@ class BankDepositFormController extends Controller
                         };
                         if(empty(request('donation_percent')[$i])){
 
-                            $validator->errors()->add('donation_percent.'.$i,'The Donation Percent is required.');
+                            $validator->errors()->add('donation_percent.'.$i+1,'The Donation Percent is required.');
                         }
                         else if(!is_numeric(request('donation_percent')[$i])){
 
-                            $validator->errors()->add('donation_percent.'.$i,'The Donation Percent must be a number.');
+                            $validator->errors()->add('donation_percent.'.$i+1,'The Donation Percent must be a number.');
                         }
                         else{
                             $a[] = $i;
@@ -607,6 +607,28 @@ class BankDepositFormController extends Controller
                     $validator->errors()->add('pecsf_id','The PECSF ID has already been used for another Donation.');
                 }
             }
+
+
+            if(!empty(request("attachments"))){
+                $fileFound = false;
+                foreach(array_reverse(request('attachments')) as $key => $attachment){
+                    if(in_array($attachment->getClientOriginalName(),explode(",",$request->ignoreFiles)) || empty($attachment) || $attachment == "undefined"){
+                    }
+                    else{
+                        $fileFound = true;
+                        break;
+                    }
+                }
+                if(!$fileFound){
+                    $validator->errors()->add('attachment','At least one attachment is required.');
+                }
+            }
+            else{
+                $validator->errors()->add('attachment','At least one attachment is required.');
+            }
+
+
+
         });
         $validator->validate();
         $regional_pool_id = ($request->charity_selection == "fsp") ? $request->regional_pool_id : null;
@@ -655,6 +677,31 @@ class BankDepositFormController extends Controller
                 $orgName--;
             }
         }
+
+
+        $upload_images = $request->file('attachments') ? $request->file('attachments') : [];
+
+        foreach($upload_images as $key => $file){
+
+            if(is_array($request->ignoreFiles)){
+                if(in_array($file->getClientOriginalName(),$request->ignoreFiles))
+                {
+                    continue;
+                }
+            }
+
+
+                $filename=date('YmdHis').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
+
+                $filePath = $file->storeAs(  "/uploads/bank_deposit_form_attachments" , $filename);
+                BankDepositFormAttachments::create([
+                'local_path' => storage_path( $this->doc_folder )."/".$filename,
+                'bank_deposit_form_id' => $request->form_id
+            ]);
+        }
+
+
+
         echo json_encode(["/admin-pledge/submission-queue"]);
     }
 
@@ -773,5 +820,31 @@ class BankDepositFormController extends Controller
             ];
             // return Storage::download($path);
             return Storage::disk('uploads')->download("/bank_deposit_form_attachments/".$fileName, $fileName, $headers);
+        }
+
+
+        public function delete(Request $request, $form_id, $fileName) {
+            // The $form_id and $fileName are route parameters
+        
+            $path = "/bank_deposit_form_attachments/" . $fileName;
+            
+            // Check if the file exists before attempting to delete it
+            if (Storage::disk('uploads')->exists($path)) {
+                // Delete the file
+                error_log(storage_path($this->doc_folder) . "/" . $fileName);
+                Storage::disk('uploads')->delete($path);
+                
+                // Use $form_id to delete records from the database
+                BankDepositFormAttachments::where([
+                    'local_path' => storage_path($this->doc_folder) . "/" . $fileName,
+                    'bank_deposit_form_id' => $form_id
+                ])->delete();
+        
+                $msg = "Attachment '$fileName' has been deleted.";
+            } else {
+                $msg = "Attachment '$fileName' does not exist or has already been deleted.";
+            }
+            
+            return response()->json(['msg' => $msg]);
         }
 }

--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -173,11 +173,14 @@
             $("#edit-event-modal").find("select").attr("disabled",false);
             $("#edit-event-modal").find("input").attr("disabled",false);
             $("#edit-event-modal").find("button").attr("disabled",false);
+            $("#edit-event-modal").find(".specific_community_or_initiative").attr("disabled",true);
+            $(".upload-area").show();
         });
 
         $(document).on("click", ".edit-event-modal" , function(e) {
             e.preventDefault();
             var row_number = 0;
+            var form_id = $(this).attr("form-id");
             $("#form_id").val($(this).attr("form-id"));
             $("#bank_deposit_form").attr("action","/bank_deposit_form/update")
             $("#sub_type").attr("disabled",false);
@@ -258,6 +261,8 @@
                         $(".form-pool").hide();
                         $("input[value='dc']").attr("checked","checked");
 
+                        $('#noselectedresults').hide();
+
 
                         for(i=0;i<data[0].charities.length;i++){
                             text = $("#organization-tmpl").html();
@@ -287,7 +292,9 @@
                         $('#attachments').append( text );
                         attachment_number++;
                      $('.attachment').last().find(".filename").html("Attachment #"+(i + 1)+" "+data[0].attachments[i].local_path.substring(data[0].attachments[i].local_path.lastIndexOf("/"))+" ");
-                        $('.attachment').last().find(".view_attachment").attr("href","/bank_deposit_form/download"+data[0].attachments[i].local_path.substring(data[0].attachments[i].local_path.lastIndexOf("/")));
+                     $('.attachment').last().find(".view_attachment").attr("href","/bank_deposit_form/download"+data[0].attachments[i].local_path.substring(data[0].attachments[i].local_path.lastIndexOf("/")));
+                     //$('.attachment').last().find(".delete_attachment").attr("href","/bank_deposit_form/"+form_id+"/delete"+data[0].attachments[i].local_path.substring(data[0].attachments[i].local_path.lastIndexOf("/")));
+                     //$('.attachment').last().find(".delete_attachment").attr("href","javascript:deleteAttachment("+form_id+", '"+data[0].attachments[i].local_path.substring(data[0].attachments[i].local_path.lastIndexOf("/"))+"');");
                     }
                     $("#edit-event-modal").find("select").attr("disabled",true);
                     $("#edit-event-modal").find("input").attr("disabled",true);
@@ -320,6 +327,26 @@
         });
 
         $("select").select2();
+
+        function deleteAttachment(formid, filename){
+
+            // Construct the URL with parameters
+            var deleteUrl = '/bank_deposit_form/' + formid + '/delete' + filename;
+
+            // Send an AJAX request to delete the attachment
+            $.ajax({
+                type: 'GET', // GET method
+                url: deleteUrl, // The URL with parameters
+                success: function(data) {
+                    // Handle the response, e.g., display a success message
+                    $('a[attr-id="' + attrIdValue + '"]').hide();
+                },
+                error: function(xhr, status, error) {
+                    alert("An error occurred: " + error);
+                }
+            });
+        
+        }
 
         $(".status").change(function(e){
             e.preventDefault();
@@ -418,6 +445,13 @@
         $(".closeModalBtn").click(function() {
                 $("#regionalPoolModal").modal("hide"); 
             });
+
+
+            $(document).ready(function() {
+                $('#edit-event-modal').on('hidden.bs.modal', function() {
+                    location.reload();
+                });
+            });  
 
     </script>
     @include('admin-pledge.submission-queue.partials.add-event-js')

--- a/resources/views/admin-pledge/submission-queue/partials/form.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/form.blade.php
@@ -377,13 +377,13 @@
 
             <div class="form-row form-body">
 
-                <div class="col-md-12"> <span style="display:block;padding:10px;">Drag and Drop or Browse to attach your completed PECSF Event Bank Deposit Form attachment (pdf,xls,xlsx,csv,png,jpg,jpeg) with bank receipt.</span>
+                <div class="col-md-12 upload-area"> <span style="padding:10px;">Drag and Drop or Browse to attach your completed PECSF Event Bank Deposit Form attachment (pdf,xls,xlsx,csv,png,jpg,jpeg) with bank receipt.</span>
                     </div>
 
 
                 <div style="padding:8px;" class="upload-area form-group col-md-3">
 
-
+                    
                     <i style="color:#1a5a96;" class="fas fa-file-upload fa-5x"></i>
                     <br>
                     <br>
@@ -394,6 +394,7 @@
 
                 </table>
             </div>
+
 
     </div>
 
@@ -420,3 +421,10 @@
 
 </form>
 
+<script>
+    var poolsNotEmpty = <?php echo !empty($pools) ? 'true' : 'false'; ?>;
+    var radioElement = document.getElementById("charity_selection_1");
+    if (poolsNotEmpty) {
+        radioElement.checked = true;
+    }
+</script>

--- a/resources/views/donate/partials/choose-charity.blade.php
+++ b/resources/views/donate/partials/choose-charity.blade.php
@@ -51,15 +51,8 @@
     <div class="error max-charities-error" style="display:none;color:#D8292F;"><i style="color:black;" class="fas fa-exclamation-circle"></i> Please select a maximum of 10 charities</div>
 
         <table class="" id="organizations" style="display:block;width:100%">
-           @if(count($selected_charities) > 0)
-            @foreach($selected_charities as $index => $charity)
-                @include('volunteering.partials.add-organization', ['index' => $index,'charity' => $charity] )
-
-            @endforeach
-            @else
                 <h3 style="width:100%;text-align:center" id="noselectedresults" class="align-content-center">You have not chosen any charities</h3>
                 <span class="charity_errors errors"></span>
-            @endif
         </table>
 </div>
 <div class="modal fade" id="charityDetails" tabindex="-1" role="dialog" aria-labelledby="charityDetailsModalTitle" aria-hidden="true">

--- a/resources/views/volunteering/partials/add-attachment.blade.php
+++ b/resources/views/volunteering/partials/add-attachment.blade.php
@@ -1,6 +1,6 @@
 <tr class="attachment" id="attachment{{$index}}">
     <td><span class="filename"></span></td>
-    <td><u><a target="_blank" class="p-2 text-primary view_attachment">Download</a></u></td>
+    <td><u><a target="_blank" class="p-2 text-primary view_attachment">Download</a></u> {{---- | <u><a attr-index="attachment{{$index}}" class="p-2 text-primary delete_attachment">Delete</a></u> ---}} </td>
     <td>
         <span class="attachment_errors errors">
             @error('attachment.'.$index)

--- a/resources/views/volunteering/partials/add-organization.blade.php
+++ b/resources/views/volunteering/partials/add-organization.blade.php
@@ -43,7 +43,7 @@
                 <input class="form-control" type="text" id="donation_percent" name="donation_percent[]">
                 <span class="donation_percent_errors  errors">
                        @error('donation_percent.'.$index)
-                        <span class="invalid-feedback">{{  $message  }}</span>
+                        <span class="invalid-feedback">{{  $message  }} </span>
                     @enderror
                   </span>
             </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -188,6 +188,7 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/bank_deposit_form/bc_gov_id',[BankDepositFormController::class, 'bc_gov_id'])->name('bc_gov_id');
     Route::get('/bank_deposit_form/business_unit',[BankDepositFormController::class, 'business_unit'])->name('business_unit');
     Route::get('/bank_deposit_form/download/{fileName}',[BankDepositFormController::class, 'download'])->name('download');
+    Route::get('/bank_deposit_form/{form_id}/delete/{fileName}',[BankDepositFormController::class, 'delete'])->name('delete');
     Route::post('/bank_deposit_form', [BankDepositFormController::class, 'store'])->name('bank_deposit_form');
     Route::post('/bank_deposit_form/update', [BankDepositFormController::class, 'update'])->name('bank_deposit_form.update');
     Route::post('/volunteering/supply_order_form', [VolunteeringController::class,'supply_order_form'])->name('supply_order_form');


### PR DESCRIPTION
fix for the following detected issues:

The submit button does not function on edit: For any type of event pledge, if admin clicks on edit, and tries saving the form by the Submit button without even changing anything on the form. Hence this results in not saving any charities.
The donation percent is required error is not displayed accurately.
For any FSP CRA charities, can we keep the Specific Community Or Initiative (Optional): field always disabled?
Added a Fundraiser pledge to Metro Vancouver FSP -> Click on Edit Pledge -> Change the FSP from Metro Vancouver to Cariboo -> Click on Submit button An error is displayed on the Submit button
Can we remove the text ‘You have not chosen any charities’ when viewing the pledge
The file section in edit pledge does not let user add/remove/drag and drop/ or select a file. Can we replicate the same section just like the one we have in the create pledge (Confirmed with Steffi and Nancy, we will not take delete feature for current phrase)