### PR TITLE
(MASTER) [jp-0054] E-form: Search function in the Org drop-down list does not work 

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -750,8 +750,14 @@ class BankDepositFormController extends Controller
             $organizations = Organization::where("status","=","A")->limit(30)->get();
         }
         else{
-            $organizations = Organization::where("code", "LIKE", $request->term . "%")->where("status","=","A")->get();
+            $organizations = Organization::where( function($q) use($request) {
+                                    $q->where("code", "like", "%" . $request->term . "%")
+                                      ->orWhere("name", "like", "%" . $request->term . "%");
+                                })
+                                ->where("status","=","A")
+                                ->get();
         }
+
         $response = ['results' => []];
         $response['results'][] = ["id" => "false", "text" => "Choose an organization"];
         foreach ($organizations as $organization) {


### PR DESCRIPTION
Nov 14 - the reported issue was located and fixed:
For all the drop-down fields, there is an option to search the menu by typing it. This feature is not working in the Organization field in the e-form 

Places to be fixed: 
1. Volunteering -> e-form 
2. Admin - > Create new event pledge 
3. Admin -> Event submission queue -> Edit pledge 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/VqO5Ojtnuk260U4i09puKGUAGXw4?Type=TaskLink&Channel=Link&CreatedTime=638355832260340000)