### PR TITLE
(MASTER) [jp-0132] Register volunteering: Cursor style does not change on hovering over the navigation bar

### DIFF
--- a/resources/views/volunteer-profile/wizard.blade.php
+++ b/resources/views/volunteer-profile/wizard.blade.php
@@ -220,6 +220,10 @@
     color: #1a5a96; /* #dc3545 */
 }
 
+.bs4-step-tracking li.active:hover {
+    cursor: pointer;
+}    
+
 .bs4-step-tracking li.active>div {
     background: #1a5a96;
 }


### PR DESCRIPTION
The program was updated. When hovering over the navigation bar on the active items (in blue color) while registering, the cursor style changes to 'pointer'.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/91DeBpz4GkuBwL3KlwHu_WUAFG1I?Type=TaskLink&Channel=Link&CreatedTime=638526800049470000)