### PR TITLE
[jp-0129] Volunteering Registration - address (remove debug statement)

### DIFF
--- a/app/Http/Controllers/Admin/MaintainVolunteerProfileController.php
+++ b/app/Http/Controllers/Admin/MaintainVolunteerProfileController.php
@@ -166,7 +166,7 @@ class MaintainVolunteerProfileController extends Controller
     {
         //
         $profile = new VolunteerProfile();
-dd($profile);
+
         $profile->address_type = 'S';
         $profile->campaign_year = date('Y');
 


### PR DESCRIPTION
Remove the GAL option in step 2 of the volunteering registration (image in the document attached). Remove the radial button in front of "Use the following address:" Located: Volunteering > Register tile

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/nnEK4nKIW0KNkGMUEU5k9mUADBKV?Type=TaskLink&Channel=Link&CreatedTime=638526140667890000)