### PR TITLE
(MASTER) [jp-0104] Donation tab does not remain highlighted when user is in th Annual Campaign donations flow

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -299,7 +299,7 @@ return [
             'text' => 'Donations',
             'url' => '/donations',
             'icon' => 'nav-icon fa fa-hand-holding-heart', //'give',
-            'active' => ['/donations/*', '/donate','/donate/*'],
+            'active' => ['/donations/*', '/annual-campaign/*', '/donate-now/*', '/special-campaign/*'],
         ],
         [
             'text' => 'Volunteering',

--- a/resources/views/annual-campaign/wizard.blade.php
+++ b/resources/views/annual-campaign/wizard.blade.php
@@ -281,7 +281,7 @@
 
 
     /* Should be override in app.scss */
-    a {
+    .content-wrapper a {
         text-decoration: underline !important; 
     }
 


### PR DESCRIPTION

Two change on Self-service Annual Campaign Pledge page

1. the menu item all underline on the sidebar 
2. donation should be "active" when entering annual campaign pledge.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/9RPYCczm9UaI5Zp53YNN2GUAA7yc?Type=TaskLink&Channel=Link&CreatedTime=638449194165830000)
