### PR TITLE
 [jp-0072] eForm - Matching eForms to campaigns

### DIFF
--- a/app/Http/Controllers/Admin/EventSubmissionQueueController.php
+++ b/app/Http/Controllers/Admin/EventSubmissionQueueController.php
@@ -145,7 +145,8 @@ class EventSubmissionQueueController extends Controller
      * @return \Illuminate\Http\Response
      */
     public function details(Request $request){
-        $submissions = BankDepositForm::selectRaw("*,bank_deposit_forms.id as bank_deposit_form_id, campaign_years.calendar_year as calendar_year")
+        $submissions = BankDepositForm::selectRaw("*,bank_deposit_forms.id as bank_deposit_form_id,
+                     campaign_years.calendar_year as calendar_year, campaign_years.id as calendar_year_id")                    
             ->where("bank_deposit_forms.id","=",$request->form_id)
             ->join("users","bank_deposit_forms.form_submitter_id","=","users.id")
             ->join("campaign_years","bank_deposit_forms.campaign_year_id","=","campaign_years.id")

--- a/resources/views/admin-pledge/submission-queue/index.blade.php
+++ b/resources/views/admin-pledge/submission-queue/index.blade.php
@@ -214,7 +214,9 @@
                     $("[name='event_type']").trigger("change");                    
                     $("#deposit_amount").val(data[0].deposit_amount);
                     $("#deposit_date").val(data[0].deposit_date);
-                    $("#campaign_year").html( (data[0].calendar_year - 1));
+                    // $("#campaign_year").html( (data[0].calendar_year - 1));
+                    $("input.calendar_year").val( (data[0].calendar_year - 1));
+                    $("input[name='campaign_year']").val( data[0].calendar_year_id );
                     $("#employee_name").val(data[0].employee_name);
 
                     if(data[0].event_type == "Fundraiser" || data[0].event_type == "Gaming"){                        


### PR DESCRIPTION
Nov 23 - Confirm if/what programming has been done (e.g. When does eForm start to show Campaign 2024)? Think always Sept 1.
Dec 13 - (JP) Review the current logic in source code, is based on Jan 1 - Dec 31 to determine the current year as a campaign year (e.g. Jan-1-2023, the camapign year is 2023 and calendar year is 2024). Are you consider use Sept 1, as a cut-off date. This mean before Sept 1, 2023, is campaig year 2022, after or on Sept 1, 2023 is camapign year 2023.
Dec 13 - eForm logic needs to follow campaign logic. eForms submitted between Sept 1 2023- Aug 31, 2024 need to fall under campaign 2023 for calendar year 2024. Campaign 2024 should start on September 1, 2024.
Dec 13 - get the confirmation from Nancy and start working on this ticket. It must be deployed before Jan 1, 2024.

Dec 14 - fix the campaign year issue on detail view page under submission queue

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/HnglL5Unu0GJTh22RoD9yWUAJcWS?Type=TaskLink&Channel=Link&CreatedTime=638380911128810000)