### PR TITLE
[jp-0093] Admin: Donate Now - FSP field needs clean up

### DIFF
--- a/app/Http/Controllers/Admin/DonateNowPledgeController.php
+++ b/app/Http/Controllers/Admin/DonateNowPledgeController.php
@@ -183,7 +183,7 @@ class DonateNowPledgeController extends Controller
         $pledge->deduct_pay_from = PayCalendar::nextDeductPayFrom();
 
         $pool_option = 'P';
-        $fspools = FSPool::current()->get()->sortBy(function($pool, $key) {
+        $fspools = FSPool::current()->where('status', 'A')->get()->sortBy(function($pool, $key) {
             return $pool->region->name;
         });
 
@@ -310,7 +310,7 @@ class DonateNowPledgeController extends Controller
         }
 
         // Prepare for display
-        $fspools = FSPool::current()->get()->sortBy(function($pool, $key) {
+        $fspools = FSPool::current()->where('status','A')->get()->sortBy(function($pool, $key) {
             return $pool->region->name;
         });
 


### PR DESCRIPTION
As we have cleaned up the list of FSP in donations, we need to do that clean up in the FSP option in Donate Now
It should only show "active, current" FSPs.
Admin -> Maintain Donate Now Pledge -> Create New Pledge ->FSP

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/GqKA8TCIWkSDRG3yzV1YAWUAJkFR?Type=TaskLink&Channel=Link&CreatedTime=638419022253440000)