### PR TITLE
[jp-0101] Dev - Donation history change amount to total amount (add the Bi-weekly column on pdf)

### DIFF
--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -135,6 +135,18 @@
         text-decoration: underline !important; 
     }
    
+    .btn-link {
+        text-decoration: underline !important; 
+    }
+
+    .fa-chevron-up {
+        transition: all 0.3s ease;
+    }
+    
+    .btn-nav-accordion.collapsed .fa-chevron-up {
+        transform: rotate(180deg);
+    }
+
 </style>
 
 @endpush

--- a/resources/views/donations/partials/history.blade.php
+++ b/resources/views/donations/partials/history.blade.php
@@ -12,13 +12,16 @@
                     {{  $key }}
                 </span>
                 <div class="flex-fill"></div>
-                <button class="custom-expander btn btn-primary" data-id="{{ $key }}">
+                <button class="btn btn-link btn-nav-accordion {{ $loop->index == 0 ? 'collapsed' : ''}}" type="button" data-id="{{ $key }}">
+                    <i class="fas fa-chevron-up fa-lg"></i>
+                </button>
+                {{-- <button class="custom-expander btn btn-primary" data-id="{{ $key }}">
                     @if ($loop->index == 0)
                         Collapse donation history
                     @else
                         Expand donation history
                     @endif
-                </button>
+                </button> --}}
             </h5>
         </div>
 
@@ -224,11 +227,13 @@ $(function () {
     });
 
     $('#accordion').on('hidden.bs.collapse', function(event){
-        $("#accordion .card-header h5").find('button.custom-expander').html('Expand donation history');
+        $("#accordion .card-header h5").find('button.btn-nav-accordion').removeClass('collapsed');
+        $("#accordion .card-header h5[aria-expanded='true']").find('button.btn-nav-accordion').addClass('collapsed');
     });
 
     $('#accordion').on('shown.bs.collapse', function(event){
-        $("#accordion .card-header h5[aria-expanded='true']").find('button.custom-expander').html('Collapse donation history');
+        $("#accordion .card-header h5").find('button.btn-nav-accordion').removeClass('collapsed');
+        $("#accordion .card-header h5[aria-expanded='true']").find('button.btn-nav-accordion').addClass('collapsed');
     });
 
 });

--- a/resources/views/donations/partials/pdf.blade.php
+++ b/resources/views/donations/partials/pdf.blade.php
@@ -84,9 +84,10 @@
                     <table class="table  rounded">
                         <tr class="bg-light">
                             <th style="width:18%;">Donation Type</th>
-                            <th style="width:62%;">Benefitting Charity</th>
+                            <th style="width:50%;">Benefitting Charity</th>
                             <th style="width:10%;">Frequency</th>
-                            <th style="width:10%;text-align:right;">Amount</th>
+                            <th class="width:10%;text-right">Bi-weekly Amount</th>
+                            <th style="width:10%;text-align:right;">Total Amount</th>
 
                         </tr>
                         @php $total = 0; @endphp
@@ -142,7 +143,11 @@
                                     </td>
                                 @endif
                                 <td>{{ $pledge->frequency }} </td>
-
+                                @if ($pledge->donation_type == 'Annual' and $pledge->frequency == 'Bi-Weekly')
+                                    <td class="text-right">$ {{ number_format($pledge->amount,2) }} </td>
+                                @else
+                                    <td class="text-right font-weight-bold"> - </td>
+                                @endif
                                 <td class="text-right">$ {{ number_format($pledge->pledge,2) }} </td>
                                 {{-- <td class="text-right">$ {{ $pledge->frequency == 'Bi-Weekly' ?
                                         number_format($pledge->pay_period_amount * $pledge->campaign_year->number_of_periods,2) :


### PR DESCRIPTION
Feb 7 – James and Steffi had a discussion on the ticket and came up with the following solution.
Add a column called Bi-weekly amount between the Frequency and Amount columns
For Donate now, one-time and special campaigns, the Bi-weekly column will display ‘ - ‘
Change the Amount column name to ‘Total Amount’

Feb 9 -- Migrated to DEV and Test. Ready for testing
Feb 12 - Steffi validated the test. Want to know if we should also include this change in the Donation Summary pdf only for the Bi-weekly donation?
Feb 13 - change applied on DEV and TEST. Please re-test.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/_nzgvwIUe0u94ixtjYQ2q2UAMttQ?Type=TaskLink&Channel=Link&CreatedTime=638430600574180000)
