### PR TITLE
(MASTER) [jp-0067] Admin Editing a Donate now pledge' FSP does not assign the selected FSP

### DIFF
--- a/resources/views/admin-pledge/donate-now/create-edit.blade.php
+++ b/resources/views/admin-pledge/donate-now/create-edit.blade.php
@@ -230,9 +230,9 @@
                                         <select class="form-control" name="pool_id" id="pool_id">
                                             <option value="" selected>Choose a pool</option>
                                             @foreach ($fspools as $fspool)
-                                                <option value="{{ $fspool->region_id }}"
+                                                <option value="{{ $fspool->id }}"
                                                     @if ( $pledge->id && $pool_option == "P")
-                                                        {{  $pledge->current_fund_supported_pool_by_region()->id == $fspool->id ? 'selected' : ''  }}
+                                                        {{  $pledge->current_fund_supported_pool_by_region()->region_id == $fspool->region_id ? 'selected' : ''  }}
                                                     @endif
                                                     >{{ $fspool->region->name }}</option>
                                             @endforeach


### PR DESCRIPTION
Issue: When editing a Donate now pledge to a FSP – incorrect FSP is assigned to the pledge.
Nov 23 - The reported issue was replciated and fixed