### PR TITLE
(MASTER) [jp-0096] Remove the time stamp from Special campaign donation history

### DIFF
--- a/resources/views/donations/partials/special-campaign-pledge-detail-modal.blade.php
+++ b/resources/views/donations/partials/special-campaign-pledge-detail-modal.blade.php
@@ -31,7 +31,7 @@
         <p class="font-weight-bold">Deduct from Pay</p>
       </div>
       <div class="col-8">
-        <p>{{ $check_dt }}</p>
+        <p>{{ $check_dt->format('Y-m-d') }}</p>
       </div>
     </div>
 


### PR DESCRIPTION
Remove the time stamp portion on field "Deduct pay from" in Special campaign donation history.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Ug_ZVn8xA0eUvo4prQpgn2UAHZBI?Type=TaskLink&Channel=Link&CreatedTime=638422475439520000)