### PR TITLE
[jp-0109] Incorrect Special Campaigns list displayed for Admin - Maintain Special Campaign Pledge

### DIFF
--- a/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
@@ -174,7 +174,12 @@ class SpecialCampaignPledgeController extends Controller
 
         $organizations = Organization::where('status', 'A')->orderBy('name')->get();
 
-        $special_campaigns = SpecialCampaign::orderBy('name')->get();
+        // Sepcial Campaign
+        // $special_campaigns = SpecialCampaign::orderBy('name')->get();
+        $special_campaigns = SpecialCampaign::where('start_date', '<=', today())
+                ->where('end_date', '>=', today())
+                ->orderBy('start_date')
+                ->get();
 
         // default the first special campaign
         // $pledge->special_campaign_id = $special_campaigns->first()->id;


### PR DESCRIPTION
To standardize the number of special Campaign choices on both Self-Service and Administration pages. 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ACw_m_SthUCEwbKvj7OP3WUANMgW?Type=TaskLink&Channel=Link&CreatedTime=638451856828830000) 