### PR TITLE
(MASTER) [jp-0030] Alphabetize FSP entries by charity name (1 more page needs

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -420,6 +420,7 @@ class CampaignPledgeController extends Controller
         $pool_charities= null;
         if ($pledge->type =='P') {
             $pool_charities = FSPool::asOfDate($pledge->created_at)->where('region_id', $pledge->region_id)->first()->charities;
+            $pool_charities = $pool_charities->sortBy('charity.charity_name');            
         }
 
 

--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -780,6 +780,7 @@ class AnnualCampaignController extends Controller
             $pool_id = $request->regional_pool_id;
             $pool = FSPool::where('id', $pool_id)->first();
             $pool_charities = $pool ? $pool->charities : [];
+            $pool_charities = $pool_charities->sortBy('charity.charity_name');
 
             $frequency = $request->frequency;
 
@@ -1001,7 +1002,7 @@ class AnnualCampaignController extends Controller
         if ($request->ajax()) {
             $pool = FSPool::where('id', $id)->first();
             $charities = $pool ? $pool->charities : [];
-
+            $charities = $charities->sortBy('charity.charity_name');
             return view('annual-campaign.partials.pool-detail', compact('charities') )->render();
         } else {
             return redirect('/');

--- a/app/Http/Controllers/DonateNowController.php
+++ b/app/Http/Controllers/DonateNowController.php
@@ -440,6 +440,7 @@ class DonateNowController extends Controller
         if ($request->ajax()) {
             $pool = FSPool::where('id', $id)->first();
             $charities = $pool ? $pool->charities : [];
+            $charities = $charities->sortBy('charity.charity_name');
             return view('donate-now.partials.pool-detail', compact('charities') )->render();
         } else {
             return redirect('/');

--- a/resources/views/admin-campaign/fund-supported-pools/edit.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/edit.blade.php
@@ -86,10 +86,10 @@
                             </tr>
                         </thead> --}}
                         <tbody id="accordion">
-                            @foreach (old('charities', $pool->charities->pluck('charity_id') ) as $index => $oldCharity)
+                            @foreach (old('charities', $charities->pluck('charity_id') ) as $index => $oldCharity)
                             <tr id="charity{{ $index }}">
                                 @if (count($errors) == 0)
-                                    @php ( $pool_charity = $pool->charities[$index] )                                    
+                                    @php ( $pool_charity = $charities[$index] )                                    
                                 @else
                                     @php ( $pool_charity = new \App\Models\FSPoolCharity )                                    
                                 @endif
@@ -111,7 +111,7 @@
                             --}}
                             </tr>
                             @endforeach
-                            <tr id="charity{{ count(old('charities', $pool->charities->pluck('charity_id') )) }}"></tr>
+                            <tr id="charity{{ count(old('charities', $charities->pluck('charity_id') )) }}"></tr>
                         </tbody>
                     </table>
 

--- a/resources/views/admin-campaign/fund-supported-pools/partials/edit-pool-charity.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/partials/edit-pool-charity.blade.php
@@ -158,7 +158,8 @@
                         <input type="file" class="form-control-file @error('images.'.$index) is-invalid @enderror" 
                                 onchange="loadFile(event)" name="images[]" value="{{ old('images.'.$index) }}"> --}}
                         @error( 'images.'.$index )
-                            <span class="invalid-feedback">{{ $message }}</span>
+                            <span class="invalid-feedback"></span>
+                            <h6 class="text-danger">{{ $message }}</h6>
                         @enderror
                     </div>
                 </div>

--- a/resources/views/admin-campaign/fund-supported-pools/show.blade.php
+++ b/resources/views/admin-campaign/fund-supported-pools/show.blade.php
@@ -69,9 +69,10 @@
                             </tr>
                         </thead> --}}
                         <tbody id="accordion">
-                            @foreach ( $pool->charities->pluck('charity_id') as $index => $oldCharity)
+                            @foreach ( $charities->pluck('charity_id') as $index => $oldCharity)
+
                             <tr id="charity{{ $index }}">
