### PR TITLE
(TEST MIGRATION) [jp-0064] Edit event pledge -> Business unit does not populate when org is changed to Gov

### DIFF
--- a/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
@@ -152,6 +152,37 @@ e.preventDefault();
 
 });
 
+function govuserinfo() {
+
+    bc_gov_id = $('#bc_gov_id').val();
+
+    if (bc_gov_id) {
+        $.ajax({
+            url: "/bank_deposit_form/bc_gov_id?id="+ bc_gov_id,
+            type: "GET",
+            headers: {'X-CSRF-TOKEN': $("input[name='_token']").val()},
+            processData: false,
+            cache: false,
+            contentType: false,
+            dataType: 'json',
+            success:function(response){
+                $("#employment_city").parents(".form-body").fadeTo("fast",0.25);
+                $("#employment_city").val(response.office_city).select2();
+                $("#region").val($("#region option[code='"+response.tgb_reg_district+"']").val()).select2();
+                $("#business_unit").val(response.business_unit_id).select2();
+                $("#employee_name").val(response.last_name+","+response.first_name);
+                setTimeout(function(){
+                    $("#employment_city").parents(".form-body").fadeTo("slow",1);
+                },500);
+            },
+            error: function(response) {
+            }
+        });
+    } 
+
+}
+
+
 function nongovuserinfo(){
     $.get({
         url: '/admin-pledge/campaign-nongov-user' +
@@ -621,7 +652,8 @@ $("#attachment_input_1").val("");
             });
         }
         else if($(this).val() == "GOV"){
-            $("#business_unit").val("").select2();
+            // $("#business_unit").val("").select2();
+            govuserinfo();
         }
     });
     $("#keyword").keypress(function(e){


### PR DESCRIPTION

When editing a event pledge from the Event submission queue, if user changes the org from Non-gov to gov, then Business unit does not populate.  

Steps to reproduce:  
Pick any bank deposit form submitted to Gov and must be Cash/cheque from the event submission queue
Click on View details
Click on edit
The BU will be populated for now based on the employee id entered
Now change the Org to any of the Non-Gov organization
Now again change the org back to ‘Gov’
The BU field now remains empty

Expected result: Since there is already a employee id present in the e-form. Is it possible to populate the BU based on the employee id.  

Nov 15 - WIP, have to wait for jz-016 and jp-0057 tickets move to master and production (otherwise code merge conflict)
Nov 17 - Fix the issue and move forward
