### PR TITLE
(MASTER) [jp-0063] Daily Campaign Update - Org/Region report error

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -347,7 +347,7 @@ class ChallengeController extends Controller
 
     public function download(Request $request)
     {
-        
+       
         $campaign_year = Setting::challenge_page_campaign_year();
         $setting = Setting::first();
 
@@ -355,10 +355,14 @@ class ChallengeController extends Controller
         $as_of_date = $request->start_date ?? today()->format('Y-m-d');
 
         if ( $as_of_date >= $setting->campaign_end_date->format('Y-m-d')) {
-            if ($sort == 'department')  {
+            if ($as_of_date < $setting->campaign_final_date->format('Y-m-d')) {
                 $as_of_date = $setting->campaign_end_date->format('Y-m-d');
             } else {
-                $as_of_date = $setting->campaign_final_date->format('Y-m-d');
+                if ($sort == 'department')  {
+                    $as_of_date = $setting->campaign_end_date->format('Y-m-d');
+                } else {
+                    $as_of_date = $setting->campaign_final_date->format('Y-m-d');
+                }
             }
         }
 


### PR DESCRIPTION
Issue:
When users try to download the (Organization/Region) Daily Campaign Update for November 13, 2023, it downloads and the date at the end of the file name for the Excel spreadsheet shows 2024-02-01. When it is opened, the report is empty.

Nov 15 - the reported issue was replicated and fix

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/h-IBhrMu9kyH-1ZUnLRj12UAIYdJ?Type=TaskLink&Channel=Link&CreatedTime=638356878233090000)