### PR TITLE
[jp-0128] Improve the Task Scheduling Status Monitoring to conditionally skip checking based on the local env configuration (more enhancement needs)

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -163,8 +163,12 @@ class SystemStatusController extends Controller
                             ->whereBetween('start_time', [$previousDueDate, $previousDueDateUpto])
                             ->first();
 
-                if ($audit || ($last_completed && $last_completed->end_date > $previousDueDate)) {
-                    $status = "Success -- The last run id: " . $audit->id . " | " . $audit->job_name . " | " . $audit->status .
+                if ($audit || ($last_completed && $last_completed->end_time > $previousDueDate)) {
+                    $status = $audit ? "Success" : "Retry success";
+                    if (!($audit)) {
+                        $audit = $last_completed;
+                    }
+                    $status .= " -- The last run id: " . $audit->id . " | " . $audit->job_name . " | " . $audit->status .
                             " | start at " . $audit->start_time . " - end at " . $audit->end_time;
                 } else {
                     $status = '@@@ Failure @@@ -- The previous schedule did not run';


### PR DESCRIPTION
The program was incorrectly report an failure when the schdule inbound.outbound flag in the environment configuration set to false, especially on the lower regions which will be disabled on adhoc basis.

.env file
TASK_SCHEDULING_INBOUND_ENABLED=false
TASK_SCHEDULING_OUTBOUND_PSFT_ENABLED=true
TASK_SCHEDULING_OUTBOUND_BI_ENABLED=false

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/IfzJI3gPzU-KHXrRWULe3WUAA7Kf?Type=TaskLink&Channel=Link&CreatedTime=638525274620920000)