-                                @php ( $pool_charity = $pool->charities[$index] )                                    
+                                @php ( $pool_charity = $charities[$index] )                                    
                                 @include('admin-campaign.fund-supported-pools.partials.show-pool-charity', ['index'=> $index, 'charity' => $oldCharity, 'pool_charity' => $pool_charity ])
                             {{-- <tr>
                                 <td>
@@ -90,7 +91,7 @@
                             --}}
                             </tr>
                             @endforeach
-                            <tr id="charity{{ count(old('charities', $pool->charities->pluck('charity_id') )) }}"></tr>
+                            <tr id="charity{{ count(old('charities', $charities->pluck('charity_id') )) }}"></tr>
                         </tbody>
                     </table>
 

--- a/resources/views/admin-pledge/campaign/partials/summary.blade.php
+++ b/resources/views/admin-pledge/campaign/partials/summary.blade.php
@@ -134,7 +134,9 @@
             <tbody>
                 @php $pay_period_sum = 0; $one_time_sum = 0; @endphp
                 @if ($pool_option  == 'P')
-                    @foreach($pool->charities as $pool_charity)
+                    @php $pool_charities = $pool->charities->sortBy('charity.charity_name') 
+                    @endphp        
+                    @foreach($pool_charities as $pool_charity)
                         <tr>
                             <td scope="row">{{ $loop->index +1 }}</td>
                             <td>

--- a/resources/views/donations/partials/event-detail-modal.blade.php
+++ b/resources/views/donations/partials/event-detail-modal.blade.php
@@ -74,7 +74,9 @@
     </thead>
     <tbody>
         @if ($pledge->regional_pool_id)
-            @foreach($pledge->fund_supported_pool->charities as $pool_charity)
+            @php $pool_charities = $pledge->fund_supported_pool->charities->sortBy('charity.charity_name') 
+            @endphp  
+            @foreach($pool_charities as $pool_charity)
                 <tr>
                     <td scope="row">{{ $loop->index +1 }}</td>
                     <td>

--- a/resources/views/donations/partials/pledge-detail-modal.blade.php
+++ b/resources/views/donations/partials/pledge-detail-modal.blade.php
@@ -50,7 +50,9 @@
     </thead>
     <tbody>
         @if ($pledge->type == 'P')
-            @foreach($pledge->fund_supported_pool->charities as $pool_charity)
+            @php $pool_charities = $pledge->fund_supported_pool->charities->sortBy('charity.charity_name') 
+            @endphp        
+            @foreach($pool_charities as $pool_charity)
                 <tr>
                     <td scope="row">{{ $loop->index +1 }}</td>
                     <td>


### PR DESCRIPTION
Oct 4 - the following areas are changed for display the charity by charity name (sorting sequence):

Pool detail in Annual Campaign
Summary Page in Annual Campaign
Pool detail in Donate Now
Pool detail in eForm
Pool detail in eForm (Administration)
Pool detail in submission Queue (Administration)
Fund Support Pool maintenance page
Donation Page (changes on Oct 12 also)
Oct 11 - Test validated. Assigning the ticket back to James to add the change to the following places as well.
1)Admin->Create a campaign pledge (Summary page)
2)Admin->View campaign pledge

Oct 12: Three more pages are changed for display in alphabetical order (ready for re-test)
8. Admin Annual Campaign -- summary page
9. Admin Annual Campaign -- show
10. Donation Page

Oct 13 - Steffi validated. The following places still needs to be fixed:
Approved E-form when displayed in the donation history -> View details does not show sorted charities (Submitted. cheque to Capital)
Oct 13 - JP updated the donation history page to show the FS Pool charities in alphetical order

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/7BD5TafWSU-i7I6lzklcCWUAFjNl?Type=TaskLink&Channel=Link&CreatedTime=638328324604880000)