### PR TITLE
[jp-0050] SQL error caused by the single quote () on the charity search string

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -677,9 +677,9 @@ class CampaignPledgeController extends Controller
             $users = User::where('users.organization_id', $request->org_id)
                 ->when($term, function($query) use($term) {
                     return $query->where( function($q) use($term) {
-                        $q->whereRaw( "lower(users.name) like '%".$term."%'")
+                        $q->whereRaw( "lower(users.name) like '%".addslashes($term)."%'")
                         //   ->orWhereRaw( "lower(users.email) like '%".$term."%'")
-                            ->orWhere( "users.emplid", 'like', '%'.$term.'%');
+                            ->orWhere( "users.emplid", 'like', '%'.addslashes($term).'%');
                 });
                 })
                 ->with('primary_job')

--- a/app/Http/Controllers/Admin/DonateNowPledgeController.php
+++ b/app/Http/Controllers/Admin/DonateNowPledgeController.php
@@ -447,9 +447,9 @@ class DonateNowPledgeController extends Controller
             $users = User::where('users.organization_id', $request->org_id)
                 ->when($term, function($query) use($term) { 
                     return $query->where( function($q) use($term) {
-                        $q->whereRaw( "lower(users.name) like '%".$term."%'")
+                        $q->whereRaw( "lower(users.name) like '%".addslashes($term)."%'")
                         //   ->orWhereRaw( "lower(users.email) like '%".$term."%'")
-                            ->orWhere( "users.emplid", 'like', '%'.$term.'%');
+                            ->orWhere( "users.emplid", 'like', '%'.addslashes($term).'%');
                 });
                 })
                 ->with('primary_job')

--- a/app/Http/Controllers/Admin/FundSupportedPoolController.php
+++ b/app/Http/Controllers/Admin/FundSupportedPoolController.php
@@ -735,8 +735,8 @@ class FundSupportedPoolController extends Controller
         $charities = Charity::orderBy('charity_name','asc')->select('id','charity_name','registration_number')
             ->when( $request->q , function ($query) use($request) {
                 $query->where( function($q) use($request) {
-                    return $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower($request->q) . "%'")
-                            ->orWhereRaw("LOWER(registration_number) LIKE '%" . strtolower($request->q) . "%'");
+                    return $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower(addslashes($request->q)) . "%'")
+                            ->orWhereRaw("LOWER(registration_number) LIKE '%" . strtolower(addslashes($request->q)) . "%'");
                 });
             })
             ->where('charity_status','Registered')

--- a/app/Http/Controllers/Admin/SpecialCampaignSetupController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignSetupController.php
@@ -237,8 +237,8 @@ class SpecialCampaignSetupController extends Controller
 
         $charities = Charity::orderBy('charity_name','asc')->select('id','charity_name','registration_number')
             ->when( $request->q , function ($q) use($request) {
-                return $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower($request->q) . "%'")
-                         ->orWhereRaw("LOWER(registration_number) LIKE '%" . strtolower($request->q) . "%'");
+                return $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower(addslashes($request->q)) . "%'")
+                         ->orWhereRaw("LOWER(registration_number) LIKE '%" . strtolower(addslashes($request->q)) . "%'");
 
             })
             ->where('charity_status','Registered')

--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -75,7 +75,7 @@ class BankDepositFormController extends Controller
             }
 
             foreach ($searchValues as $term) {
-                $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower($term) . "%'");
+                $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower(addslashes($term)) . "%'");
             }
             return $q->orderby('charity_name','asc');
 

--- a/app/Http/Controllers/CharityController.php
+++ b/app/Http/Controllers/CharityController.php
@@ -220,7 +220,7 @@ class CharityController extends Controller
             }
 
             foreach ($searchValues as $term) {
-                $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower($term) . "%'");
+                $q->whereRaw("LOWER(charity_name) LIKE '%" . strtolower(addslashes($term)) . "%'");
             }
             return $q->orderby('charity_name','asc');
 


### PR DESCRIPTION
According to the application log, there are lots of SQL error caused by the single quote (‘) entered on the search value by users on charity search field.

`[2023-11-06 11:29:36] prod.ERROR: SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 's%' or LOWER(registration_number) LIKE '%bc children's%') and `charity_status` =' at line 1 (SQL: select `id`, `charity_name`, `registration_number` from `charities` where (LOWER(charity_name) LIKE '%bc children's%' or LOWER(registration_number) LIKE '%bc children's%') and `charity_status` = Registered order by `charity_name` asc limit 100) 
`
Nov 8 -- fixed the following search fields:
a. charity 
b. user / employee name
c. special campaign name

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/bN0SN6h48UeiC-Qnr-3ia2UANwaq?Type=TaskLink&Channel=Link&CreatedTime=638350978807380000)