### PR TITLE
(MASTER) [jp-0115] Fund Support Pool Setup -- store and retreive logo image onto/from database

### DIFF
--- a/app/Console/Commands/CopyFSPoolCharityImagesInPublicFolder.php
+++ b/app/Console/Commands/CopyFSPoolCharityImagesInPublicFolder.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Console\Commands;
+
+use GuzzleHttp;
+use App\Models\FSPoolCharity;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Storage;
+
+class CopyFSPoolCharityImagesInPublicFolder extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'command:CopyFSPoolCharityImagesInPublicFolder';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Store the image data in the public directory.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+
+        $attachments = FSPoolCharity::whereNotNull('image_data')->orderBy('id')->get();
+
+        foreach ($attachments as $attachment) {
+
+            $filepath = public_path( 'img/uploads/fspools/' ) . $attachment->image;
+           
+            if (file_exists($filepath) ) {
+               // Skip 
+            } else {
+                
+                $image_data = base64_decode($attachment->image_data);
+                file_put_contents( $filepath, $image_data);
+
+                echo  $attachment->id . ' | ' . $filepath  . PHP_EOL;
+            }
+
+        }
+
+        return 0;
+    }
+}

--- a/app/Http/Controllers/Admin/FundSupportedPoolController.php
+++ b/app/Http/Controllers/Admin/FundSupportedPoolController.php
@@ -296,6 +296,11 @@ class FundSupportedPoolController extends Controller
                     if (array_key_exists($i, $upload_images)) {
                         // dd ( $request->file('images') );
                         $file= $upload_images[$i];
+
+                          // also store the upload file in database for backup purpose
+                        $mime = $file->getMimeType();
+                        $base64 = base64_encode( $file->get() );
+
                         $filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
 
                         $file->move(public_path( $this->image_folder ), $filename);
@@ -314,6 +319,9 @@ class FundSupportedPoolController extends Controller
                         'contact_email' => array_key_exists($i, $contact_emails) ? $contact_emails[$i] : null,
                         'notes'         => array_key_exists($i, $notes) ? $notes[$i] :null,
                         'image'         => $filename,
+
+                        'mime'          => $mime,
+                        'image_data'    => $base64,
                     ]);
                 }
             }
@@ -540,8 +548,15 @@ class FundSupportedPoolController extends Controller
 
                     if (array_key_exists($i, $upload_images)) {
                         $file= $upload_images[$i];
+
+                        // also store the upload file in database for backup purpose
+                        $mime = $file->getMimeType();
+                        $base64 = base64_encode( $file->get() );
+
                         $new_filename=now()->format('YmdHisu').'_'. str_replace(' ', '_', $file->getClientOriginalName() );
                         $payload['image'] = $new_filename;
+                        $payload['mime'] = $mime;
+                        $payload['image_data'] = $base64;
 
                         // Save the new image file on folder 
                         $file->move(public_path( $this->image_folder ), $new_filename);

--- a/app/Models/FSPoolCharity.php
+++ b/app/Models/FSPoolCharity.php
@@ -16,7 +16,7 @@ class FSPoolCharity extends Model implements Auditable
     protected $fillable =[
         'f_s_pool_id', 'charity_id', 'status', 'name', 'description', 
         'percentage',  'contact_title', 'contact_name', 'contact_email', 'notes',
-        'image'
+        'image', 'mime', 'image_data' 
     ];
 
     public function charity() 

--- a/database/migrations/2024_03_21_075257_add_file_in_f_s_pool_charities_table.php
+++ b/database/migrations/2024_03_21_075257_add_file_in_f_s_pool_charities_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('f_s_pool_charities', function (Blueprint $table) {
+            //
+            $table->string('mime')->nullable()->after('image');
+        });
+
+        DB::statement("ALTER TABLE f_s_pool_charities ADD COLUMN image_data MEDIUMBLOB AFTER `mime` ");
+  
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('f_s_pool_charities', function (Blueprint $table) {
+            //
+            $table->dropColumn('mime');
+            $table->dropColumn('image_data');
+        });
+    }
+};

--- a/database/seeders/FSPoolCharityImagesSeeder.php
+++ b/database/seeders/FSPoolCharityImagesSeeder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use App\Models\Setting;
+use App\Models\FSPoolCharity;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+
+class FSPoolCharityImagesSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+
+        $attachments = FSPoolCharity::whereNull('image_data')->orderBy('id')->get();
+
+        foreach ($attachments as $attachment) {
+
+            $filename = $attachment->image;
+            $filepath = public_path( 'img/uploads/fspools/' ) . $filename;
+            // $original_filename = substr($filename, strpos($filename, '_') + 1);
+            $mime = pathinfo( $filepath , PATHINFO_EXTENSION);
+
+            $doc = file_get_contents( $filepath );
+            $base64 = base64_encode($doc);
+
+            // File::move( storage_path( 'app/tmp/'. $filename ), storage_path( $this->doc_folder ."/". $filename));
+
+            // echo $attachment->local_path; 
+            $attachment->mime = $mime;
+            $attachment->image_data = $base64;
+            $attachment->timestamps = false;
+            $attachment->save();
+
+            echo  $attachment->id . ' | ' . $filepath  . ' | ' . $mime . PHP_EOL;
+
+        }
+
+    }
+
+}


### PR DESCRIPTION
Save the Fund Support Pool logo image to the database, ensuring benefits such as efficient storage and backup, and optionally move it to the public folder for recovery purpose.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/H-G4tJCCdUqj26nchQAIGWUABTS_?Type=TaskLink&Channel=Link&CreatedTime=638466425422540000)