### PR TITLE
(MASTER) [jp-0113] No hardcoded email addresses in Daily email notification process (string to array on ToAddresses)

### DIFF
--- a/app/Console/Commands/SendDailyNotification.php
+++ b/app/Console/Commands/SendDailyNotification.php
@@ -49,7 +49,7 @@ class SendDailyNotification extends Command
         //                 'Kunal.Kapoor1@ca.ey.com',
         //                 'jpoon88@gmail.com', 'employee11@extest.gov.bc.ca',
         //                 'employee12@extest.gov.bc.ca'];
-        $toAddresses = env('EMAIL_DAILY_NOTIFICATION_ADDRESSES');   
+        $toAddresses = explode( ',', env('EMAIL_DAILY_NOTIFICATION_ADDRESSES') );   
 
         $subject = '(from region: '. env('APP_ENV') .') ' . env('APP_NAME') . ' - schedule daily notification testing (Ver 2.0)';
         $body = "Test message -- daily notification send out from server for testing purpose, please ignore. (from region: " . env('APP_ENV') .')';

--- a/app/Console/Commands/SendDailyNotification.php
+++ b/app/Console/Commands/SendDailyNotification.php
@@ -40,11 +40,17 @@ class SendDailyNotification extends Command
     {
 
         // June 24, replaceto send 
+        $switch = env('EMAIL_DAILY_NOTIFICATION_ENABLED');
+        if (!($switch)) {
+            return true;
+        }
 
-        $toAddresses = ['james.poon@gov.bc.ca', 'james.poon@telus.com',
-                        'Kunal.Kapoor1@ca.ey.com',
-                        'jpoon88@gmail.com', 'employee11@extest.gov.bc.ca',
-                        'employee12@extest.gov.bc.ca'];
+        // $toAddresses = ['james.poon@gov.bc.ca', 'james.poon@telus.com',
+        //                 'Kunal.Kapoor1@ca.ey.com',
+        //                 'jpoon88@gmail.com', 'employee11@extest.gov.bc.ca',
+        //                 'employee12@extest.gov.bc.ca'];
+        $toAddresses = env('EMAIL_DAILY_NOTIFICATION_ADDRESSES');   
+
         $subject = '(from region: '. env('APP_ENV') .') ' . env('APP_NAME') . ' - schedule daily notification testing (Ver 2.0)';
         $body = "Test message -- daily notification send out from server for testing purpose, please ignore. (from region: " . env('APP_ENV') .')';
 


### PR DESCRIPTION
The email recipients' addresses ought to be retrieved from the configuration (specific to each region) rather than being hardcoded into the program.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/M_QlCsCdVUu-5O4SZ9v9MmUAB8Z3?Type=TaskLink&Channel=Link&CreatedTime=638464651049200000)