### PR TITLE
(MASTER) [jp-0062] Donate now - Program name for a FSP - CRA charity is not displayed in the pdf and donation history (additiona changes)

### DIFF
--- a/app/Http/Controllers/DonateNowController.php
+++ b/app/Http/Controllers/DonateNowController.php
@@ -382,7 +382,7 @@ class DonateNowController extends Controller
             foreach ($pool_charities as $key => $pool_charity) {
                 $charity = $pool_charity->charity->toArray();
                 $charity['text'] = $pool_charity->charity->charity_name;
-                $charity['additional'] = '';
+                $charity['additional'] = $pool_charity->name;
 
                 $percentage = $pool_charity->percentage;
 

--- a/app/Http/Controllers/DonateNowController.php
+++ b/app/Http/Controllers/DonateNowController.php
@@ -412,7 +412,7 @@ class DonateNowController extends Controller
         } else {
             $charity = Charity::where('id', $pledge->charity_id)->first();
             $charity['text'] = $charity->charity_name;
-            $charity['additional'] = $charity->status;
+            $charity['additional'] = $pledge->special_program;
             $charity['one-time-percentage-distribution'] = 100;
             $charity['one-time-amount-distribution'] = $one_time_amount;
             $in_support_of = $charity ? $charity->charity_name : '';

--- a/resources/views/donations/partials/donate-now-pledge-detail-modal.blade.php
+++ b/resources/views/donations/partials/donate-now-pledge-detail-modal.blade.php
@@ -62,7 +62,7 @@
                 <td scope="row">1</td>
                 <td>
                     <p>{{ $pledge->charity->charity_name }}</p>
-                    <p>{{ $pledge->additional  }}</p>
+                    <p>{{ $pledge->special_program  }}</p>
                 </td>
                 <td class="text-center">{{ number_format( 100 ,2) }}%</td>
                 <td class="text-center">${{ number_format( $total_amount, 2) }}</td>


### PR DESCRIPTION
Issue: When making a donation to the FSP – Charity charity, the program name must be displayed in the pdf and the donation history just like its displayed in the Annual campaign. 

Expected result: Please add the program name below the charity name 


Nov 14 -- The reported issues was replicated and fixed.
Nov 17 - Fixed and ready for retest
Nov 20 - Test failed. Cannot see the program name in the Donate now pdf nor in the View details modal in donation history
Nov 21 - Missing to display the "Donate Now" special program on donation history and the Donate Today summary in PDF format.  