### PR TITLE
(TEST) [jp-0127] Challenge Page rename

### DIFF
--- a/config/adminlte.php
+++ b/config/adminlte.php
@@ -331,7 +331,7 @@ return [
             // ]
         ],
         [
-            'text' => 'Challenge',
+            'text' => 'Statistics',
             'url' => '/challenge',
             'icon' => 'nav-icon fa fa-chart-bar', // 'challenge',
             'active' => ['challenge/*']

--- a/resources/views/challenge/daily_campaign.blade.php
+++ b/resources/views/challenge/daily_campaign.blade.php
@@ -11,7 +11,7 @@
 @section('content_header')
 
 <div class="mt-2">
-    <h1>Challenge</h1>
+    <h1>Statistics</h1>
 
     @include('challenge.partials.tabs')
 

--- a/resources/views/challenge/index.blade.php
+++ b/resources/views/challenge/index.blade.php
@@ -2,7 +2,7 @@
 
 @section('content_header')
 <div class="mt-2">
-    <h1>Challenge</h1>
+    <h1>Statistics</h1>
 
     @include('challenge.partials.tabs')
 

--- a/resources/views/challenge/org_participation_tracker.blade.php
+++ b/resources/views/challenge/org_participation_tracker.blade.php
@@ -2,7 +2,7 @@
 @section('content_header')
 
 <div class="mt-2">
-    <h1>Challenge</h1>
+    <h1>Statistics</h1>
 
     @include('challenge.partials.tabs')
 


### PR DESCRIPTION
Challenge Page rename – to “Statistics” (front -end)
Update Challenge Page references everywhere in front-end App to “Statistics”

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/9w9vDAxIBU6rsYj7Es8HSmUAEOZT?Type=TaskLink&Channel=Link&CreatedTime=638526986762400000)