### PR TITLE
(TEST) [jp-0082] Challenge page data report - Stats cleared after new year

### DIFF
--- a/app/Console/Commands/UpdateDailyCampaign.php
+++ b/app/Console/Commands/UpdateDailyCampaign.php
@@ -151,7 +151,7 @@ class UpdateDailyCampaign extends Command
             // Step 1A
             $this->LogMessage("Updating daily campaign by business units");
 
-            $campaign_year = today()->year;
+            // $campaign_year = today()->year;
 
             $history = HistoricalChallengePage::select('year')
                                     ->where('year', '<', $campaign_year)


### PR DESCRIPTION
Issue - Challenge page stats should "freeze" when the campaign is finalized and should only reset on September 1st.

Jan 4 - bug in the Daily UpdateDailyCampaign process caused the progress try to create 2024 campaign year data.  