### PR TITLE
(TEST) [jp-0100] E-form FSP - Pools are not organized (add aria-labels)

### DIFF
--- a/resources/views/admin-pledge/submission-queue/partials/form.blade.php
+++ b/resources/views/admin-pledge/submission-queue/partials/form.blade.php
@@ -362,7 +362,7 @@
         
                             <div class=" text-right m-2 pt-2" data-id="{{ $pool->region_id }}">
                                 <i class="more-info fas fa-info-circle fa-2x bottom-right" data-id="{{ $pool->id }}" tabindex="0"
-                                    data-name="{{ $pool->region->name }}"></i>
+                                    data-name="{{ $pool->region->name }}" aria-label="More information on the Pool"></i>
                             </div>
                         </div>
                     </div>

--- a/resources/views/volunteering/partials/form.blade.php
+++ b/resources/views/volunteering/partials/form.blade.php
@@ -370,7 +370,7 @@
                 
                                     <div class=" text-right m-2 pt-2" data-id="{{ $pool->region_id }}">
                                         <i class="more-info fas fa-info-circle fa-2x bottom-right" data-id="{{ $pool->id }}" tabindex="0"
-                                            data-name="{{ $pool->region->name }}"></i>
+                                            data-name="{{ $pool->region->name }}" aria-label="More information on the Pool"></i>
                                     </div>
                                 </div>
                             </div>


### PR DESCRIPTION
Update Fund Support Pool selection UI on pages under self-service event pledge (eForm) and event submission queue, make it similiar to "Annual campaign pledge" page.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/algcnP8GiEOfHdWZA3CfKmUANQt-?Type=TaskLink&Channel=Link&CreatedTime=638442393333690000)