### PR TITLE
(MASTER) [jz-18]Edit event pledge -> Drop down fields does not let admin type and search an option 

### DIFF
--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -60,7 +60,7 @@
         </div>
     </div>
 
-    <div class="modal fade" id="edit-event-modal" tabindex="-1" >
+    <div class="modal fade" id="edit-event-modal" >
         <div class="modal-dialog custom-modal">
             <div class="modal-content">
                 <div class="modal-header">


### PR DESCRIPTION
remove the tabindex="-1" from modal to enable keyword searching of select2 plugin