### PR TITLE
[jp-0061] Admin Donate now - When editing, changes are being saved without clicking on the Save button

### DIFF
--- a/resources/views/admin-pledge/donate-now/create-edit.blade.php
+++ b/resources/views/admin-pledge/donate-now/create-edit.blade.php
@@ -350,7 +350,7 @@
 
 
         <div class="mt-3">
-            <button class="btn btn-outline-primary" onclick="location.href='{{ route('admin-pledge.donate-now.index') }}'">Cancel</button>
+            <button type="button" class="btn btn-outline-primary" onclick="location.href='{{ route('admin-pledge.donate-now.index') }}'">Cancel</button>
             <input class="btn btn-primary ml-2" type="submit" value="Save">
         </div>
 


### PR DESCRIPTION
Issue: Admin Donate now - When editing, changes are being saved without clicking on the Save button 
Steps to reproduce:  

- Go to admin -> Maintain donate now pledge 
- Edit the pledge made to CRA charity 
- Go to the ‘Donate to charity’ section 
- Change the charity from the drop-down section 
- Click on the ‘Cancel’ button 

Notice that the transaction is being updated with the newly selected charity without hitting the Save button 

Expected result: Can we only save the changes if user clicks on the Save button 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Chw4gNwkfkeEemeYEM7xGmUACmz1?Type=TaskLink&Channel=Link&CreatedTime=638356198793910000)

Nov 14 - The reported issues was replicated and fixed.