### PR TITLE
(TEST) [jp-0140] Register/Edit volunteering - All tabs in left menu remains highlighted

### DIFF
--- a/resources/views/volunteer-profile/wizard.blade.php
+++ b/resources/views/volunteer-profile/wizard.blade.php
@@ -293,9 +293,9 @@
 
 
     /* Should be override in app.scss */
-    a {
+    /* a {
         text-decoration: underline !important; 
-    }
+    } */
 
     .form-control[type='search']:focus-visible {
         outline: 2px solid #000;


### PR DESCRIPTION
While registering/editing volunteer profile, the expected result is that only the Volunteering tab in the left hand menu must remain highlighted but instead all other tabs are highlighted too. Please see the screenshot attached for reference

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/gFIlJUrp8kC9WrRy9Z5m1mUAAbpK?Type=TaskLink&Channel=Link&CreatedTime=638533838245030000)