### PR TITLE
(TEST) [jp-0094] Admin - Maintain EE pledges - Clean up FSP options to only show active

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -177,7 +177,7 @@ class CampaignPledgeController extends Controller
     {
         //
         $pool_option = 'P';
-        $fspools = FSPool::current()->get()->sortBy(function($pool, $key) {
+        $fspools = FSPool::current()->where('status','A')->get()->sortBy(function($pool, $key) {
             return $pool->region->name;
         });
 
@@ -469,7 +469,7 @@ class CampaignPledgeController extends Controller
             return abort(404);      // 404 Not Found
         }
 
-        $fspools = FSPool::current()->get()->sortBy(function($pool, $key) {
+        $fspools = FSPool::current()->where('status','A')->get()->sortBy(function($pool, $key) {
             return $pool->region->name;
         });
 


### PR DESCRIPTION
As we have cleaned up the list of FSP in donations, we need to do that clean up in the FSP option in Annual Campaign Pledges.
It should only show "active, current" FSPs.
Admin -> Maintain EE Pledge -> Create/Edit New Pledge ->FSP

https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/NAUcyODuekKur5WlU9mpZmUAAeKM?Type=TaskLink&Channel=Link&CreatedTime=638421440144700000

