### PR TITLE
[jp-0070][<--jp-0066] 8th commit -- eform attachment functionality (max attachemnt is 3)

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -151,7 +151,7 @@ class BankDepositFormController extends Controller
 
             'description' => 'required',
             // 'attachments.*' => 'required|mimes:pdf,xls,xlsx,csv,png,jpg,jpeg',
-            'attachments' => "required|max:5",
+            'attachments' => "required|max:3",
         ],[
 
             'organization_code' => 'The Organization Code is required.',
@@ -527,7 +527,7 @@ class BankDepositFormController extends Controller
         $bu_election_bc = BusinessUnit::where('code', 'BC015')->first();
 
         $no_of_attachments = BankDepositFormAttachments::where('bank_deposit_form_id', $request->form_id)->count();
-        $max_attachments = 5 - $no_of_attachments;
+        $max_attachments = 3 - $no_of_attachments;
 
         $validator = Validator::make(request()->all(), [
             'organization_code'         => 'required',

--- a/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
@@ -317,7 +317,7 @@ var formData = new FormData();
         exist_count = $('table#attachments .filename').length;
         total_count = $('#bank_deposit_form .dropzone .dz-complete').length;
         error_count = $('#bank_deposit_form .dropzone .dz-error').length;
-        if (total_count > (5 - exist_count) ) {
+        if (total_count > (3 - exist_count) ) {
             Swal.fire({
                 title: "Problem on upload files",
                 text: "You have reached the maximum number of allowed file uploads. To continue, please remove some files from your current selection and try again.",

--- a/resources/views/admin-pledge/submission-queue/partials/form.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/form.blade.php
@@ -368,7 +368,7 @@
 
 
             <div class="form-row form-header">
-                            <h3 class="blue">File(s)</h3>
+                <h3>Attach/Upload Document(s)</h3>
 
 
                 <span class="pl-3 attachments_errors errors">

--- a/resources/views/admin-pledge/submission-queue/partials/form.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/form.blade.php
@@ -389,7 +389,7 @@
 
                 <div class="col-md-12 upload-area"> 
                     <p ><span class="font-weight-bold">Browse to attach your completed PECSF Event Bank Deposit Form attachment with bank receipt.</span><br>
-                        <em>(Please note that you can only upload files with a maximum size of 2MB each, in pdf, xls, xlsx, csv, png, jpg or jpeg format, and the total number of files should not exceed 5.)</em>
+                        <em>(Please note that you can only upload files with a maximum size of 2MB each, in pdf, xls, xlsx, csv, png, jpg or jpeg format, and the total number of files should not exceed 3.)</em>
                     </p>
 
                     <div class="needsclick dropzone" id="attachment-dropzone"></div>  

--- a/resources/views/volunteering/partials/add-event-js.blade.php
+++ b/resources/views/volunteering/partials/add-event-js.blade.php
@@ -344,7 +344,7 @@ var formData = new FormData();
 
         total_count = $('#bank_deposit_form .dropzone .dz-complete').length;
         error_count = $('#bank_deposit_form .dropzone .dz-error').length;
-        if (total_count > 5 ) {
+        if (total_count > 3 ) {
             Swal.fire({
                 title: "Problem on upload files",
                 text: "You have reached the maximum number of allowed file uploads. To continue, please remove some files from your current selection and try again.",

--- a/resources/views/volunteering/partials/dropzone-js.blade.php
+++ b/resources/views/volunteering/partials/dropzone-js.blade.php
@@ -75,7 +75,7 @@
     Dropzone.options.attachmentDropzone = {
         url: '{{ route("bank_deposit_form.storeMedia") }}',
         maxFilesize: 2, // MB
-        maxFiles: 5,        
+        // maxFiles: 5,        
         // autoQueue: false,
         dictDefaultMessage: "<strong>Drop files here or click to upload. </strong>",
         previewTemplate: document.querySelector("#my-template").innerHTML,

--- a/resources/views/volunteering/partials/form.blade.php
+++ b/resources/views/volunteering/partials/form.blade.php
@@ -406,7 +406,7 @@
 
                 <div class="col-md-12">
                     <p ><span class="font-weight-bold">Browse to attach your completed PECSF Event Bank Deposit Form attachment with bank receipt.</span><br>
-                        <em>(Please note that you can only upload files with a maximum size of 2MB each, in pdf, xls, xlsx, csv, png, jpg or jpeg format, and the total number of files should not exceed 5.)</em>
+                        <em>(Please note that you can only upload files with a maximum size of 2MB each, in pdf, xls, xlsx, csv, png, jpg or jpeg format, and the total number of files should not exceed 3.)</em>
                     </p>
                 </div>
 

--- a/resources/views/volunteering/partials/form.blade.php
+++ b/resources/views/volunteering/partials/form.blade.php
@@ -389,7 +389,7 @@
 
 
             <div class="form-row form-header">
-                <h3 class="blue">File(s)</h3>
+                <h3>Attach/Upload Document(s)</h3>
 
 
                 <span class="pl-3 attachments_errors errors">


### PR DESCRIPTION
Merged with jp-0066 and avoid code conflict.

This pull request contains 2 tickets:

[jp-0070 <-- jp-0066] eForm - When user attaches Multiple files to eform, some of the files are missing in admin-event pledge,
[jp-0070 <-- jp-0066] eForm - store eForm Attachments in Database instead of system folder

Additional change required -- max upload files is 3 