### PR TITLE
[jp-0057] Event Pledge: Editing a Retiree form, lets admin change the event type to Fundraiser/Gaming

### DIFF
--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -249,7 +249,7 @@
                             $("#bcgovid").show();
                         }
                         else{                            
-                            // If "non-GOV" is selected, disable specific options
+                            // If "non-GOV" is selected (except RET), disable specific options
                             if(data[0].organization_code != "RET") {
                                 disableOneTime(); 
                             }

--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -250,7 +250,7 @@
                         }
                         else{                            
                             // If "non-GOV" is selected, disable specific options
-                            if(data[0].organization_code != "GOV") {
+                            if(data[0].organization_code != "RET") {
                                 disableOneTime(); 
                             }
                             

--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -250,7 +250,9 @@
                         }
                         else{                            
                             // If "non-GOV" is selected, disable specific options
-                            disableOneTime(); 
+                            if(data[0].organization_code != "GOV") {
+                                disableOneTime(); 
+                            }
                             
                             $("#pecsfid").find("label").show();
                             $("#pecsfid").find("input").show();


### PR DESCRIPTION
Nov 14 - The reported issue was replicated and fixed
Nov 15 - Required to merge with jz-016 and required additional logic fix.

Issue: Event Pledge: Editing a Retiree form, lets admin change the event type to Fundraiser/Gaming 

When submitting an e-form, if org is selected as ‘Retirees’ then Donation or event type list is modified to disable the options Fundraiser and Gaming. So, the user cannot select any of these options.  

But when editing the pledge made to Retirees with event type cash or cheque, admin can see the options Fundraiser and Gaming in Event type.  

Expected result: Keep the 2 options disabled when Retiree is selected 

[Ticket ](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/mSras7_0_UeP-C8J9EGAV2UAAWu6?Type=TaskLink&Channel=Link&CreatedTime=638356043225370000)

