### PR TITLE
(MASTER) [jp-0042] Dev - Error admin entering LDB(Non-Gov) pledge

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -281,6 +281,8 @@ class CampaignPledgeController extends Controller
         } else {
             // Create a new Pledge
 
+            $deptid = null;
+            $dept_name = null;
             if ($is_GOV) {
                 $business_unit =  $user->primary_job ? $user->primary_job->business_unit : null;
                 // $tgb_reg_district =  $user->primary_job ? $user->primary_job->tgb_reg_district : null;


### PR DESCRIPTION
Root cause: undefined variable for Non-Gov pledge. fixed by assign nul value on both variable deptid and dept_name,

[Ticket](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:68ee6eb15df44390b85fb02cac58153d@thread.tacv2_p_ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt_h_1611165472107?tenantId=6fdb5200-3d0d-4a8a-b036-d3685e359adc&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2Fb60NIdmwpkeHotKIZvqLI2UAPpJJ%22%2C%22channelId%22%3A%2219%3A68ee6eb15df44390b85fb02cac58153d%40thread.tacv2%22%7D)