### PR TITLE
(MASTER) [jp-0037] Maintain ee table - minutes are wrong for created and updated at

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -128,10 +128,10 @@ class CampaignPledgeController extends Controller
 
                 })
                 ->editColumn('created_at', function ($user) {
-                    return $user->created_at->format('Y-m-d H:m:s'); // human readable format
+                    return $user->created_at->format('Y-m-d H:i:s'); // human readable format
                 })
                 ->editColumn('updated_at', function ($user) {
-                    return $user->updated_at->format('Y-m-d H:m:s'); // human readable format
+                    return $user->updated_at->format('Y-m-d H:i:s'); // human readable format
                 })
                 ->rawColumns(['action','description'])
                 ->make(true);

--- a/app/Http/Controllers/Admin/DonateNowPledgeController.php
+++ b/app/Http/Controllers/Admin/DonateNowPledgeController.php
@@ -141,10 +141,10 @@ class DonateNowPledgeController extends Controller
 
                 })
                 ->editColumn('created_at', function ($user) {
-                    return $user->created_at->format('Y-m-d H:m:s'); // human readable format
+                    return $user->created_at->format('Y-m-d H:i:s'); // human readable format
                 })
                 ->editColumn('updated_at', function ($user) {
-                    return $user->updated_at->format('Y-m-d H:m:s'); // human readable format
+                    return $user->updated_at->format('Y-m-d H:i:s'); // human readable format
                 })                        
                 ->rawColumns(['action','description'])
                 ->make(true);

--- a/app/Http/Controllers/Admin/DonationDataController.php
+++ b/app/Http/Controllers/Admin/DonationDataController.php
@@ -71,10 +71,10 @@ class DonationDataController extends Controller
 
             return Datatables::of($donations)
                 ->editColumn('created_at', function ($donation) {
-                    return $donation->process_history->created_at->format('Y-m-d H:m:s'); // human readable format
+                    return $donation->process_history->created_at->format('Y-m-d H:i:s'); // human readable format
                 })
                 ->editColumn('updated_at', function ($donation) {
-                    return $donation->process_history->updated_at->format('Y-m-d H:m:s'); // human readable format
+                    return $donation->process_history->updated_at->format('Y-m-d H:i:s'); // human readable format
                 })                        
                 // ->rawColumns(['action','description'])
                 ->make(true);

--- a/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
@@ -132,10 +132,10 @@ class SpecialCampaignPledgeController extends Controller
 
                 })
                 ->editColumn('created_at', function ($user) {
-                    return $user->created_at->format('Y-m-d H:m:s'); // human readable format
+                    return $user->created_at->format('Y-m-d H:i:s'); // human readable format
                 })
                 ->editColumn('updated_at', function ($user) {
-                    return $user->updated_at->format('Y-m-d H:m:s'); // human readable format
+                    return $user->updated_at->format('Y-m-d H:i:s'); // human readable format
                 })                        
                 ->rawColumns(['action','description'])
                 ->make(true);

--- a/app/Http/Controllers/System/UserMaintenanceController.php
+++ b/app/Http/Controllers/System/UserMaintenanceController.php
@@ -118,10 +118,10 @@ class UserMaintenanceController extends Controller
                         //     return $user->deleted_at ? $user->updated_by->name : '';       
                         // })
                         ->editColumn('created_at', function ($user) {
-                            return $user->created_at ? $user->created_at->format('Y-m-d H:m:s') : null; // human readable format
+                            return $user->created_at ? $user->created_at->format('Y-m-d H:i:s') : null; // human readable format
                         })
                         ->editColumn('updated_at', function ($user) {
-                            return $user->updated_at ? $user->updated_at->format('Y-m-d H:m:s') : null; // human readable format
+                            return $user->updated_at ? $user->updated_at->format('Y-m-d H:i:s') : null; // human readable format
                         })
                         ->rawColumns(['action'])
                         ->make(true);


### PR DESCRIPTION
Oct 12 - Investigation and findings:
Root Cause: typo on the datetime format characters. It should be format('Y-m-d H:i:s') instead of format('Y-m-d HⓂ️s'). The following areas are updated:
a. Admin -- Annual Campaign Pledge (index page)
b. Admin -- Donation Now Pledge (index page)
c. Admin -- Special Campaign Pledge (index page)
d: System -- User Maintenance (index page)
e. Reportng -- Review Donation Data (index page)

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/2_nCQXel20uVbFL3RLJScmUAOAWc?Type=TaskLink&Channel=Link&CreatedTime=638327399329180000)