### PR TITLE
(MASTER) [jp-0060] Donate now: Remove an extra line form the Donate now summary pdf

### DIFF
--- a/app/Http/Controllers/DonateNowController.php
+++ b/app/Http/Controllers/DonateNowController.php
@@ -419,7 +419,7 @@ class DonateNowController extends Controller
         }
 
         // download PDF file with download method
-        $fsp_name = empty($in_support_of) ? false : $in_support_of;
+        $fsp_name = $pledge->type == 'P' ? $in_support_of : false;
         if(isset($request->download_pdf)){
             // view()->share('donations.index',compact('pledges', 'currentYear', 'totalPledgedDataTillNow', 'campaignYear',
             //     'pledge', 'pledges_by_yearcd'));


### PR DESCRIPTION
Nov 14 - The reported issue was replicated and fixed:

In the Donate now summary pdf, there is an extra line below the title ‘One-time total disbursement’ that displays the charity name and the text ‘Fund supported pool’. Can we please remove that line when a pledge is made to a CRA charity as it does not make sense. 

Note: That line must remain present when donation is made to a FSP so that we can display the name of the FSP.  

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/DoJGk0eZXkGc9qMNuMRuQGUAEkKW?Type=TaskLink&Channel=Link&CreatedTime=638356192057890000)

