### PR TITLE
[jp-0079] Challenge page - Report - Only show "active" Business Units

### DIFF
--- a/app/Http/Controllers/Admin/ChallengePageDataReportController.php
+++ b/app/Http/Controllers/Admin/ChallengePageDataReportController.php
@@ -45,6 +45,7 @@ class ChallengePageDataReportController extends Controller
                 where campaign_year = ?
                 and as_of_date = ?
                 and daily_type = 0     
+                and business_unit in (select code from business_units where status = 'A')                
                 order by participation_rate desc, abs(change_rate);     
 
             SQL;


### PR DESCRIPTION
BC0601 is inactive and doesn't need to show in the report
BC006 is inactive and doesn't need to show in the report

Confirm with Gillian/FMO - What is the use case for having BC000 - Government of B.C. as a BU?

Dec 27 -- exclude the inactive business unit on the challenge data report