### PR TITLE
[jp-0108] Various changes on Admin - Annual Campaign

### DIFF
--- a/app/Http/Requests/CampaignPledgeRequest.php
+++ b/app/Http/Requests/CampaignPledgeRequest.php
@@ -237,7 +237,7 @@ class CampaignPledgeRequest extends FormRequest
             'pay_period_amount_other.min' => 'The min amount is $ 1.',
             'pay_period_amount_other.regex' => 'The invalid amount, max 2 decimal places.',
 
-            'pool_id.required_if' => "The pool id field is required.",
+            'pool_id.required_if' => "The Fund Supported Pool field is required",
             'charities.*.required_if' => 'The Charity field is required.',
 
             'percentages.*.required' => 'The Percentage field is required.',


### PR DESCRIPTION
Multiple change on Admin - Annual Campaign Pledge page

1. [jp-0108] Admin: Annual Campaign - FSP required field error message enhancement  
[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/wBDaXO0rD0yaKLGGSladkGUAKiOG?Type=TaskLink&Channel=Link&CreatedTime=638451831607420000)

3. [jp-0108] Admin: Annual Campaign - No error is displayed when admin tries to click Next button without adding any CRA charity to Annual Pledge    
[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/75gmBf2eA0a5D5Imkzsp-mUAERjK?Type=TaskLink&Channel=Link&CreatedTime=638451844276080000)

