### PR TITLE
[jp-0085] For PS interface, the start date on 'Annual Campaign pledge is the next upcoming check date

### DIFF
--- a/app/Console/Commands/ExportPledgesToPSFT.php
+++ b/app/Console/Commands/ExportPledgesToPSFT.php
@@ -195,7 +195,10 @@ class ExportPledgesToPSFT extends Command
             $period = PayCalendar::where('check_dt', '>=',  $check_dt)->orderBy('check_dt')->first();
             $start_date = $period ? $period->check_dt : $check_dt;
             $end_date   = $pledge->campaign_year->calendar_year . '-12-31';
-
+            if (today() >= $check_dt) {
+                $period = PayCalendar::whereRaw("DATE_SUB(check_dt, INTERVAL 8 DAY) > '". today()->format('Y-m-d') ."'")->orderBy('check_dt')->first(); 
+                $start_date = $period ? $period->check_dt : $start_date;
+            }
 
             $one_time_sent = false;
             $pay_period_sent = false;


### PR DESCRIPTION
Jan 10 - Per Jon's request. the start date on the Annual Campaign pledge transactions should the next pay check date, with 8 days grace period (pay check date - 8 days) comparing to the current date of the export process.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/KYb_wCwY5EKW7cD4yUOL2GUALWUY?Type=TaskLink&Channel=Link&CreatedTime=638405130548880000)