### PR TITLE
(TEST) [jp-0097] Breadcrumb in Special Campaign is not clickable (2nd commit - change cursor to pointer when hover)

### DIFF
--- a/resources/views/special-campaign/wizard.blade.php
+++ b/resources/views/special-campaign/wizard.blade.php
@@ -211,6 +211,11 @@
     background: #1a5a96;
 }
 
+.bs4-step-tracking li.active:hover {
+    cursor: pointer;
+}
+
+
     #nav-tab li:not(.active)  a{
         pointer-events: none;
         color: #555;


### PR DESCRIPTION
The breadcrumb in the Special campaign donation flow is not clickable and user cannot go back and forth using the breadcrumb. Can we replicate the functionality from the Annual Donations flow?

Additional change: A little fix is still needed. The breadcrumb is working good, but the cursor does not change to hand when hovered over.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ZSHCQCLp7E2XWHqIXCXwGWUAOO4f?Type=TaskLink&Channel=Link&CreatedTime=638422489338110000)

