### PR TITLE
[jp-0083] BC0000 - Clean up and re-assignment

### DIFF
--- a/database/seeders/DataFixFor_jp_0083.php
+++ b/database/seeders/DataFixFor_jp_0083.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0083 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+        DB::update('update bank_deposit_forms set business_unit = (select id from business_units where code = :bu), updated_at = now() where id in (85,93,150,151,152,153)', ['bu'=> 'BC120']);
+        DB::update('update bank_deposit_forms set business_unit = (select id from business_units where code = :bu), updated_at = now() where id = 97', ['bu'=> 'BC031']);
+    }
+}


### PR DESCRIPTION
7 events show under BU0000. This has been deactivated and shouldn't have any entries. 7 current entries need BU updated. See attached spreadsheet.

Jan 8  -- per request, create a seeder file to run the following SQL scripts 

update bank_deposit_forms set business_unit = 29, updated_at = now() where id in (85,93,150,151,152,153);
update bank_deposit_forms set business_unit = 13, updated_at = now() where id = 97;

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/zeFSeQwe_ECek68mJsnmu2UAA287?Type=TaskLink&Channel=Link&CreatedTime=638403375869050000)