### PR TITLE
(TEST MIGRATION) [jp-0058] Donate now - Maximum charity reached message displayed while adding the 3rd charity

### DIFF
--- a/resources/views/donate-now/partials/choose-charity-js.blade.php
+++ b/resources/views/donate-now/partials/choose-charity-js.blade.php
@@ -124,7 +124,7 @@
             // }
             $('#selectedcountresults').html(  $("input[name='charities[]']").length + ' item(s) selected');
 
-            if ($(".organization").length > 2) {
+            if ($(".organization").length > 1) {
                     Toast('More than one charity were specified','Please be aware, only one charity is required for Donate Now pledge.',"bg-danger");
                     return false;
             }


### PR DESCRIPTION
Nov 14 - The reported issue was replicated and fixed:

As we know the donate now feature only lets user select one charity, we have added a pop-up message which is displayed when user adds more than the allowed number of charities.  

Expected result: The message must be displayed when adding the 2nd charity 

Actual result: The message is displayed when adding the 3rd charity 

