### PR TITLE
[jp-0032] Dev - Charity Mailing address and financial contact info upload (add 2 fields (phone & fax) in export output file)

### DIFF
--- a/app/Jobs/CharitiesExportJob.php
+++ b/app/Jobs/CharitiesExportJob.php
@@ -78,6 +78,8 @@ class CharitiesExportJob implements ShouldQueue, ShouldBeUnique
                     'Financial Contact Name',
                     'Financial Contact Title',
                     'Financial Contact Email',
+                    'phone',
+                    'fax',
 
                     'ongoing_program',
                     'url',
@@ -128,6 +130,8 @@ class CharitiesExportJob implements ShouldQueue, ShouldBeUnique
             'financial_contact_name',
             'financial_contact_title',
             'financial_contact_email',
+            'phone',
+            'fax',
 
             'ongoing_program',
             'url',  


### PR DESCRIPTION
Reference ticket - DEV - PECSF Admin Section - Maintain Charity List - Part 3 - Sprint 28

Oct 5 - Meet with FMO team and the sample vendor file provided. 2 additional field require for storing phone# and fax#. Per Tara, the row with the vendor id equal to "remit vendor id" will used for update the fields

use_alt_address
alt_address1 // Column L -- Address 1
alt_address2 // Column M -- Address 2  
alt_city // Column P -- City       
alt_province // Column X -- State
alt_country  // Column K -- Country
alt_postal_code // Column Y -- postal

financial_contact_name // Column AB -- Name
financial_contact_title // Column AC -- Title
financial_contact_email // Column AH -- email
phone // Column AE -- Phone
fax // Column AF -- Fax
url // Column AI -- Fax

updated_by_id // always assigned to 999

To FMO team, for latest data, please provide a new file from the query "PECSF Vendor Table Curr Data" (1_PECSF_VENDOR_TABLE)) which will replace the initial seed "database/seeds/1_PECSF_VENDOR_TABLE.xlsx".

Additional Deployment Steps :

php artisan migrate
php artisan php artisan command:ImportCharityContacts

Oct 20 - add fields phone, fax and url on show/edit page

Oct 31 - add fields phone & fax on export output file 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/0ZZtVqC7rEe-eMCviyaaGWUAHyH9?Type=TaskLink&Channel=Link&CreatedTime=638331617586490000)