### PR TITLE
(MASTER) [jp-0074] Fatal Error when access ‘create’ action on Special Campaign Setup (Admin)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -252,7 +252,7 @@ Route::middleware(['auth'])->prefix('settings')->name('settings.')->group(functi
 
     // Special Campaign Setup
     Route::get('/special-campaigns/charities', [SpecialCampaignSetupController::class,'getCharities']);
-    Route::resource('/special-campaigns', SpecialCampaignSetupController::class);
+    Route::resource('/special-campaigns', SpecialCampaignSetupController::class)->except('create');
 
     // Fund Supported Pools
     Route::get('/fund-supported-pools/charities', [FundSupportedPoolController::class,'getCharities']);


### PR DESCRIPTION
Issue: Fatal error when access ‘create’ action on Special Campaign Setup

http://domain:port/settings/special-campaigns/create

Action Required:
When declaring a resource route, have to specify a subset of actions the controller should handle instead of the full set of default actions.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/7BujhHc_YE2M0Inr47FXT2UAF2B-?Type=TaskLink&Channel=Link&CreatedTime=638381657894160000)