### PR TITLE
[jp-0124] Improve the logic in Task Scheduling Status Monitoring

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -113,6 +113,25 @@ class SystemStatusController extends Controller
                     ->getPreviousRunDate(Carbon::now()->setTimezone($event->timezone), allowCurrentDate: true)
                     ->setTimezone($timezone)
             );
+
+            if (CampaignYear::isAnnualCampaignOpenNow()) {
+                // Use the previous calculate date
+            } else {
+                if ($job_name == 'command:ImportCities' || $job_name == 'command:ImportDepartments') {
+                    if ($job_name == 'command:ImportCities') {
+                        $hr = 2; $min = 30;
+                    } else {
+                        $hr = 2; $min = 45;
+                    }
+
+                    if (now() <= (today()->hour($hr)->minute($min)) ) {
+                    // if ($test < (today()->hour($hr)->minute($min))) {                        
+                        $prevMonday = today()->previous('Monday');
+                        $previousDueDate = $prevMonday->hour($hr)->minute($min);
+                    } 
+                }
+            }
+
             $previousDueDateUpto = $previousDueDate->copy()->addMinutes(5)->format('Y-m-d H:i:s');
 
             // 2 mins grace period for the schedule job start 


### PR DESCRIPTION
The program was incorrectly report an failure when the campaign period is closed and the following 2 process only run on Monday, the chkecing for previous job should be on Monday instead of Friday when the campaign period is not yet open.

{
            "name": "command:ImportCities",
            "cron": "30 2 * * 1-5",
            "environments": [],
            "previous schedule time": "2024-04-19 02:30:00",
            "status": "@@@ Failure @@@ -- The previous schedule did not run",
            "next schedule time": "2024-04-22 02:30:00"
        },
        {
            "name": "command:ImportDepartments",
            "cron": "45 2 * * 1-5",
            "environments": [],
            "previous schedule time": "2024-04-19 02:45:00",
            "status": "@@@ Failure @@@ -- The previous schedule did not run",
            "next schedule time": "2024-04-22 02:45:00"
        },

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/awWzsysfPkSqIFRJEqqxu2UAGMkc?Type=TaskLink&Channel=Link&CreatedTime=638493974206380000)

