### PR TITLE
[jp-0139] Donate now - All tabs in left menu remains highlighted

### DIFF
--- a/resources/views/donate-now/wizard.blade.php
+++ b/resources/views/donate-now/wizard.blade.php
@@ -293,9 +293,9 @@
 
 
     /* Should be override in app.scss */
-    a {
+    /* a {
         text-decoration: underline !important; 
-    }
+    } */
 
     .form-control[type='search']:focus-visible {
         outline: 2px solid #000;


### PR DESCRIPTION
While donating, the expected result is that only the donation tab in the left hand menu must remain highlighted but instead all other tabs are highlighted too. Please see the screenshot attached for reference

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/0H5HvExlLE6l_PYMsSiJl2UAEQbl?Type=TaskLink&Channel=Link&CreatedTime=638533837710230000)