### PR TITLE
(MASTER) [jp-0091] Edit Special campaign confirmation modal is missing the Campaign name

### DIFF
--- a/resources/views/admin-campaign/special-campaigns/index.blade.php
+++ b/resources/views/admin-campaign/special-campaigns/index.blade.php
@@ -464,6 +464,7 @@
             var formData = new FormData( document.getElementById("bu-edit-model-form") );
             formData.append('_method', 'PUT');
             var id = $("#bu-edit-model-form [name='id']").val();
+            var name = $("#bu-edit-model-form [name='name']").val();
 
             info = 'Confirm to update this record?';
             // if (confirm(info))


### PR DESCRIPTION
Issue: The confirmation modal displays the message but does not display the campaign name and rather displays “”

Fix: the program was missed to get the name for display in javascript.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/GLbd3yg6QUOJDzsp3XDf42UABD1I?Type=TaskLink&Channel=Link&CreatedTime=638418184582360000)