### PR TITLE
[jp-0065] DEV - Admin report list - Charity Amount (incorrect calendar year in event pledge)

### DIFF
--- a/app/Exports/PledgeCharitiesExport.php
+++ b/app/Exports/PledgeCharitiesExport.php
@@ -464,7 +464,7 @@ class PledgeCharitiesExport implements FromQuery, WithHeadings, WithMapping, Wit
 
 
         $events = BankDepositForm::selectRaw("bank_deposit_forms.* 
-                            ,year(bank_deposit_forms.created_at) as calendar_year
+                            ,campaign_years.calendar_year as calendar_year
                             ,CASE WHEN bank_deposit_forms.organization_code = 'GOV'
                                 THEN employee_jobs.name
                                 ELSE ''

--- a/app/Exports/PledgeCharitiesExport.php
+++ b/app/Exports/PledgeCharitiesExport.php
@@ -465,17 +465,17 @@ class PledgeCharitiesExport implements FromQuery, WithHeadings, WithMapping, Wit
 
         $events = BankDepositForm::selectRaw("bank_deposit_forms.* 
                             ,campaign_years.calendar_year as calendar_year
-                            ,CASE WHEN bank_deposit_forms.organization_code = 'GOV'
+                            ,CASE WHEN bank_deposit_forms.bc_gov_id is not null
                                 THEN employee_jobs.name
-                                ELSE ''
+                                ELSE bank_deposit_forms.employee_name
                             END as name
                             ,(select code from business_units where business_units.id = bank_deposit_forms.business_unit) as business_unit_code
                             ,(select code from regions where regions.id = bank_deposit_forms.region_id) as tgb_reg_district
                             ,bank_deposit_forms.deptid as deptid
                             ,bank_deposit_forms.dept_name as dept_name
-                            ,CASE WHEN bank_deposit_forms.organization_code = 'GOV'
+                            ,CASE WHEN bank_deposit_forms.bc_gov_id is not null
                                 THEN employee_jobs.office_city
-                                ELSE bank_deposit_forms.address_city
+                                ELSE bank_deposit_forms.employment_city
                             END as city
                             ,CASE when regional_pool_id is not NULL 
                                 THEN 'P'


### PR DESCRIPTION
Create a new tab in the reporting section called Program reports. 
Put reports underneath:
- Pledges and events report
- Amount by charity report
- Charity report
- Eligible employee report (lowest priority - Post MVP - Just noted here to show which reports should live together)


LA - BU(Business unit) is BC002
LDB - BU is BCLDB
BCS - BU is BCSC
RET - BU is BC000

March  28 - Disucss with Nancy on the no campiagn year stored in the event transaction, which required for reporting purpose
March 29, 30  -- WIP on the CRA charities report
April 4 - Update the program for using the stored 'Campiagn Year' value in table "Bank Deposit form" as criteria.
April 5 -- Deployed on DEV and TEST regions with 3 reports under Administration > Reporting -> Progarm reports
1) Annual and Event Pledges
2) Amount by Charity
3) Charity

Nov 6 - retest the scenario since we did a lots of changes on the eForm 
Nov 15 - re-tested and made notes; Assigned back to James for updates.
Nov 17 - WIP
Nov 20 - Program was improved per request, and also added additional column (Q - Pool region name)
1) Change the Excel report title 
2) Fix the column A header typo - No completed in test
3) Remove the header info (Rows 1-3); Start at Row 4 
4) departname ID and Name should be based on pledges instead of the current demography data 

Nov 21 - Updated notes; Issue 2 above has not been addressed. 
Nov 30 - (JP) Issue 2 and 5 were addressed and program was revised per request. 
Dec 1 -- Deployed the new program on DEV and TEST. Ready for testing
Dec 5 - Tested; Issue 5 [FSP shows as 1 line rather than many] needs resolution for eForm pledges
Dec 7 - (JP) Issue 5 -- FSP on event pledge shouldn't show breakdown. Fixed and redeployed on DEV & TEST. 
Dec 7 - (JP) Fixed incorrect calendar year on event pledge. 