### PR TITLE
[jp-0069] Donate Now pledges displayed in 2023 instead of 2024 (based on year of pay deduction date)

### DIFF
--- a/app/Http/Controllers/Admin/DonateNowPledgeController.php
+++ b/app/Http/Controllers/Admin/DonateNowPledgeController.php
@@ -87,13 +87,8 @@ class DonateNowPledgeController extends Controller
                                              ->orWhere('donate_now_pledges.city', 'like', '%'. $request->city .'%');
                                 });
                             })
-                            ->when( $request->campaign_year_id, function($query) use($request) {
-                                // $query->where('campaign_year_id', $request->campaign_year_id);
-                                $query->where('yearcd', function($q) use($request){
-                                            $q->select('calendar_year')
-                                                    ->from('campaign_years')
-                                                    ->where('campaign_years.id', $request->campaign_year_id);
-                                });
+                            ->when( $request->yearcd && $request->yearcd <> 'all', function($query) use($request) {
+                                $query->where('donate_now_pledges.yearcd', $request->yearcd );
                             })
                             ->when( $request->cancelled == 'C', function($query) use($request) {
                                 $query->whereNotNull('donate_now_pledges.cancelled');
@@ -162,8 +157,11 @@ class DonateNowPledgeController extends Controller
         $campaign_years = CampaignYear::orderBy('calendar_year', 'desc')->get();
         $cities = City::orderBy('city')->get();
 
+        $deduct_pay_from = PayCalendar::nextDeductPayFrom();
+        $yearcd = substr($deduct_pay_from,0,4);
+
         // load the view and pass 
-        return view('admin-pledge.donate-now.index', compact('organizations', 'campaign_years','cities', 'filter'));
+        return view('admin-pledge.donate-now.index', compact('organizations', 'campaign_years','cities', 'filter', 'yearcd'));
 
     }
 
@@ -192,9 +190,12 @@ class DonateNowPledgeController extends Controller
         $cities = City::orderBy('city')->get();
 
         $is_new_pledge = true;
+        
+        $deduct_pay_from = PayCalendar::nextDeductPayFrom();
+        $yearcd = substr($deduct_pay_from,0,4);
 
         return view('admin-pledge.donate-now.create-edit', compact('pledge', 'pool_option', 'fspools', 'organizations','campaignYears','cities',
-                    'is_new_pledge',
+                    'is_new_pledge', 'yearcd'
                     //  'deduct_pay_from', 'one_time_amount'
                     ));
     }

--- a/app/Http/Controllers/DonateNowController.php
+++ b/app/Http/Controllers/DonateNowController.php
@@ -66,7 +66,9 @@ class DonateNowController extends Controller
 
 
         // Self service
-        $yearcd = Carbon::now()->format('Y');
+        $deduct_pay_from = PayCalendar::nextDeductPayFrom();
+        $yearcd = substr($deduct_pay_from,0,4);
+
         $amount_options =  [
                             6 => '$6',
                             12 => '$12',
@@ -107,11 +109,11 @@ class DonateNowController extends Controller
         // Calculate the deduct pay from
         $current = PayCalendar::whereRaw(" ( date(SYSDATE()) between pay_begin_dt and pay_end_dt) ")->first();
 
-        $check_dt = '';
-        if ($current) {
-            $period = PayCalendar::where('check_dt', '>=',  $current->check_dt )->skip(2)->take(1)->orderBy('check_dt')->first();
-            $check_dt = $period ? $period->check_dt : null;
-        }
+        $check_dt = PayCalendar::nextDeductPayFrom();
+        // if ($current) {
+        //     $period = PayCalendar::where('check_dt', '>=',  $current->check_dt )->skip(2)->take(1)->orderBy('check_dt')->first();
+        //     $check_dt = $period ? $period->check_dt : null;
+        // }
 
         if ($request->ajax()) {
 

--- a/resources/views/admin-pledge/donate-now/create-edit.blade.php
+++ b/resources/views/admin-pledge/donate-now/create-edit.blade.php
@@ -49,20 +49,8 @@
                     <div class="row">
                         <div class="form-group ">
                             <label for="yearcd">Calendar Year</label>
-                            @if ($is_new_pledge)
-                                <select id="yearcd" class="form-control" name="yearcd" style="max-width:200px;">
-                                    @foreach ($campaignYears as $cy)
-                                        <option value="{{ $cy->calendar_year }}"
-                                            {{ ($cy->calendar_year == date('Y')) ? 'selected' : '' }}>
-                                            {{ $cy->calendar_year }}
-                                        </option>
-                                    @endforeach
-                                </select>
-                            @else
-                                <select id="yearcd" class="form-control" name="yearcd" style="max-width:200px;" {{ $is_new_pledge ? '' : 'readonly' }}>
-                                <option value="{{ $pledge->calendar_year }}" selected>{{ $pledge->yearcd }}</option>
-                                </select>
-                            @endif
+                            <input type="text" class="form-control" name="yearcd" 
+                                value="{{ $is_new_pledge ? $yearcd : $pledge->yearcd }}" readonly>    
                         </div>
                     </div>
             </div>

--- a/resources/views/admin-pledge/donate-now/index.blade.php
+++ b/resources/views/admin-pledge/donate-now/index.blade.php
@@ -111,12 +111,12 @@
                 <label for="campaign_year">
                     Calendar Year
                 </label>
-                <select id="campaign_year_id" class="form-control" name="campaign_year_id">
-                    <option value="">All</option>
+                <select id="yearcd" class="form-control" name="yearcd">
+                    <option value="all">All</option>
                     @foreach ($campaign_years as $cy)
-                        <option value="{{ $cy->id }}" {{ 
-                            isset($filter['campaign_year_id']) ? ($filter['campaign_year_id'] == $cy->id ? 'selected' : '') :
-                            ($cy->calendar_year == date('Y') ? 'selected' : '') }}>
+                        <option value="{{ $cy->calendar_year }}" {{ 
+                            isset($filter['yearcd']) ? ($filter['yearcd'] == $cy->calendar_year ? 'selected' : '') :
+                            ($cy->calendar_year == $yearcd ? 'selected' : '') }}>
                             {{ $cy->calendar_year }} 
                         </option>
                     @endforeach
@@ -282,7 +282,7 @@
                     data.seqno = $('#seqno').val();
                     data.name = $('#name').val();
                     data.city = $('#city').val();
-                    data.campaign_year_id = $('#campaign_year_id').val();
+                    data.yearcd = $('#yearcd').val();
                     data.one_time_amt_from = $('#one_time_amt_from').val();
                     data.one_time_amt_to = $('#one_time_amt_to').val();
                     data.pay_period_amt_from = $('#pay_period_amt_from').val();

--- a/resources/views/donations/partials/donate-now-pledge-detail-modal.blade.php
+++ b/resources/views/donations/partials/donate-now-pledge-detail-modal.blade.php
@@ -5,7 +5,7 @@
         <p class="font-weight-bold">Calendar Year</p>
       </div>
       <div class="col-1">
-        <p>{{ $year + 1 }}</p>
+        <p>{{ $year }}</p>
       </div>
 </div>
 <div class="row">


### PR DESCRIPTION
Nov 30 - The year on the Donate Pledges should be based on the year of pay deduction date. The following area should be changed:

1) The donations made in Donate now after Nov 23, must be displayed in the year 2024 of the users' donation history page
2) For admin ‘Maintain Donate Now Pledge’ -> Create new pledge -> Make the calendar year non editable field and change it to 2024 (Deduction yr)
3) On the Maintain Donate Now Pledge -> Search criteria -> Change the default Calendar yr to 2024
4) The donations must be displayed in 2024
