### PR TITLE
(MASTER) [jp-0075] To arrange the several schedule processes from daily to weekly 

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -118,7 +118,7 @@ class Kernel extends ConsoleKernel
 
                 $schedule->command('command:ImportCities')
                         ->skip(function () {
-                                return CampaignYear::isAnnualCampaignOpenNow() or (today()->dayOfWeek == 1);
+                                return (!(CampaignYear::isAnnualCampaignOpenNow())) and (today()->dayOfWeek != 1);
                         })
                         ->weekdays()
                         ->at('2:30')
@@ -126,7 +126,7 @@ class Kernel extends ConsoleKernel
 
                 $schedule->command('command:ImportDepartments')
                         ->skip(function () {
-                                return CampaignYear::isAnnualCampaignOpenNow() or (today()->dayOfWeek == 1);
+                                return (!(CampaignYear::isAnnualCampaignOpenNow())) and (today()->dayOfWeek != 1);
                         })
                         ->weekdays()
                         ->at('2:35')

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,6 +3,7 @@
 namespace App\Console;
 
 use App\Models\Pledge;
+use App\Models\CampaignYear;
 use Illuminate\Support\Facades\App;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
@@ -99,7 +100,8 @@ class Kernel extends ConsoleKernel
 
                 // Foundation table
                 $schedule->command('command:ImportPayCalendar')
-                        ->weekdays()
+                        ->weekly()
+                        ->mondays()
                         ->at('2:00')
                         //  ->everyFifteenMinutes()
                         ->sendOutputTo(storage_path('logs/ImportPayCalendar.log'));
@@ -115,12 +117,17 @@ class Kernel extends ConsoleKernel
                 //         ->sendOutputTo(storage_path('logs/ImportPledgeHistory.log'));    
 
                 $schedule->command('command:ImportCities')
-                        //  ->yearlyOn(9, 1, '02:30')
+                        ->skip(function () {
+                                return CampaignYear::isAnnualCampaignOpenNow() or (today()->dayOfWeek == 1);
+                        })
                         ->weekdays()
                         ->at('2:30')
                         ->sendOutputTo(storage_path('logs/ImportCities.log')); 
 
                 $schedule->command('command:ImportDepartments')
+                        ->skip(function () {
+                                return CampaignYear::isAnnualCampaignOpenNow() or (today()->dayOfWeek == 1);
+                        })
                         ->weekdays()
                         ->at('2:35')
                         ->sendOutputTo(storage_path('logs/ImportDepartments.log'));


### PR DESCRIPTION
Dec 13 - Confirmed with Nancy
Cities and departments should update with the same timeline as Business Unit. If this data updates at different times, it could cause data issues for our reports. Currently, this is daily, I believe. This works for campaign! If you're asking to improve efficiency, these items could be updated weekly outside of campaign. The pay calendar could go weekly at any time.

Import Pay Calendar (every Monday)
ImportCities (every Monday or every weekday during campaign period)
ImportDepartments (every Monday or every weekday during campaign period)