### PR TITLE
(TEST) [jp-0116] To monitor Queue and Task Scheduling Status (2nd fix on hours calculaion for database uptime)

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -159,8 +159,8 @@ class SystemStatusController extends Controller
 
             // Calculate UpTime
             $result = DB::select("SHOW GLOBAL STATUS LIKE 'Uptime'");
-            $seconds = $result ? round($result[0]->Value) : null;
-            $uptime = sprintf('%d day(s), %2d hour(s), %2d minute(s), %2d second(s)', ($seconds/ 86400), ($seconds/ 3600 % 3600), ($seconds/ 60 % 60), $seconds% 60);
+            $s = $result ? round($result[0]->Value) : null;
+            $uptime = sprintf('%d day(s), %d hour(s), %d minute(s) and %d second(s)', $s/86400, round($s/3600) %24, round($s/60) %60, $s%60);
 
         } catch (Exception $ex) {
             $status = "@@@ Failure @@@ -- " . $ex->getMessage();


### PR DESCRIPTION
To monitor the status of database, queues and task scheduling within a system or application, this task involves regularly checking the status of queues to ensure they are functioning properly and monitoring the scheduling of tasks to ensure they are being executed as intended.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/36oOdx7K1UmppJXSi92cd2UAJqr3?Type=TaskLink&Channel=Link&CreatedTime=638467169947200000)