### PR TITLE
(TEST) [jp-0116] To monitor Queue and Task Scheduling Status (3nd fix logic issue related to schedule job checking)

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -91,7 +91,7 @@ class SystemStatusController extends Controller
                 $cy = CampaignYear::where('calendar_year', today()->year + 1)->first();
                 $last_change_date = $cy ? $cy->updated_at->startOfDay() : null;
 
-                if (CampaignYear::isAnnualCampaignOpenNow() || (today()->dayOfWeek == 1) || ($last_change_date == today()) ) {
+                if (CampaignYear::isAnnualCampaignOpenNow() || (today()->dayOfWeek == 1) || ($last_change_date != today()) ) {
                     // it should be processed 
                 } else {
                     continue;


### PR DESCRIPTION
To monitor the status of database, queues and task scheduling within a system or application, this task involves regularly checking the status of queues to ensure they are functioning properly and monitoring the scheduling of tasks to ensure they are being executed as intended.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/36oOdx7K1UmppJXSi92cd2UAJqr3?Type=TaskLink&Channel=Link&CreatedTime=638467169947200000)