### PR TITLE
[jp-0066] 6th commit -- eform attachment functionality (wrong criteria on the seeder file)

### DIFF
--- a/database/seeders/BankDepositFormAttachmentsSeeder.php
+++ b/database/seeders/BankDepositFormAttachmentsSeeder.php
@@ -18,11 +18,9 @@ class BankDepositFormAttachmentsSeeder extends Seeder
     public function run()
     {
 
-        $attachemnts = BankDepositFormAttachments::whereNull('file')->where('local_path','like', 'C:%')->orderBy('id')->get();
+        $attachemnts = BankDepositFormAttachments::whereNull('file')->orderBy('id')->get();
 
         foreach ($attachemnts as $attachment) {
-
-            
 
             $filename = substr($attachment->local_path, strrpos($attachment->local_path, '/') + 1);
             $original_filename = substr($filename, strpos($filename, '_') + 1);


### PR DESCRIPTION
This pull request contains 2 tickets:

[jp-0066] eForm - When user attaches Multiple files to eform, some of the files are missing in admin-event pledge,
[jp-0066] eForm - store eForm Attachments in Database instead of system folder

Additional fix on seeder file.