### PR TITLE
[jp-0109] Incorrect Special Campaigns list displayed for Admin - Maintain Special Campaign Pledge (changes on the edit mode also)

### DIFF
--- a/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
@@ -301,7 +301,11 @@ class SpecialCampaignPledgeController extends Controller
             return abort(404);      // 404 Not Found
         }
 
-        $special_campaigns = SpecialCampaign::orderBy('name')->get();
+        // $special_campaigns = SpecialCampaign::orderBy('name')->get();
+        $special_campaigns = SpecialCampaign::where('start_date', '<=', today())
+                                ->where('end_date', '>=', today())
+                                ->orderBy('start_date')
+                                ->get();
 
         // $organization = Organization::where('id', $pledge->organization_id)->first();
         $cities = City::orderBy('city')->get();


### PR DESCRIPTION

To standardize the number of special Campaign choices on both Self-Service and Administration pages.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ACw_m_SthUCEwbKvj7OP3WUANMgW?Type=TaskLink&Channel=Link&CreatedTime=638451856828830000)