### PR TITLE
(MASTER) [jp-0086] Avoid to change 'updated_at' when the pledge scucessfully sent to PS

### DIFF
--- a/app/Console/Commands/ExportPledgesToPSFT.php
+++ b/app/Console/Commands/ExportPledgesToPSFT.php
@@ -289,6 +289,7 @@ class ExportPledgesToPSFT extends Command
 
                 $pledge->ods_export_status = 'C';
                 $pledge->ods_export_at = Carbon::now()->format('c');
+                $pledge->timestamps = false;
                 $pledge->save();
 
                 $this->LogMessage( "    Transaction {$pledge->id} has been sent - " . json_encode( $pledge ) );
@@ -413,6 +414,7 @@ class ExportPledgesToPSFT extends Command
                     // Update the complete flag in pledge table
                     $pledge->ods_export_status = 'C';
                     $pledge->ods_export_at = Carbon::now()->format('c');
+                    $pledge->timestamps = false;
                     $pledge->save();
 
                     // Log Message                 
@@ -529,6 +531,7 @@ class ExportPledgesToPSFT extends Command
                     // Update the complete flag in pledge table
                     $pledge->ods_export_status = 'C';
                     $pledge->ods_export_at = Carbon::now()->format('c');
+                    $pledge->timestamps = false;
                     $pledge->save();
 
                     // Log Message                 


### PR DESCRIPTION
Jan 16 -- The "updated_at" value should not be changed when the pledge was successfully sent to PS. The schedule process "ExportPledgesToPSFT.php" need to revise.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/pMxt1Hbjy0yTCwgtcMtNH2UAKJnu?Type=TaskLink&Channel=Link&CreatedTime=638410201570380000)