### PR TITLE
[jp-0055] Employee name does not get stored when editing an Gov event pledge

### DIFF
--- a/app/Http/Controllers/Admin/EventSubmissionQueueController.php
+++ b/app/Http/Controllers/Admin/EventSubmissionQueueController.php
@@ -147,6 +147,7 @@ class EventSubmissionQueueController extends Controller
             ->where("bank_deposit_forms.id","=",$request->form_id)
             ->join("users","bank_deposit_forms.form_submitter_id","=","users.id")
             ->join("campaign_years","bank_deposit_forms.campaign_year_id","=","campaign_years.id")
+            ->with('form_submitted_by')
             ->get();
             error_log('1');
         foreach($submissions as $index => $submission){

--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -63,7 +63,7 @@
     <div class="modal fade" id="edit-event-modal" >
         <div class="modal-dialog custom-modal">
             <div class="modal-content">
-                <div class="modal-header">
+                <div class="modal-header bg-primary">
                     <h5 class="modal-charity-name" id="charity-modal-label">Submission Details</h5>
                     <button type="button" class="close" data-dismiss="modal" aria-label="Close">
                         <span aria-hidden="true">&times;</span>
@@ -197,6 +197,8 @@
                 },
                 function (data, status) {
                     $('#organizations').html("");
+                    $('#form_submitter_name').val(data[0]['form_submitted_by']['name']);
+                    $('#form_submitter').val(data[0]['form_submitter_id']);
                     $("#event_type").val(data[0].event_type).select2();
                     $("#business_unit").val(data[0].business_unit).select2();
                     $("[name='event_type']").trigger("change");

--- a/resources/views/admin-pledge/submission-queue/partials/form.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/form.blade.php
@@ -28,9 +28,9 @@
         <div class="form-group col-md-4">
             <label for="form_submitter">Form submitter</label>
             <!--<div id="form_submitter">{{$current_user->name}}</div>-->
-            <input type="text" disabled class="form-control" value="{{$current_user->name}}" />
+            <input type="text" disabled class="form-control" value="{{$current_user->name}}" id="form_submitter_name"/>
 
-            <input type="hidden" disabled value="{{$current_user->id}}" name="form_submitter" />
+            <input type="hidden" disabled value="{{$current_user->id}}" name="form_submitter" id="form_submitter"/>
 
             <span class="form_submitter_errors errors">
                        @error('form_submitter')


### PR DESCRIPTION
Nov 8 - Ticket created / screenshots added (GH)
Nov 9 - Steffi confirmed the issue.
Nov 14 - The reported issue was located and fixed:
In production environment 

When user goes to Event Submission Queue 

When choosing an eForm and viewing details – the name of the submitter changes from the volunteer, to the admin name… 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/WAUYvDiShkqT04JYhDZtBGUAA8HU?Type=TaskLink&Channel=Link&CreatedTime=638355887650870000)
