### PR TITLE
(MASTER) [jp-0128] Improve the Task Scheduling Status Monitoring to conditionally skip checking based on the local env configuration

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -163,8 +163,12 @@ class SystemStatusController extends Controller
                             ->whereBetween('start_time', [$previousDueDate, $previousDueDateUpto])
                             ->first();
 
-                if ($audit || ($last_completed && $last_completed->end_date > $previousDueDate)) {
-                    $status = "Success -- The last run id: " . $audit->id . " | " . $audit->job_name . " | " . $audit->status .
+                if ($audit || ($last_completed && $last_completed->end_time > $previousDueDate)) {
+                    $status = $audit ? "Success" : "Retry success";
+                    if (!($audit)) {
+                        $audit = $last_completed;
+                    }
+                    $status .= " -- The last run id: " . $audit->id . " | " . $audit->job_name . " | " . $audit->status .
                             " | start at " . $audit->start_time . " - end at " . $audit->end_time;
                 } else {
                     $status = '@@@ Failure @@@ -- The previous schedule did not run';

--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -85,6 +85,22 @@ class SystemStatusController extends Controller
                 continue;
             }
 
+            // Check whether the environment variables enable for outbound
+            if ((!(env('TASK_SCHEDULING_OUTBOUND_PSFT_ENABLED'))) && $job_name == 'command:ExportPledgesToPSFT') {
+                continue;
+            } elseif (((!env('TASK_SCHEDULING_OUTBOUND_BI_ENABLED'))) && $job_name == 'command:ExportDatabaseToBI') {
+                continue;
+            } elseif (((!env('TASK_SCHEDULING_INBOUND_ENABLED'))) && (
+                    $job_name == 'command:ImportPayCalendar' ||
+                    $job_name == 'command:ImportCities' ||
+                    $job_name == 'command:ImportDepartments' ||
+                    $job_name == 'command:ImportEmployeeJob' ||
+                    $job_name == 'command:SyncUserProfile')) {
+                continue;
+            } else {
+                // perform checking
+            }
+
             // SPECIAL -- job "command:ExportPledgesToPSFT"
             if ($job_name == $last_job_name && $job_name == 'command:ExportPledgesToPSFT') {
                 continue;

--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -167,6 +167,11 @@ class SystemStatusController extends Controller
                 }
             }
 
+            $last_completed = ScheduleJobAudit::where('job_name', 'like', $job_name . '%')
+                                ->where('status', 'Completed')
+                                ->orderBy('end_time', 'desc')
+                                ->first();
+
             $tasks[] = [
                 'name' => $job_name,
                 'cron' => $event->expression,
@@ -175,6 +180,8 @@ class SystemStatusController extends Controller
                 // $event->description,
                 'previous schedule time' => $previousDueDate->format('Y-m-d H:i:s'),
                 'status' => $status,
+                'last completed start time' => $last_completed ? $last_completed->start_time : null,
+                'last completed end time' => $last_completed ? $last_completed->end_time : null,
                 'next schedule time' => (new CronExpression($event->expression))
                             ->getNextRunDate(Carbon::now())
                             ->setTimezone( $timezone )->format('Y-m-d H:i:s'),


### PR DESCRIPTION
The program was incorrectly report an failure when the schdule inbound.outbound flag in the environment configuration set to false, especially on the lower regions which will be disabled on adhoc basis.

.env file
TASK_SCHEDULING_INBOUND_ENABLED=false
TASK_SCHEDULING_OUTBOUND_PSFT_ENABLED=true
TASK_SCHEDULING_OUTBOUND_BI_ENABLED=false

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/IfzJI3gPzU-KHXrRWULe3WUAA7Kf?Type=TaskLink&Channel=Link&CreatedTime=638525274620920000)