### PR TITLE
[jp-0114] Special Campaign Setup -- store and retreive logo image onto/from database

### DIFF
--- a/app/Console/Commands/CopySpecialCampaignImagesInPublicFolder.php
+++ b/app/Console/Commands/CopySpecialCampaignImagesInPublicFolder.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Console\Commands;
+
+use GuzzleHttp;
+use App\Models\FSPoolCharity;
+use App\Models\SpecialCampaign;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class CopySpecialCampaignImagesInPublicFolder extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:CopySpecialCampaignImagesInPublicFolder';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Store the image data in the public directory.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+
+        $attachments = SpecialCampaign::whereNotNull('image_data')->orderBy('id')->get();
+
+        foreach ($attachments as $attachment) {
+
+            $filepath = public_path( 'img/uploads/special_campaign/' ) . $attachment->image;
+           
+            if (file_exists($filepath) ) {
+               // Skip 
+            } else {
+                
+                $image_data = base64_decode($attachment->image_data);
+                file_put_contents( $filepath, $image_data);
+
+                echo  $attachment->id . ' | ' . $filepath  . PHP_EOL;
+            }
+
+        }
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/Admin/SpecialCampaignSetupController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignSetupController.php
@@ -93,9 +93,14 @@ class SpecialCampaignSetupController extends Controller
 
             // file handling
             $file = $request->file('logo_image_file');
+
+            // also store the upload file in database for backup purpose
+            $mime = $file->getMimeType();
+            $base64 = base64_encode( $file->get() );
+
             $filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
             $file->move(public_path( $this->image_folder ), $filename);
-            
+
             $special_campaign = SpecialCampaign::Create([
 
                 'name' => $request->name,
@@ -105,7 +110,10 @@ class SpecialCampaignSetupController extends Controller
                 'start_date' => $request->start_date,
                 'end_date' =>$request->end_date,
                 'image' => $filename,
-                
+
+                'mime' => $mime,
+                'image_data' => $base64,
+
                 'created_by_id' => Auth::id(),
                 'updated_by_id' => Auth::id(),
 
@@ -170,6 +178,11 @@ class SpecialCampaignSetupController extends Controller
             $new_filename = '';
             if ($request->file('logo_image_file')) {
                 $file = $request->file('logo_image_file');
+
+                // also store the upload file in database for backup purpose
+                $mime = $file->getMimeType();
+                $base64 = base64_encode( $file->get() );
+
                 $new_filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
                 $file->move(public_path( $this->image_folder ), $new_filename);
 
@@ -189,6 +202,10 @@ class SpecialCampaignSetupController extends Controller
                 }
 
                 $special_campaign->image = $new_filename;
+                
+                $special_campaign->mime = $mime;
+                $special_campaign->image_data = $base64;
+
             }
             $special_campaign->updated_by_id = Auth::id();
             $special_campaign->save();

--- a/app/Models/SpecialCampaign.php
+++ b/app/Models/SpecialCampaign.php
@@ -14,7 +14,7 @@ class SpecialCampaign extends Model implements Auditable
 
     protected $fillable = [
         'name', 'description', 'banner_text', 'charity_id', 'start_date', 'end_date',
-        'image', 'created_by_id', 'updated_by_id'
+        'image', 'mime', 'image_data', 'created_by_id', 'updated_by_id'
     ];
 
     protected $casts = [

--- a/database/migrations/2024_03_20_080537_add_file_in_special_campaigns_table.php
+++ b/database/migrations/2024_03_20_080537_add_file_in_special_campaigns_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('special_campaigns', function (Blueprint $table) {
+            //
+            $table->string('mime')->nullable()->after('image');
+            
+        });
+
+        DB::statement("ALTER TABLE special_campaigns ADD COLUMN image_data MEDIUMBLOB AFTER `mime` ");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('special_campaigns', function (Blueprint $table) {
+            //
+            $table->dropColumn('mime');
+            $table->dropColumn('image_data');
+        });
+    }
+};

--- a/database/seeders/SpecialCampaignImagesSeeder.php
+++ b/database/seeders/SpecialCampaignImagesSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use App\Models\Setting;
+use App\Models\SpecialCampaign;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+
+class SpecialCampaignImagesSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+
+        $attachments = SpecialCampaign::whereNull('image_data')->orderBy('id')->get();
+
+        foreach ($attachments as $attachment) {
+
+            $filename = $attachment->image;
+            $filepath = public_path( 'img/uploads/special_campaign/' ) . $filename;
+            // $original_filename = substr($filename, strpos($filename, '_') + 1);
+            $mime = pathinfo( $filepath , PATHINFO_EXTENSION);
+
+            $doc = file_get_contents( $filepath );
+            $base64 = base64_encode($doc);
+
+            // File::move( storage_path( 'app/tmp/'. $filename ), storage_path( $this->doc_folder ."/". $filename));
+
+            // echo $attachment->local_path; 
+            $attachment->mime = $mime;
+            $attachment->image_data = $base64;
+            $attachment->timestamps = false;
+            $attachment->save();
+
+            echo  $attachment->id . ' | ' . $filepath  . ' | ' . $mime . PHP_EOL;
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Save the Special Campaign logo image to the database, ensuring benefits such as efficient storage and backup, and optionally move it to the public folder for recovery purpose.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/lXf9zK-V_ky6qN9R7yoIYGUAOELY?Type=TaskLink&Channel=Link&CreatedTime=638466420697850000)