### PR TITLE
(MASTER) [jp-0047] Duplicate pledge button disappears when a cash/cheque is added to donation history

### DIFF
--- a/resources/views/donations/partials/history.blade.php
+++ b/resources/views/donations/partials/history.blade.php
@@ -29,6 +29,11 @@
                     </tr>
                     @php $total = 0; $ignore = true; @endphp
                     @foreach($pledges as $pledge)
+                        @php
+                            if($pledge->donation_type == "Annual") {
+                                $ignore = false;
+                            }
+                        @endphp
                         <tr class="">
                             <td style="width: 15%">
                                 @switch($pledge->donation_type)
@@ -116,23 +121,9 @@
                         </tr>
                     @endforeach
                 </table>
-                @php
-                foreach($pledges as $pledge){
-                    if($pledge->donation_type == "Annual")
-                    {
-                        $ignore = false;
-                        break;
-                    }
-                }
-                @endphp
-                @if($key > $currentYear || $ignore || isset($globalIgnore) || !$campaignYear->isOpen())
-                    @php
-                    if($key>$currentYear)
-                        {
-                            $globalIgnore = true;
-                        }
-                        $ignore = true;
-                    @endphp
+
+                @if($key > $currentYear ||  $ignore  || $current_pledge || !$campaignYear->isOpen())
+                    {{-- No 'duplicate' button --}}
                 @else
 
                     <a class="duplicate-pledge btn btn-primary" style="margin-left: auto; margin-right: auto; width: fit-content; display: block;"
@@ -141,7 +132,7 @@
                                 data-source="{{ $pledge->source }}"
                                 {{-- onclick="event.preventDefault(); document.getElementById('duplicate-form-{{ $pledge->id }}').submit();" --}}
                                 >
-                                {{$ignore}}Duplicate this Annual Campaign pledge
+                                Duplicate this Annual Campaign pledge
                     </a>
 
                 {{-- <a style="margin-left: auto;


### PR DESCRIPTION
Issue:
Employees have submitted 3 cash/cheque e-forms which are displayed in the donation history. Since these entries are not a pledge donation for calendar year 2024, the Duplicate Pledge button must still be displayed in the years of donation history.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/UgKwXU8dn0O8BZbmqBAiO2UABuJ3?Type=TaskLink&Channel=Link&CreatedTime=638349684102380000)
