### PR TITLE
MASTER) [jp-0106] Sort Region list in Admin - Core Setup - FSP - Create new FSP

### DIFF
--- a/app/Http/Controllers/Admin/FundSupportedPoolController.php
+++ b/app/Http/Controllers/Admin/FundSupportedPoolController.php
@@ -140,8 +140,7 @@ class FundSupportedPoolController extends Controller
             }
         }
 
-        $regions = Region::where('status', 'A')->get();
-
+        $regions = Region::where('status', 'A')->orderBy('name')->get();
 
         return view('admin-campaign.fund-supported-pools.create', compact('regions'));
 


### PR DESCRIPTION
The regions drop-down list for Admin -> Campaign Setup -> Core Setup -> Fund Supported Pools -> Add New Fund Supported Pool -> Region list is not sorted from A-z

Resolution: define a sorting order for regions.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/BnMtUlxVrU2tZyX9URATZGUAKX5Y?Type=TaskLink&Channel=Link&CreatedTime=638449366717530000)