### PR TITLE
[jp-0100] Donation: Display Dollar Amount besides the % in Donationn Distributions

### DIFF
--- a/resources/views/annual-campaign/partials/amount-distribution.blade.php
+++ b/resources/views/annual-campaign/partials/amount-distribution.blade.php
@@ -37,12 +37,12 @@
                     </div>
                 </div>
             </td>
-            <td style="width:140px" class="by-amount d-none">
+            <td style="width:140px" class="by-amount">
                 <div class="input-group input-group-sm mb-3">
                     <div class="input-group-prepend">
                         <span class="input-group-text">$</span>
                     </div>
-                    <input type="number" class="form-control form-control-sm amount-input" name="{{$keyCase}}Amount[{{ $charity['id'] }}]" placeholder="" value='{{ number_format($charity["$key_-amount-distribution"],2,'.','') }}'>
+                    <input type="number" class="form-control form-control-sm amount-input" name="{{$keyCase}}Amount[{{ $charity['id'] }}]" placeholder="" value='{{ number_format($charity["$key_-amount-distribution"],2,'.','') }}' readonly>
                 </div>
             </td>
             {{-- <td>
@@ -64,7 +64,7 @@
                     </div>
                 </div>
             </td>
-            <td class="by-amount d-none ">
+            <td class="by-amount">
                 <div class="input-group input-group-sm mb-3">
                     <div class="input-group-prepend">
                         <span class="input-group-text">$</span>

--- a/resources/views/annual-campaign/partials/distribution-js.blade.php
+++ b/resources/views/annual-campaign/partials/distribution-js.blade.php
@@ -10,13 +10,17 @@ $(function () {
         const frequency = '#oneTimeSection';
 
         if ($(this).attr('id') == "distributeByDollarOneTime") {
-            $("#oneTimeSection").find(".by-amount").removeClass("d-none");
-            $("#oneTimeSection").find(".by-percent").addClass("d-none");
+            // $("#oneTimeSection").find(".by-amount").removeClass("d-none");
+            // $("#oneTimeSection").find(".by-percent").addClass("d-none");
+            $("#oneTimeSection").find('td.by-amount input.amount-input').prop('readonly', false);
+            $("#oneTimeSection").find('td.by-percent input.percent-input').prop('readonly', true);
             $("#oneTimeSection").find(".percent-amount-text").html("Distribute by Percentage");
             // redistribute('amount', $("#oneTimeSection"));
         } else {
-            $("#oneTimeSection").find(".by-percent").removeClass("d-none");
-            $("#oneTimeSection").find(".by-amount").addClass("d-none");
+            // $("#oneTimeSection").find(".by-percent").removeClass("d-none");
+            // $("#oneTimeSection").find(".by-amount").addClass("d-none");
+            $("#oneTimeSection").find('td.by-amount input.amount-input').prop('readonly', true);
+            $("#oneTimeSection").find('td.by-percent input.percent-input').prop('readonly', false);
             $("#oneTimeSection").find(".percent-amount-text").html("Distribute by Dollar Amount");
             // redistribute('percent', $("#oneTimeSection"));
         }
@@ -27,13 +31,17 @@ $(function () {
         const frequency = '#oneTimeSection';
 
         if ($(this).attr('id') == "distributeByDollarBiWeekly") {
-            $("#biWeeklySection").find(".by-amount").removeClass("d-none");
-            $("#biWeeklySection").find(".by-percent").addClass("d-none");
+            // $("#biWeeklySection").find(".by-amount").removeClass("d-none");
+            // $("#biWeeklySection").find(".by-percent").addClass("d-none");
+            $("#biWeeklySection").find('td.by-amount input.amount-input').prop('readonly', false);
+            $("#biWeeklySection").find('td.by-percent input.percent-input').prop('readonly', true);
             $("#biWeeklySection").find(".percent-amount-text").html("Distribute by Percentage");
             // redistribute('amount', $("#biWeeklySection"));
         } else {
-            $("#biWeeklySection").find(".by-percent").removeClass("d-none");
-            $("#biWeeklySection").find(".by-amount").addClass("d-none");
+            // $("#biWeeklySection").find(".by-percent").removeClass("d-none");
+            // $("#biWeeklySection").find(".by-amount").addClass("d-none");
+            $("#biWeeklySection").find('td.by-amount input.amount-input').prop('readonly', true);
+            $("#biWeeklySection").find('td.by-percent input.percent-input').prop('readonly', false);
             $("#biWeeklySection").find(".percent-amount-text").html("Distribute by Dollar Amount");
             // redistribute('percent', $("#biWeeklySection"));
         }


### PR DESCRIPTION
The Donation Distributions on Step 4 right now gives user 2options ‘Percentage’ and ‘Dollar Amount’ to enter or distribute the amount.  

This causes an issue to calculate the amount and percentage every time the user tries to switch the tabs or the user has to keep on switching if they want to see the figures of amount when they are in the Percentage section or vice versa 

We can add a Dollar Amount label to view beside the Percentage for each charity.  

And add a Percentage label to view beside the Dollar amount field for each charity 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/YM1kZknYVUq7gUrrOU3kyGUAG8X0?Type=TaskLink&Channel=Link&CreatedTime=638430574296180000)