### PR TITLE
(TEST) [jp-0087] eform -- Fix PECSF_ID assignment with correct campaign year and Campaign years need to overlap with calendar years 

### DIFF
--- a/app/Http/Controllers/Admin/MaintainEventPledgeController.php
+++ b/app/Http/Controllers/Admin/MaintainEventPledgeController.php
@@ -159,7 +159,11 @@ class MaintainEventPledgeController extends Controller
             ->where('status', 'A')
             ->get();
         $regional_pool_id = $pools->count() > 0 ? $pools->first()->id : null;
-        $business_units = BusinessUnit::where("status","=","A")->whereColumn("code","linked_bu_code")->groupBy("linked_bu_code")->orderBy("name")->get();
+        // $business_units = BusinessUnit::where("status","=","A")->whereColumn("code","linked_bu_code")->groupBy("linked_bu_code")->orderBy("name")->get();
+        $business_units = BusinessUnit::where("status","=","A")
+            ->whereColumn("code","linked_bu_code")
+            ->selectRaw("business_units.id, business_units.code, business_units.name, (select code from organizations where organizations.bu_code = business_units.code limit 1 ) as org_code ")
+            ->groupBy("linked_bu_code")->orderBy("name")->get();
         $regions = Region::where("status","=","A")->get();
         $departments = Department::all();
         $campaign_year = CampaignYear::where('start_date', '<=', today() )->orderBy('calendar_year', 'desc')->first();

--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -364,7 +364,7 @@ class BankDepositFormController extends Controller
 
         $organization_code = $request->organization_code;
         $event_type = $request->event_type;
-        $pecsf_id = $this->assign_pecsf_id($organization_code, $event_type );
+        $pecsf_id = $this->assign_pecsf_id($request->campaign_year, $organization_code, $event_type );
         // if($organization_code == "RET"){ //R****  PECSF ID
         //     $existing = BankDepositForm::where("pecsf_id","LIKE","R".substr(date("Y"),2,2)."%")
         //         ->orderBy("pecsf_id","desc")
@@ -800,13 +800,13 @@ class BankDepositFormController extends Controller
         $pecsf_id = $request->pecsf_id;
         $prefix = substr($pecsf_id,0,1);
         if ($organization_code == "RET" && $prefix != 'R') { //R****  PECSF ID
-            $pecsf_id = $this->assign_pecsf_id($organization_code, $event_type );        
+            $pecsf_id = $this->assign_pecsf_id($request->campaign_year, $organization_code, $event_type );        
         } else {
 
             if (($event_type == "Fundraiser" &&  $prefix != 'F') ||
                 ($event_type == "Gaming" &&  $prefix != 'G') ||
                 ( substr($event_type,0,1) == 'C' &&  $prefix != 'S') ) {
-                $pecsf_id = $this->assign_pecsf_id($organization_code, $event_type );        
+                $pecsf_id = $this->assign_pecsf_id($request->campaign_year, $organization_code, $event_type );        
             } else {
                 //do nothing, we don't support one-time cheque/cash donation for non-GOV organziations.
             }
@@ -1069,12 +1069,13 @@ class BankDepositFormController extends Controller
             return response()->json(['msg' => $msg]);
         }
 
-    public function assign_pecsf_id( $organization_code, $event_type) 
+    public function assign_pecsf_id( $campaign_year_id, $organization_code, $event_type) 
     {
 
         $pecsf_id = null;
         $prefix = '';
-        $yy = substr(date("Y"),2,2);
+        $campaign_year = CampaignYear::where('id', $campaign_year_id )->first();
+        $yy = substr( ($campaign_year->calendar_year - 1) ,2,2);
         $seq = '001';
 
         switch ($organization_code) {

--- a/database/seeders/DataFixFor_jp_0087_reset_approval.php
+++ b/database/seeders/DataFixFor_jp_0087_reset_approval.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0087_reset_approval extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+        DB::update("update bank_deposit_forms set pecsf_id = null, approved = 0, approved_by_id = null, approved_at = null, updated_at = now() where SUBSTRING( pecsf_id, 2, 2) = '24'");
+    }
+}

--- a/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/add-event-js.blade.php
@@ -447,6 +447,7 @@ var formData = new FormData();
     });
 
 $('#organization_code').select2({
+    minimumResultsForSearch: -1,
 ajax: {
 url: '/bank_deposit_form/organization_code',
 dataType: 'json'


### PR DESCRIPTION
Jan 16 - Campaign years need to overlap with calendar years. E.g. Campaign 2023 opened on September 1, 2023, and will continue through til next campaign opens on September 1, 2024. Any funds reported using eForm should continue to be labelled as Campaign 2023 until that time.
Jan 16 - The previous ticket "[jp-0072] eForm - Matching eForms to campaigns" already take care the campaign year logic based on the open date of the campaign year setting to determine the campaign year. This ticket issue is mainly on PECSF_ID assignment, the year should be the campaign year instead of current year.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/B24UAhvGnUiayiRz_h9fo2UAKulm?Type=TaskLink&Channel=Link&CreatedTime=638410294883270000)