### PR TITLE
(MASTER) [jp-0053] Incorrect header in the pdf - Change Percentage to Amount

### DIFF
--- a/resources/views/annual-campaign/partials/summary-distribution.blade.php
+++ b/resources/views/annual-campaign/partials/summary-distribution.blade.php
@@ -38,7 +38,7 @@
                     <th style="width:18%;">Donation Type</th>
                     <th style="width:62%;">Benefitting Charity</th>
                     <th style="width:10%;">Frequency</th>
-                    <th style="width:10%;text-align:right;" class="percentage-amount-head-title">Percentage</th>
+                    <th style="width:10%;text-align:right;" class="percentage-amount-head-title">{{ ($viewMode ?? '') !== 'pdf' ? 'Percentage' : 'Amount'}}</th>
                 </tr>
                 @foreach ($charities as $charity)
                 <tr>


### PR DESCRIPTION
Nov 14 - located the reported issue and fixed the issue:
In the pdf’s the Percentage title in the donation disbursement table must be changed to Amount, since the data displayed within is in $$ 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/2a_sFVCdpkmVdP_O1uuirWUAJflb?Type=TaskLink&Channel=Link&CreatedTime=638355831277690000)