### PR TITLE
[jp-0044] Stop scheduling both import Gov and Non-gov pledge history from BI process

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -82,11 +82,13 @@ class Kernel extends ConsoleKernel
 
                 $schedule->command('command:ImportCities')
                         //  ->yearlyOn(9, 1, '02:30')
-                        ->dailyAt('2:30')
+                        ->weekdays()
+                        ->at('2:30')
                         ->sendOutputTo(storage_path('logs/ImportCities.log')); 
 
                 $schedule->command('command:ImportDepartments')
-                        ->dailyAt('2:35')
+                        ->weekdays()
+                        ->at('2:35')
                         ->sendOutputTo(storage_path('logs/ImportDepartments.log'));
 
                 // For testing purpose: to generate 2022 pledges based on the BI pledge history

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -72,13 +72,13 @@ class Kernel extends ConsoleKernel
                         
 
                 // Pledge History Data (refresh the current year +2 when Jan-Mar OR +1 when Apr - Dec
-                $schedule->command('command:ImportNonGovPledgeHistory')
-                        ->dailyAt('2:05')
-                        ->sendOutputTo(storage_path('logs/ImportNonPledgeHistory.log'));
+                // $schedule->command('command:ImportNonGovPledgeHistory')
+                //         ->dailyAt('2:05')
+                //         ->sendOutputTo(storage_path('logs/ImportNonPledgeHistory.log'));
 
-                $schedule->command('command:ImportPledgeHistory')
-                        ->dailyAt('2:15')
-                        ->sendOutputTo(storage_path('logs/ImportPledgeHistory.log'));    
+                // $schedule->command('command:ImportPledgeHistory')
+                //         ->dailyAt('2:15')
+                //         ->sendOutputTo(storage_path('logs/ImportPledgeHistory.log'));    
 
                 $schedule->command('command:ImportCities')
                         //  ->yearlyOn(9, 1, '02:30')
@@ -104,25 +104,25 @@ class Kernel extends ConsoleKernel
                         ->at('4:15')
                         ->sendOutputTo(storage_path('logs/SyncUserProfile.log'));
 
-                // Snapshot of eligible employees 
-                $schedule->command('command:UpdateEligibleEmployeeSnapshot')
-                        ->dailyAt('4:30')
-                        ->appendOutputTo(storage_path('logs/UpdateEligibleEmployeeSnapshot.log'));
-
-                $schedule->command('command:UpdateDailyCampaign')
-                        ->dailyAt('4:45')
-                        ->appendOutputTo(storage_path('logs/UpdateDailyCampaign.log'));
-                
-                $schedule->command('command:SystemCleanUp')
-                        ->dailyAt('5:30')
-                        ->appendOutputTo(storage_path('logs/SystemCleanUp.log'));
-
-                // Daily Testing 
-                $schedule->command('notify:daily')
-                        ->dailyAt('08:30')
-                        ->appendOutputTo(storage_path('logs/daily.log'));
-
         }
+
+        // Snapshot of eligible employees 
+        $schedule->command('command:UpdateEligibleEmployeeSnapshot')
+                ->dailyAt('4:30')
+                ->appendOutputTo(storage_path('logs/UpdateEligibleEmployeeSnapshot.log'));
+
+        $schedule->command('command:UpdateDailyCampaign')
+                ->dailyAt('4:45')
+                ->appendOutputTo(storage_path('logs/UpdateDailyCampaign.log'));
+        
+        $schedule->command('command:SystemCleanUp')
+                ->dailyAt('5:30')
+                ->appendOutputTo(storage_path('logs/SystemCleanUp.log'));
+        
+        // Daily Testing 
+        $schedule->command('notify:daily')
+                ->dailyAt('08:30')
+                ->appendOutputTo(storage_path('logs/daily.log'));
 
     }
 


### PR DESCRIPTION
Oct 26 -- Confirmation from Nancy 

"We can stop the scheduled jobs for donation history. Assuming that if a change is made between now and the end of the year, we COULD do a one-time refresh, if needed. We would, of course, let you know."

Action Required:
Stop scheduling both "ImportPledgeHistory" and "ImportNonGovPledgeHistory" from the daily process in all regions.
The process could run per adhoc rqeuest basis.

And also additional cleanup:
1. adjust the process, no BI import process running daily the weekend.
2. excluded some process from the conditional branch (configuration file flag "env('TASK_SCHEDULING_INBOUND_ENABLED')"