### PR TITLE
[jp-0057] Event Pledge: Editing a Retiree form, lets admin change the event type to Fundraiser/Gaming

### DIFF
--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -199,7 +199,15 @@
                     $('#organizations').html("");
                     $("#event_type").val(data[0].event_type).select2();
                     $("#business_unit").val(data[0].business_unit).select2();
-                    $("[name='event_type']").trigger("change");
+
+                    $("#organization_code").html("<option value='"+data[0].organization_code+"'>"+data[0].organization_code+"</option>");
+                    $("#organization_code").select2({
+                        ajax: {
+                            url: '/bank_deposit_form/organization_code',
+                            dataType: 'json'
+                        }
+                    });
+                    $("[name='event_type']").trigger("change");                    
                     $("#deposit_amount").val(data[0].deposit_amount);
                     $("#deposit_date").val(data[0].deposit_date);
                     $("#campaign_year").html( (data[0].calendar_year - 1));
@@ -251,13 +259,6 @@
                     $("#region").val(data[0].region_id).select2();
                     $("#description").val(data[0].description);
 
-                    $("#organization_code").html("<option value='"+data[0].organization_code+"'>"+data[0].organization_code+"</option>");
-                    $("#organization_code").select2({
-                        ajax: {
-                            url: '/bank_deposit_form/organization_code',
-                            dataType: 'json'
-                        }
-                    });
 
 
 


### PR DESCRIPTION
Nov 14 - The reported issue was replicated and fixed

Issue: Event Pledge: Editing a Retiree form, lets admin change the event type to Fundraiser/Gaming 

When submitting an e-form, if org is selected as ‘Retirees’ then Donation or event type list is modified to disable the options Fundraiser and Gaming. So, the user cannot select any of these options.  

But when editing the pledge made to Retirees with event type cash or cheque, admin can see the options Fundraiser and Gaming in Event type.  

Expected result: Keep the 2 options disabled when Retiree is selected 

[Ticket ](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/mSras7_0_UeP-C8J9EGAV2UAAWu6?Type=TaskLink&Channel=Link&CreatedTime=638356043225370000)

