### PR TITLE
[jp-0048] Incorrect Benefiting charity displayed in donation history

### DIFF
--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -205,7 +205,7 @@ class DonationController extends Controller {
                     {
                         $pledges_by_yearcd[$yearcd][$index]->charities = BankDepositForm::where("id","=",$pledge->id)->first()->charities;
                         if(!empty(BankDepositForm::where("id","=",$pledge->id)->first()->region()->get()->first())){
-                            $pledges_by_yearcd[$yearcd][$index]->region = BankDepositForm::where("id","=",$pledge->id)->first()->region()->get()->first()->name;
+                            $pledges_by_yearcd[$yearcd][$index]->region = BankDepositForm::where("id","=",$pledge->id)->first()->fund_supported_pool()->first()->region->name;
                         }
                     }
                     else


### PR DESCRIPTION
Issue:
User details: [employee54@example.com](mailto:employee54@example.com), emp id: 190429
User Lee Gu submitted a Cash event form to the Capital FSP.  
Event was approved by admin.  
Now the event is displayed in the donation history, but with the incorrect benefitting charity.  
Here, the expected charity must display ‘Capital’ but is displaying ‘Central Kootenay ‘instead 

Nov 6 -- (JP) Reassign to myself and start the investigation
Nov 7 -  replicated this scenario on local and fixed the logic of the program.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Mn0zH18LmUy8Peod7O1BnWUAG70n?Type=TaskLink&Channel=Link&CreatedTime=638349703375890000)

