### PR TITLE
(TEST) [jp-0097] Breadcrumb in Special Campaign is not clickable

### DIFF
--- a/resources/views/special-campaign/wizard.blade.php
+++ b/resources/views/special-campaign/wizard.blade.php
@@ -269,6 +269,23 @@
 
 $(function () {
 
+    // treat browser back button like the 'back' button in this wizard page
+    history.pushState(null, null, location.href);
+    window.addEventListener('popstate', function(event) {
+        url = this.location.href;
+        if (url.indexOf('special-campaign/create')) {
+            current_step = $("input[type=hidden][name='step']").val();
+            if (current_step == 1) {
+                // back
+                $(".cancel").trigger("click");
+            } else {
+                history.pushState(null, null, location.href);
+                $('.modal').modal('hide');
+                $(".back").trigger("click");
+            }
+        }
+    });
+
     $('#special-campaign-pledge-form').on('keyup keypress', function(e) {
         var keyCode = e.keyCode || e.which;
         if (keyCode === 13) {
@@ -311,10 +328,47 @@ $(function () {
     $(".back").on("click", function() {
         if (step > 1) {
             step = step - 2;
-            $(".next").trigger("click");
+            // $(".next").trigger("click");
         }
+
+        // to show current and hide other tabs
+        if (step < $(".step").length) {
+            $(".step").show();
+            $(".step")
+                .not(":eq(" + step++ + ")")
+                .hide();
+            stepProgress(step);
+            $('#nav-tab li:nth-child(' + step +') a').tab('show');   // Select third tab
+        }
+
         hideButtons(step);
+        $(this).blur();
     });
+
+    // Click on Wizard STEP icon to jump to visited  page
+    $('ul.bs4-step-tracking li').on('click', function(e) {
+
+        if ($(this).hasClass('active') && ($(this).index() + 1 != step) ) {
+            step = $(this).index();
+            // $(".next").trigger("click");
+
+            // to show current and hide other tabs
+            if (step < $(".step").length) {
+                $(".step").show();
+                $(".step")
+                    .not(":eq(" + step++ + ")")
+                    .hide();
+                stepProgress(step);
+                $('#nav-tab li:nth-child(' + step +') a').tab('show');   // Select third tab
+            }
+
+            // Update nav buttons
+            hideButtons(step);
+            $(this).blur();
+        }
+
+    })
+
 
     // CALCULATE PROGRESS BAR
     stepProgress = function(currstep) {
@@ -338,6 +392,10 @@ $(function () {
 
     // DISPLAY AND HIDE "NEXT", "BACK" AND "SUMBIT" BUTTONS
     hideButtons = function(step) {
+
+        // sync variable and the hidden variable
+        $("input[type=hidden][name='step']").val( step );
+
         var limit = parseInt($(".step").length);
         $(".action").hide();
         if (step < limit) {


### PR DESCRIPTION
The breadcrumb in the Special campaign donation flow is not clickable and user cannot go back and forth using the breadcrumb. Can we replicate the functionality from the Annual Donations flow?

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ZSHCQCLp7E2XWHqIXCXwGWUAOO4f?Type=TaskLink&Channel=Link&CreatedTime=638422489338110000)