### PR TITLE
(TEST) [jp-0144] Export Audit Log -- search by Row ID doesn't work

### DIFF
--- a/app/Http/Controllers/System/ExportAuditLogController.php
+++ b/app/Http/Controllers/System/ExportAuditLogController.php
@@ -36,7 +36,7 @@ class ExportAuditLogController extends Controller
                      return $query->where('export_audit_logs.table_name', $request->table_name);
                 })
                 ->when($request->row_id, function($query) use($request) {
-                    return $query->where('export_audit_logs.table_name', $request->row_id);
+                    return $query->where('export_audit_logs.row_id', $request->row_id);
                 })
                 ->when($request->start_time || $request->end_time, function($query) use($request) {
                      $from = $request->start_time ?? '1990-01-01';

--- a/resources/views/system-security/export-audit-log/index.blade.php
+++ b/resources/views/system-security/export-audit-log/index.blade.php
@@ -372,6 +372,15 @@
 
         });
 
+        $('.search-filter').on('keyup', function(e) {
+            var key  = e.key;
+            if (key === 'Enter') {
+                e.preventDefault();
+                oTable.draw();
+                // $(this).trigger('click');
+            }
+        });
+
     });
 
     </script>


### PR DESCRIPTION
June 14 - In Export Audit Log page, no expected result returned when searching by Row ID field.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/0YycVEzpsEm6EXqZiKMcs2UAFcEZ?Type=TaskLink&Channel=Link&CreatedTime=638539780000350000)