### PR TITLE
[jp-0101] All tabs remains highlighted when Donations page is open

### DIFF
--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -131,11 +131,11 @@
 <style>
 
     /* Should be override in app.scss */
-    a {
+    #accordion a {
         text-decoration: underline !important; 
     }
    
-    .btn-link {
+    #accordion .btn-link {
         text-decoration: underline !important; 
     }
 


### PR DESCRIPTION
When any other page example Home, Volunteering, Challenge are open, then they are highlighted in the right menu and other pages remain unhighlighted.  

But when user is on the Donations page, all the tabs in the right menu are highlighted.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/W3BTdleedUmhdvANxRmmEGUAHW4A?Type=TaskLink&Channel=Link&CreatedTime=638435480800610000)