### PR TITLE
[jp-0107] Schedule process 'UpdateEligibleEmployeeSnapshot' ran 2 times daily at 4:30 and 4:45 on all regions (2nd change)

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -150,12 +150,12 @@ class Kernel extends ConsoleKernel
         }
 
         // Snapshot of eligible employees 
-        $schedule->command('command:UpdateEligibleEmployeeSnapshot')
+        $schedule->command('command:UpdateEligibleEmployeeSnapshot --date=' . today()->format('Y-m-d') )
                 ->dailyAt('4:30')
                 ->appendOutputTo(storage_path('logs/UpdateEligibleEmployeeSnapshot.log'));
 
         $schedule->command('command:UpdateDailyCampaign')
-                ->dailyAt('5:00')
+                ->dailyAt('4:45')
                 ->appendOutputTo(storage_path('logs/UpdateDailyCampaign.log'));
         
         $schedule->command('command:SystemCleanUp')


### PR DESCRIPTION
Issue: The "UpdateEligibleEmployeeSnapshot" schedule process was setup to run once at 4:30am. However, this schedule process
was always run 2 times, one at 4:30am and other one 4:45am

Resolution: Adjust the following job timing to test out.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/M-j2xuGlnkqIJvb2ouwJ02UAEyqw?Type=TaskLink&Channel=Link&CreatedTime=638451752804360000)