### PR TITLE
[jp-0116] To monitor Queue and Task Scheduling Status (excluded queue Status and notify:daily)

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -44,6 +44,11 @@ class SystemStatusController extends Controller
 
             $job_name = explode(" ", $event->command)[2];
 
+            // skip serveral jobs which the history doesn't logged in audit table
+            if ($job_name == 'command:queueStatus' || $job_name == 'notify:daily') {
+                continue;
+            }
+
             // special handle for job "command:ExportPledgesToPSFT"
             if ($job_name == $last_job_name && $job_name == 'command:ExportPledgesToPSFT') {
                 continue;


### PR DESCRIPTION
To monitor the status of queues and task scheduling within a system or application, this task involves regularly checking the status of queues to ensure they are functioning properly and monitoring the scheduling of tasks to ensure they are being executed as intended.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/36oOdx7K1UmppJXSi92cd2UAJqr3?Type=TaskLink&Channel=Link&CreatedTime=638467169947200000)