### PR TITLE
(MASTER) [jp-0134] No of charities in view details do not match the list when duplicating pledge

### DIFF
--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -1242,7 +1242,7 @@ class AnnualCampaignController extends Controller
                             $new_pledge_charity = new PledgeCharity();
 
                             $new_pledge_charity->charity_id = $bi_weekly_pledge->charity->id;
-                            $new_pledge_charity->additional = $bi_weekly_pledge->name2;
+                            $new_pledge_charity->additional = $bi_weekly_pledge->vendor_name2;
                             $new_pledge_charity->percentage = $bi_weekly_pledge->percent;
                             $new_pledge_charity->amount = round(($bi_weekly_pledge->amount / 26),2);
                             $new_pledge_charity->frequency = 'bi-weekly'; // : 'one-time',
@@ -1266,7 +1266,7 @@ class AnnualCampaignController extends Controller
                             $new_pledge_charity = new PledgeCharity();
 
                             $new_pledge_charity->charity_id = $one_time_pledge->charity->id;
-                            $new_pledge_charity->additional = $one_time_pledge->name2;
+                            $new_pledge_charity->additional = $one_time_pledge->vendor_name2;
                             $new_pledge_charity->percentage = $one_time_pledge->percent;
                             $new_pledge_charity->amount = $one_time_pledge->amount;
                             $new_pledge_charity->frequency = 'one-time';

--- a/resources/views/donations/partials/bi-pledge-detail-modal.blade.php
+++ b/resources/views/donations/partials/bi-pledge-detail-modal.blade.php
@@ -160,8 +160,8 @@
               <tr>
                   <td scope="row">{{ $loop->index +1 }}</td>
                   <td>
-                      <p>{{ $pledge->name1 ?? 'N/A' }}</p>
-                      <p>{{ $pledge->name2 ?? 'N/A' }}</p>
+                      <p>{{ $pledge->vendor_name1 ?? 'N/A' }}</p>
+                      <p>{{ $pledge->vendor_name2 ?? 'N/A' }}</p>
                   </td>
                   <td class="text-center">{{ number_format($pledge->percent,2) }}%</td>
                   <td class="text-center">${{ number_format(($total_amount * $pledge->percent / 100),2) }}</td>


### PR DESCRIPTION
Issue 2: The name was blank on "Benefitting Charity" field, it was caused by data from BI was difference on columns name1 and vendor_name1. After some data analysis, looks like better to use the column vendor_name1 and vendor_name2 instead of name1 and name2. The program was updated to use the vendor_name1 and vendor_name2.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/krg_x2GtEkaGgDDvIVsFnGUACGXV?Type=TaskLink&Channel=Link&CreatedTime=638526851543530000)