### PR TITLE
[jp-0070][<--jp-0066] 7th commit -- eform attachment functionality (display error message when submit)

### DIFF
--- a/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
@@ -314,6 +314,26 @@ var formData = new FormData();
         e.preventDefault();
         var form = document.getElementById("create_pool");
 
+        exist_count = $('table#attachments .filename').length;
+        total_count = $('#bank_deposit_form .dropzone .dz-complete').length;
+        error_count = $('#bank_deposit_form .dropzone .dz-error').length;
+        if (total_count > (5 - exist_count) ) {
+            Swal.fire({
+                title: "Problem on upload files",
+                text: "You have reached the maximum number of allowed file uploads. To continue, please remove some files from your current selection and try again.",
+                icon: "warning"
+            });
+            return; 
+        }
+        if (error_count > 0 ) {
+            Swal.fire({
+                title: "Problem on upload files",
+                text: "You have uploaded some unsupported format or file size exceeds limit file(s). Please remove and upload a valid file within the specified size constraints",
+                icon: "warning"
+            });
+            return;
+        }
+
         $(".max-charities-error").hide();
         $(".charity-error-hook").css("border","none")
 

--- a/resources/views/admin-pledge/submission-queue/partials/form.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/form.blade.php
@@ -387,12 +387,13 @@
                     </table>
                 </div>
 
-                <div class="col-md-12 upload-area"> <span style="padding:10px;">Browse to attach your completed PECSF Event Bank Deposit Form attachment (pdf,xls,xlsx,csv,png,jpg,jpeg) with bank receipt.</span>
+                <div class="col-md-12 upload-area"> 
+                    <p ><span class="font-weight-bold">Browse to attach your completed PECSF Event Bank Deposit Form attachment with bank receipt.</span><br>
+                        <em>(Please note that you can only upload files with a maximum size of 2MB each, in pdf, xls, xlsx, csv, png, jpg or jpeg format, and the total number of files should not exceed 5.)</em>
+                    </p>
 
                     <div class="needsclick dropzone" id="attachment-dropzone"></div>  
-                
                 </div>
-
 
                 {{-- <div style="padding:8px;" class="upload-area form-group col-md-3">
 

--- a/resources/views/volunteering/partials/add-event-js.blade.php
+++ b/resources/views/volunteering/partials/add-event-js.blade.php
@@ -342,6 +342,25 @@ var formData = new FormData();
         e.preventDefault();
         var form = document.getElementById("create_pool");
 
+        total_count = $('#bank_deposit_form .dropzone .dz-complete').length;
+        error_count = $('#bank_deposit_form .dropzone .dz-error').length;
+        if (total_count > 5 ) {
+            Swal.fire({
+                title: "Problem on upload files",
+                text: "You have reached the maximum number of allowed file uploads. To continue, please remove some files from your current selection and try again.",
+                icon: "warning"
+            });
+            return; 
+        }
+        if (error_count > 0 ) {
+            Swal.fire({
+                title: "Problem on upload files",
+                text: "You have uploaded some unsupported format or file size exceeds limit file(s). Please remove and upload a valid file within the specified size constraints",
+                icon: "warning"
+            });
+            return;
+        }
+
         $(".max-charities-error").hide();
         $(".charity-error-hook").css("border","none")
 

--- a/resources/views/volunteering/partials/form.blade.php
+++ b/resources/views/volunteering/partials/form.blade.php
@@ -405,9 +405,9 @@
 
 
                 <div class="col-md-12">
-                    <p class="pl-1">Browse to attach your completed
-                        PECSF Event Bank Deposit Form attachment (pdf,xls,xlsx,csv,png,jpg,jpeg) with bank
-                        receipt.</p>
+                    <p ><span class="font-weight-bold">Browse to attach your completed PECSF Event Bank Deposit Form attachment with bank receipt.</span><br>
+                        <em>(Please note that you can only upload files with a maximum size of 2MB each, in pdf, xls, xlsx, csv, png, jpg or jpeg format, and the total number of files should not exceed 5.)</em>
+                    </p>
                 </div>
 
                 <div class="col-md-12">


### PR DESCRIPTION
Merged with jp-0066 and avoid code conflict.

This pull request contains 2 tickets:

[jp-0070 <-- jp-0066] eForm - When user attaches Multiple files to eform, some of the files are missing in admin-event pledge,
[jp-0070 <-- jp-0066] eForm - store eForm Attachments in Database instead of system folder

Additional change required -- display error message when submit