### PR TITLE
[jp-0062] Donate now - Program name for a FSP - CRA charity is not displayed in the pdf and donation history

### DIFF
--- a/app/Http/Controllers/DonateNowController.php
+++ b/app/Http/Controllers/DonateNowController.php
@@ -382,7 +382,7 @@ class DonateNowController extends Controller
             foreach ($pool_charities as $key => $pool_charity) {
                 $charity = $pool_charity->charity->toArray();
                 $charity['text'] = $pool_charity->charity->charity_name;
-                $charity['additional'] = '';
+                $charity['additional'] = $pool_charity->name;
 
                 $percentage = $pool_charity->percentage;
 


### PR DESCRIPTION
Issue: When making a donation to the FSP – Charity charity, the program name must be displayed in the pdf and the donation history just like its displayed in the Annual campaign. 

Expected result: Please add the program name below the charity name 

Nov 14 -- The reported issues was replicated and fixed.

[Ticket ](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/u9JFAhNEFkSPhaqcuSIyb2UAOmlK?Type=TaskLink&Channel=Link&CreatedTime=638356231547330000)