### PR TITLE
[jp-0056] Emp Id and name in Admin -> Event submission queue are not mandatory

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -2,28 +2,29 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Controllers\Controller;
-use App\Models\BankDepositForm;
-use App\Models\BankDepositFormOrganizations;
-use App\Models\BankDepositFormAttachments;
-use App\Models\Charity;
-use App\Models\EmployeeJob;
-use App\Models\Organization;
+use App\Models\City;
+use App\Models\User;
+use App\Models\FSPool;
 use App\Models\Pledge;
-use App\Models\ProcessHistory;
+use App\Models\Region;
+use App\Models\Charity;
+use App\Models\Department;
+use App\Models\EmployeeJob;
+use App\Models\BusinessUnit;
+use App\Models\CampaignYear;
+use App\Models\Organization;
 use Illuminate\Http\Request;
+use App\Models\ProcessHistory;
+
+use App\Models\BankDepositForm;
+use Illuminate\Validation\Rule;
+use App\Http\Controllers\Controller;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Session;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
-
-use App\Models\FSPool;
-use App\Models\Region;
-use App\Models\BusinessUnit;
-use App\Models\Department;
-use App\Models\CampaignYear;
-use App\Models\User;
-use App\Models\City;
-use Illuminate\Support\Facades\Auth;
+use App\Models\BankDepositFormAttachments;
+use App\Models\BankDepositFormOrganizations;
 
 class BankDepositFormController extends Controller
 {
@@ -457,6 +458,8 @@ class BankDepositFormController extends Controller
             'event_type'         => 'required',
             //'sub_type'         => 'required',
             //'sub_type' => ['sometimes', 'boolean', 'default:false'], // Make it not required and set default to false
+            'bc_gov_id'  => [ Rule::when( $request->organization_code == 'GOV', ['required_unless:event_type,Fundraiser,Gaming']) ], 
+            'employee_name'  => [ Rule::when( $request->organization_code == 'GOV', ['required_unless:event_type,Fundraiser,Gaming']) ], 
             'deposit_date'         => 'required|before:tomorrow',
             'deposit_amount'         => 'required|numeric|gt:0',
             'employment_city'         => 'required',


### PR DESCRIPTION
Nov 14 - The reported issues was replicated and fixed 

For admin -> Event pledge -> Edit pledge -> The employee name and employee id field are not mandatory when Cheque or Cheque is selected.    
For gov org, Changed the event type from gaming/fundraiser to cash/cheque, without entering the emp id and name, clicked the submit button.  
Expected result: The emp id and emp name field must be validated as shown in the following screenshot 
Actual result: Fields are not validated 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/3rzCDqikbk66AwRU3XCEEGUAPwuu?Type=TaskLink&Channel=Link&CreatedTime=638355945507220000)

