### PR TITLE
[jp-0123] Dev - PECSF Admin: Org Acronyms in foundations table

### DIFF
--- a/app/Http/Controllers/Admin/BusinessUnitController.php
+++ b/app/Http/Controllers/Admin/BusinessUnitController.php
@@ -34,8 +34,9 @@ class BusinessUnitController extends Controller
 
         if($request->ajax()) {
 
-            $columns = ["code","name","status","effdt","linked_bu_code", "created_at"];
-            $business_units = BusinessUnit::orderBy($columns[$request->input("order")[0]['column']],$request->input("order")[0]['dir']);
+            // $columns = ["code","name","status","effdt","linked_bu_code", "created_at"];
+            // $business_units = BusinessUnit::orderBy($columns[$request->input("order")[0]['column']],$request->input("order")[0]['dir']);
+            $business_units = BusinessUnit::all();
 
             return Datatables::of($business_units)
                 ->addColumn('action', function ($business_unit) {
@@ -67,6 +68,7 @@ class BusinessUnitController extends Controller
                 'name' => $request->name,
                 'status' => $request->status,
                 'effdt' => $request->effdt,
+                'acronym' => $request->acronym,
                 'linked_bu_code' => $request->linked_bu_code,
                 'notes' => $request->notes,
                 'created_by_id' => Auth::id(),

--- a/app/Http/Requests/BusinessUnitRequest.php
+++ b/app/Http/Requests/BusinessUnitRequest.php
@@ -30,6 +30,7 @@ class BusinessUnitRequest extends FormRequest
                          ],
             'name'    => 'required|max:60',
             'status'  => ['required', Rule::in(['A', 'I']) ],
+            'acronym' => 'required|max:5|alpha|uppercase',
             'linked_bu_code' => [ 'required', 'max:5', 
                                     Rule::when( $this->code <> $this->linked_bu_code,
                                     [Rule::exists('business_units')->where(function ($query) {

--- a/app/Http/Requests/BusinessUnitRequest.php
+++ b/app/Http/Requests/BusinessUnitRequest.php
@@ -30,7 +30,7 @@ class BusinessUnitRequest extends FormRequest
                          ],
             'name'    => 'required|max:60',
             'status'  => ['required', Rule::in(['A', 'I']) ],
-            'acronym' => 'required|max:5|alpha|uppercase',
+            'acronym' => 'required|max:4|alpha|uppercase',
             'linked_bu_code' => [ 'required', 'max:5', 
                                     Rule::when( $this->code <> $this->linked_bu_code,
                                     [Rule::exists('business_units')->where(function ($query) {

--- a/app/Models/BusinessUnit.php
+++ b/app/Models/BusinessUnit.php
@@ -14,7 +14,7 @@ class BusinessUnit extends Model implements Auditable
     use \OwenIt\Auditing\Auditable;
 
     protected $fillable =[
-        'code', 'name', 'status', 'effdt', 'linked_bu_code', 'notes', 'created_by_id', 'updated_by_id'
+        'code', 'name', 'status', 'effdt', 'acronym', 'linked_bu_code', 'notes', 'created_by_id', 'updated_by_id'
     ];
 
     public function scopeCurrent($query)

--- a/database/migrations/2024_04_19_093901_add_acronym_in_business_units.php
+++ b/database/migrations/2024_04_19_093901_add_acronym_in_business_units.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('business_units', function (Blueprint $table) {
+            //
+            $table->string('acronym')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('business_units', function (Blueprint $table) {
+            //
+            $table->dropColumn('acronym');
+        });
+    }
+};

--- a/resources/views/admin-campaign/business-units/index.blade.php
+++ b/resources/views/admin-campaign/business-units/index.blade.php
@@ -42,6 +42,7 @@
 				<tr>
                     <th>Business Unit</th>
 					<th>Name</th>
+                    <th>Acronym</th>
                     <th>Status</th>
                     <th>Effective Date</th>
                     <th>Associated BU</th>
@@ -131,6 +132,7 @@
             columns: [
                 {data: 'code', name: 'code', className: "dt-nowrap" },
                 {data: 'name', name: 'name', className: "dt-nowrap" },
+                {data: 'acronym', name: 'acronym', className: "dt-nowrap" },
                 {data: 'status', name: 'status', className: "dt-nowrap" },
                 {data: 'effdt', name: 'effdt'},
                 {data: 'linked_bu_code',  className: 'dt-nowrap'},
@@ -139,8 +141,8 @@
             ],
             columnDefs: [
                     {
-                        width: '5em',
-                        targets: [0]
+                        // width: '5em',
+                        // targets: [0]
                     },
             ]
         });
@@ -148,7 +150,7 @@
         // Model for creating new business unit
         $('#bu-create-modal').on('show.bs.modal', function (e) {
             // do something...
-            var fields = ['code', 'name', 'status', 'effdt', 'notes', 'linked_bu_code'];
+            var fields = ['code', 'name', 'acronym', 'status', 'effdt', 'notes', 'linked_bu_code'];
             $.each( fields, function( index, field_name ) {
                 $(document).find('[name='+field_name+']').nextAll('span.text-danger').remove();
                 $(document).find('[name='+field_name+']').val('');
@@ -166,7 +168,7 @@
             if (confirm(info))
             {
 
-                var fields = ['code', 'name', 'status', 'effdt', 'notes', 'linked_bu_code'];
+                var fields = ['code', 'name', 'acronym', 'status', 'effdt', 'notes', 'linked_bu_code'];
                 $.each( fields, function( index, field_name ) {
                     $(document).find('[name='+field_name+']').nextAll('span.text-danger').remove();
                 });
@@ -201,7 +203,7 @@
     	$(document).on("click", ".edit-bu" , function(e) {
 			e.preventDefault();
 
-            var fields = ['code', 'name', 'status', 'effdt', 'notes', 'linked_bu_code'];
+            var fields = ['code', 'name', 'acronym', 'status', 'effdt', 'notes', 'linked_bu_code'];
             $.each( fields, function( index, field_name ) {
                 $(document).find('[name='+field_name+']').nextAll('span.text-danger').remove();
             });
@@ -249,7 +251,7 @@
             info = 'Confirm to update this record?';
             if (confirm(info))
             {
-                var fields = ['code', 'name', 'status', 'effdt', 'notes', 'linked_bu_code'];
+                var fields = ['code', 'name', 'acronym', 'status', 'effdt', 'notes', 'linked_bu_code'];
                 $.each( fields, function( index, field_name ) {
                     $('#bu-edit-model-form [name='+field_name+']').nextAll('span.text-danger').remove();
                 });
@@ -285,7 +287,7 @@
     	$(document).on("click", ".show-bu" , function(e) {
 			e.preventDefault();
 
-            var fields = ['code', 'name', 'status', 'effdt', 'notes', 'linked_bu_code'];
+            var fields = ['code', 'name', 'acronym', 'status', 'effdt', 'notes', 'linked_bu_code'];
             $.each( fields, function( index, field_name ) {
                 $(document).find('[name='+field_name+']').nextAll('span.text-danger').remove();
             });

--- a/resources/views/admin-campaign/business-units/partials/model-create.blade.php
+++ b/resources/views/admin-campaign/business-units/partials/model-create.blade.php
@@ -26,6 +26,13 @@
             </div>
 
 			<div class="form-group row">
+                <label for="acronym" class="col-sm-2 col-form-label">Acronym:</label>
+                <div class="col-sm-4">
+					<input type="text" class="form-control" id="acronym" name="acronym">
+            	</div>
+            </div>
+			
+			<div class="form-group row">
                 <label for="status" class="col-sm-2 col-form-label">Status:</label>
                 <div class="col-sm-4">
 					<select id="status" name="status" class="form-control" required>

--- a/resources/views/admin-campaign/business-units/partials/model-edit.blade.php
+++ b/resources/views/admin-campaign/business-units/partials/model-edit.blade.php
@@ -27,6 +27,13 @@
             </div>
 
 			<div class="form-group row">
+                <label for="acronym" class="col-sm-2 col-form-label">Acronym:</label>
+                <div class="col-sm-4">
+					<input type="text" class="form-control" name="acronym" value="">
+            	</div>
+            </div>
+
+			<div class="form-group row">
                 <label for="status" class="col-sm-2 col-form-label">Status:</label>
                 <div class="col-sm-4">
 					<select name="status" class="form-control">

--- a/resources/views/admin-campaign/business-units/partials/model-show.blade.php
+++ b/resources/views/admin-campaign/business-units/partials/model-show.blade.php
@@ -27,6 +27,13 @@
             </div>
 
 			<div class="form-group row">
+                <label for="acronym" class="col-sm-2 col-form-label">Acronym:</label>
+                <div class="col-sm-4">
+					<input type="text" class="form-control" name="acronym" value="" disabled>
+            	</div>
+            </div>
+
+			<div class="form-group row">
                 <label for="status" class="col-sm-2 col-form-label">Status:</label>
                 <div class="col-sm-4">
 					<select name="status" class="form-control" disabled>


### PR DESCRIPTION
Under Administration\Campaign Set up\Foundation tables\Business Units add a column for the organizations acronym.  Example: BC Public Service Agency = PSA.  

The field would allow for no more than four letters, all caps and no duplication. 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/rZTchpgg6k6wUBLNynP0-2UAHP7c?Type=TaskLink&Channel=Link&CreatedTime=638491435490780000)