### PR TITLE
[jp-0116] To monitor Queue and Task Scheduling Status (fix hours calculation on database uptime)

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -160,7 +160,7 @@ class SystemStatusController extends Controller
             // Calculate UpTime
             $result = DB::select("SHOW GLOBAL STATUS LIKE 'Uptime'");
             $seconds = $result ? round($result[0]->Value) : null;
-            $uptime = sprintf('%d day(s), %2d hour(s), %2d minute(s), %2d second(s)', ($seconds/ 86400), ($seconds/ 3600), ($seconds/ 60 % 60), $seconds% 60);
+            $uptime = sprintf('%d day(s), %2d hour(s), %2d minute(s), %2d second(s)', ($seconds/ 86400), ($seconds/ 3600 % 3600), ($seconds/ 60 % 60), $seconds% 60);
 
         } catch (Exception $ex) {
             $status = "@@@ Failure @@@ -- " . $ex->getMessage();


### PR DESCRIPTION
To monitor the status of database, queues and task scheduling within a system or application, this task involves regularly checking the status of queues to ensure they are functioning properly and monitoring the scheduling of tasks to ensure they are being executed as intended.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/36oOdx7K1UmppJXSi92cd2UAJqr3?Type=TaskLink&Channel=Link&CreatedTime=638467169947200000)