### PR TITLE
(TEST) [0068] Donate now - Maximum charity reached message update

### DIFF
--- a/app/Http/Requests/DonateNowRequest.php
+++ b/app/Http/Requests/DonateNowRequest.php
@@ -102,7 +102,7 @@ class DonateNowRequest extends FormRequest
             // 'charity_id.required_if' => 'A charity selection is required. Please choose a charity.',
             'charities.required' => 'At least one charity must be specified.',
             'charities.min' => 'At least one charity must be specified.',
-            'charities.max' => 'More than one charity were specified.',
+            'charities.max' => 'More than one charity chosen.',
             'charities.*.exists' =>  'The invalid charity entered.',
             'one_time_amount_custom.numeric' => ' The One-time custom amount must be a number.',
             'one_time_amount_custom.required' => 'The amount is required.',

--- a/resources/views/donate-now/partials/choose-charity-js.blade.php
+++ b/resources/views/donate-now/partials/choose-charity-js.blade.php
@@ -125,7 +125,7 @@
             $('#selectedcountresults').html(  $("input[name='charities[]']").length + ' item(s) selected');
 
             if ($(".organization").length > 1) {
-                    Toast('More than one charity were specified','Please be aware, only one charity is required for Donate Now pledge.',"bg-danger");
+                    Toast('More than one charity chosen','Only one charity can be selected for a Donate Now pledge.',"bg-danger");
                     return false;
             }
 


### PR DESCRIPTION
Nov 14 - The reported issue was replicated and fixed:

As we know the donate now feature only lets user select one charity, we have added a pop-up message which is displayed when user adds more than the allowed number of charities.  

The error message needs an update. See attached.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/bLFzO-7YT0SMlKAWCpA7KmUAOpPs?Type=TaskLink&Channel=Link&CreatedTime=638363563818170000)