### PR TITLE
[jp-0065] DEV - Admin report list - Charity Amount (issue 5 on FSP event pledge no breakdown)

### DIFF
--- a/app/Exports/PledgeCharitiesExport.php
+++ b/app/Exports/PledgeCharitiesExport.php
@@ -511,14 +511,14 @@ class PledgeCharitiesExport implements FromQuery, WithHeadings, WithMapping, Wit
                 $calc_total = 0;
                 $goal_amount = $event->deposit_amount;
 
-                foreach( $pool->charities as $index => $pool_charity) {
+                // foreach( $pool->charities as $index => $pool_charity) {
 
-                    if ($index === count( $pool->charities ) - 1  ) {
-                        $calc_amount = $goal_amount - $calc_total;
-                    } else {
-                        $calc_amount = round( $pool_charity->percentage * $goal_amount /100 ,2); 
-                        $calc_total += $calc_amount;
-                    }
+                //     if ($index === count( $pool->charities ) - 1  ) {
+                //         $calc_amount = $goal_amount - $calc_total;
+                //     } else {
+                //         $calc_amount = round( $pool_charity->percentage * $goal_amount /100 ,2); 
+                //         $calc_total += $calc_amount;
+                //     }
 
                     \App\Models\PledgeCharityStaging::insert([
                         'history_id' => $this->history_id,
@@ -545,13 +545,13 @@ class PledgeCharitiesExport implements FromQuery, WithHeadings, WithMapping, Wit
                         'created_at' => $event->created_at,
                         'updated_at' => $event->updated_at,
 
-                        'charity_id' => $pool_charity->charity_id,
-                        'percentage' => $pool_charity->percentage,
-                        'supported_program' => $pool_charity->name,
-                        'prorate_amount' => $calc_amount,
+                        'charity_id' => null,               // $pool_charity->charity_id,
+                        'percentage' => 0,                  // $pool_charity->percentage,
+                        'supported_program' => null,        // $pool_charity->name,
+                        'prorate_amount' => 0,              // $calc_amount,
 
                     ]);
-                }
+                // }
 
             } else {
 


### PR DESCRIPTION
Create a new tab in the reporting section called Program reports. 
Put reports underneath:
- Pledges and events report
- Amount by charity report
- Charity report
- Eligible employee report (lowest priority - Post MVP - Just noted here to show which reports should live together)


LA - BU(Business unit) is BC002
LDB - BU is BCLDB
BCS - BU is BCSC
RET - BU is BC000

March  28 - Disucss with Nancy on the no campiagn year stored in the event transaction, which required for reporting purpose
March 29, 30  -- WIP on the CRA charities report
April 4 - Update the program for using the stored 'Campiagn Year' value in table "Bank Deposit form" as criteria.
April 5 -- Deployed on DEV and TEST regions with 3 reports under Administration > Reporting -> Progarm reports
1) Annual and Event Pledges
2) Amount by Charity
3) Charity

Nov 6 - retest the scenario since we did a lots of changes on the eForm 
Nov 15 - re-tested and made notes; Assigned back to James for updates.
Nov 17 - WIP
Nov 20 - Program was improved per request, and also added additional column (Q - Pool region name)
1) Change the Excel report title 
2) Fix the column A header typo - No completed in test
3) Remove the header info (Rows 1-3); Start at Row 4 
4) departname ID and Name should be based on pledges instead of the current demography data 

Nov 21 - Updated notes; Issue 2 above has not been addressed. 
Nov 30 - (JP) Issue 2 and 5 were addressed and program was revised per request. 
Dec 1 -- Deployed the new program on DEV and TEST. Ready for testing
Dec 5 - Tested; Issue 5 [FSP shows as 1 line rather than many] needs resolution for eForm pledges