### PR TITLE
(TEST) [jp-0128] Improve the Task Scheduling Status Monitoring to conditionally skip checking based on the local env configuration

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -85,6 +85,22 @@ class SystemStatusController extends Controller
                 continue;
             }
 
+            // Check whether the environment variables enable for outbound
+            if ((!(env('TASK_SCHEDULING_OUTBOUND_PSFT_ENABLED'))) && $job_name == 'command:ExportPledgesToPSFT') {
+                continue;
+            } elseif (((!env('TASK_SCHEDULING_OUTBOUND_BI_ENABLED'))) && $job_name == 'command:ExportDatabaseToBI') {
+                continue;
+            } elseif (((!env('TASK_SCHEDULING_INBOUND_ENABLED'))) && (
+                    $job_name == 'command:ImportPayCalendar' ||
+                    $job_name == 'command:ImportCities' ||
+                    $job_name == 'command:ImportDepartments' ||
+                    $job_name == 'command:ImportEmployeeJob' ||
+                    $job_name == 'command:SyncUserProfile')) {
+                continue;
+            } else {
+                // perform checking
+            }
+
             // SPECIAL -- job "command:ExportPledgesToPSFT"
             if ($job_name == $last_job_name && $job_name == 'command:ExportPledgesToPSFT') {
                 continue;


### PR DESCRIPTION
The program was incorrectly report an failure when the schdule inbound.outbound flag in the environment configuration set to false, especially on the lower regions which will be disabled on adhoc basis.

.env file
TASK_SCHEDULING_INBOUND_ENABLED=false
TASK_SCHEDULING_OUTBOUND_PSFT_ENABLED=true
TASK_SCHEDULING_OUTBOUND_BI_ENABLED=false

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/IfzJI3gPzU-KHXrRWULe3WUAA7Kf?Type=TaskLink&Channel=Link&CreatedTime=638525274620920000)