### PR TITLE
(TEST) [jp-0141] bug fix Volunteer Reg Programming - Opt out selected, address not required

### DIFF
--- a/app/Http/Controllers/Admin/MaintainVolunteerProfileController.php
+++ b/app/Http/Controllers/Admin/MaintainVolunteerProfileController.php
@@ -225,10 +225,10 @@ class MaintainVolunteerProfileController extends Controller
             'preferred_role' => $request->preferred_role,
 
             'address_type' =>  $request->address_type,
-            'address' => ($request->address_type =="G") ? null : $request->address,
-            'city' => ($request->address_type =="G") ? null : $city->city,
-            'province' => ($request->address_type =="G") ? null : $request->province,
-            'postal_code' => ($request->address_type =="G") ? null : $request->postal_code,
+            'address' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->address,
+            'city' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $city->city,
+            'province' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->province,
+            'postal_code' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->postal_code,
             'opt_out_recongnition' => $request->opt_out_recongnition ? 'Y' : 'N',
 
             'created_by_id' => Auth::Id(),
@@ -333,10 +333,10 @@ class MaintainVolunteerProfileController extends Controller
         $profile->preferred_role = $request->preferred_role;
 
         $profile->address_type = $request->address_type;
-        $profile->address = ($request->address_type =="G") ? null : $request->address;
-        $profile->city = ($request->address_type =="G") ? null : $city->city;
-        $profile->province = ($request->address_type =="G") ? null : $request->province;
-        $profile->postal_code = ($request->address_type =="G") ? null : $request->postal_code;
+        $profile->address = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->address;
+        $profile->city = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $city->city;
+        $profile->province = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->province;
+        $profile->postal_code = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->postal_code;
         $profile->opt_out_recongnition = $request->opt_out_recongnition ? 'Y' : 'N';
 
         $profile->updated_by_id = Auth::id();

--- a/app/Http/Controllers/VolunteerProfileController.php
+++ b/app/Http/Controllers/VolunteerProfileController.php
@@ -104,9 +104,13 @@ class VolunteerProfileController extends Controller
                 if ($request->address_type == 'G') { 
                     $address = $job->office_full_address;
                 } else {
-                    $city = City::where('id', $request->city)->first();            
-                    $province = $request->province ? VolunteerProfile::PROVINCE_LIST[$request->province] : '';
-                    $address = $request->address .', '. $city->city .', '. $province .', '. $request->postal_code;
+                    if ($request->opt_out_recongnition == 'Y') {
+                        $address = 'Not applicable';
+                    } else {
+                        $city = City::where('id', $request->city)->first();            
+                        $province = $request->province ? VolunteerProfile::PROVINCE_LIST[$request->province] : '';
+                        $address = $request->address .', '. $city->city .', '. $province .', '. $request->postal_code;
+                    }
                 }
                 
                 $is_renew = $request->is_renew == 'Y' ? true : false;
@@ -148,10 +152,10 @@ class VolunteerProfileController extends Controller
                 'preferred_role' => $request->preferred_role,
 
                 'address_type' => $request->address_type,
-                'address' => ($request->address_type =="G") ? null : $request->address,
-                'city' => ($request->address_type =="G") ? null : $city->city,
-                'province' => ($request->address_type =="G") ? null : $request->province,
-                'postal_code' => ($request->address_type =="G") ? null : $request->postal_code,
+                'address' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->address,
+                'city' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $city->city,
+                'province' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->province,
+                'postal_code' => ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->postal_code,
                 'opt_out_recongnition' => $request->opt_out_recongnition ? 'Y' : 'N',
 
                 'created_by_id'  => Auth::id(),
@@ -251,10 +255,10 @@ class VolunteerProfileController extends Controller
         $profile->business_unit_code = $request->business_unit_code;
         $profile->no_of_years = $profile->is_renew_profile ? 1 : $request->no_of_years;
         $profile->preferred_role = $request->preferred_role;
-        $profile->address = ($request->address_type =="G") ? null : $request->address;
-        $profile->city = ($request->address_type =="G") ? null : $city->city;
-        $profile->province = ($request->address_type =="G") ? null : $request->province;
-        $profile->postal_code = ($request->address_type =="G") ? null : $request->postal_code;
+        $profile->address = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->address;
+        $profile->city = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $city->city;
+        $profile->province = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->province;
+        $profile->postal_code = ($request->address_type =="G" || $request->opt_out_recongnition == 'Y') ? null : $request->postal_code;
         $profile->opt_out_recongnition  = $request->opt_out_recongnition ? 'Y' : 'N';
 
         $profile->updated_by_id = Auth::id();

--- a/app/Http/Requests/MaintainVolunteerProfileRequest.php
+++ b/app/Http/Requests/MaintainVolunteerProfileRequest.php
@@ -60,15 +60,16 @@ class MaintainVolunteerProfileRequest extends FormRequest
             'preferred_role' => ["required", Rule::in( $role_keys )],
 
             'address_type' => ['required', Rule::in(['G', 'S'])],
-            'address'  => ['required_if:address_type,S'],
-            'city'  => ['required_if:address_type,S',
-                            Rule::when( $this->address_type == 'S', ['exists:cities,id']),
+            // 'address'  => ['required_if:address_type,S'],
+            'address'  => Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+            'city'  => [ Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+                            Rule::when( $this->address_type == 'S' && $this->opt_out_recongnition != 'Y', ['exists:cities,id']),
                     ],
-            'province' => ['required_if:address_type,S',
-                                Rule::when( $this->address_type == 'S', Rule::in( $province_keys )) 
+            'province' => [ Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+                                Rule::when( $this->address_type == 'S' && $this->opt_out_recongnition != 'Y', Rule::in( $province_keys )) 
                             ],
-            'postal_code'  => ['required_if:address_type,S',
-                    Rule::when( $this->address_type == 'S', 'regex:/^([a-zA-Z]\d[a-zA-Z])\ {0,1}(\d[a-zA-Z]\d)$/'),
+            'postal_code'  => [ Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+                    Rule::when( $this->address_type == 'S' && $this->opt_out_recongnition != 'Y', 'regex:/^([a-zA-Z]\d[a-zA-Z])\ {0,1}(\d[a-zA-Z]\d)$/'),
                                 ],
 
             ];

--- a/app/Http/Requests/VolunteerProfileRequest.php
+++ b/app/Http/Requests/VolunteerProfileRequest.php
@@ -47,15 +47,16 @@ class VolunteerProfileRequest extends FormRequest
             $my_rules = array_merge($my_rules,
                 [
                     'address_type' => ['required', Rule::in(['G', 'S']) ],
-                    'address'  => ['required_if:address_type,S'],
-                    'city'  => ['required_if:address_type,S',
-                                    Rule::when( $this->address_type == 'S', ['exists:cities,id']),
+                    // 'address'  => ['required_if:address_type,S'],
+                    'address' => Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+                    'city'  => [ Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+                                    Rule::when( $this->address_type == 'S' && $this->opt_out_recongnition != 'Y', ['exists:cities,id']),
                             ],
-                    'province' => ['required_if:address_type,S',
-                                     Rule::when( $this->address_type == 'S', Rule::in( $province_keys )) 
+                    'province' => [  Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+                                     Rule::when( $this->address_type == 'S' && $this->opt_out_recongnition != 'Y', Rule::in( $province_keys )) 
                                  ],
-                    'postal_code'  => ['required_if:address_type,S',
-                            Rule::when( $this->address_type == 'S', 'regex:/^([a-zA-Z]\d[a-zA-Z])\ {0,1}(\d[a-zA-Z]\d)$/'),
+                    'postal_code'  => [ Rule::requiredIf($this->address_type == 'S' && $this->opt_out_recongnition != 'Y'),
+                            Rule::when( $this->address_type == 'S' && $this->opt_out_recongnition != 'Y', 'regex:/^([a-zA-Z]\d[a-zA-Z])\ {0,1}(\d[a-zA-Z]\d)$/'),
                                      ],
           
                     // 'pool_id'      => ['required_if:pool_option,P', Rule::when( $this->pool_option == 'P', [ Rule::exists("f_s_pools", "id")->whereNull("deleted_at"), ]) ],

--- a/app/Models/VolunteerProfile.php
+++ b/app/Models/VolunteerProfile.php
@@ -93,7 +93,11 @@ class VolunteerProfile extends Model implements Auditable
                 $address = $job->office_full_address;
             }
         } else {
-            $address = $this->address .', '. $this->city .', '. $this->province .', '. $this->postal_code;
+            if ($this->opt_out_recongnition == 'Y') {
+                $address = 'Not applicable';
+            } else {
+                $address = $this->address .', '. $this->city .', '. $this->province .', '. $this->postal_code;
+            }
         }
         return $address;
     }

--- a/resources/views/admin-volunteering/profile/create-edit.blade.php
+++ b/resources/views/admin-volunteering/profile/create-edit.blade.php
@@ -838,6 +838,24 @@ $(function () {
     });
 
 
+    $('#opt_out_recongnition').on('click', function(e) {
+         if (e.originalEvent ) {
+            val = this.checked ? this.value : '';
+            if (val == 'Y') {
+                $('input[name=address]').val('');
+                $('select[name=city]').val('').trigger('change');
+                $('select[name=province]').val('');
+                $('input[name=postal_code]').val('');
+            }
+         }
+    });
+
+    $('input[name=address],select[name=city],select[name=province],input[name=postal_code]').on('change', function (e) {
+        if (e.originalEvent ) {
+            $('#opt_out_recongnition').prop('checked', false);
+        }
+    });
+
 });
 
 </script>

--- a/resources/views/volunteer-profile/partials/recognition-items.blade.php
+++ b/resources/views/volunteer-profile/partials/recognition-items.blade.php
@@ -73,8 +73,7 @@
     <div class="form-group col-12">
         <label>
             <input id="opt_out_recongnition" name="opt_out_recongnition" 
-                type="checkbox" {{ ($profile && $profile->opt_out_recongnition == "Y") ? "checked":""}}  
-                name="address_type" value="Y" {{ ($profile && $profile->opt_out_recongnition == 'Y') ? 'checked' : '' }}>
+                type="checkbox" value="Y" {{ ($profile && $profile->opt_out_recongnition == "Y") ? "checked":""}}>  
             <span class="pl-2">I wish to opt-out from receiving recognition items.</span>
         </label>
     </div>
@@ -107,6 +106,24 @@ $(function () {
             $('input[name=postal_code]').prop('disabled',false);
         }
 
+    });
+
+    $('#opt_out_recongnition').on('click', function(e) {
+         if (e.originalEvent ) {
+            val = this.checked ? this.value : '';
+            if (val == 'Y') {
+                $('input[name=address]').val('');
+                $('select[name=city]').val('').trigger('change');
+                $('select[name=province]').val('');
+                $('input[name=postal_code]').val('');
+            }
+         }
+    });
+
+    $('#recognition-items-area').on('change', 'input[name=address],select[name=city],select[name=province],input[name=postal_code]', function (e) {
+        if (e.originalEvent ) {
+            $('#opt_out_recongnition').prop('checked', false);
+        }
     });
 
 });

--- a/resources/views/volunteer-profile/partials/summary.blade.php
+++ b/resources/views/volunteer-profile/partials/summary.blade.php
@@ -45,6 +45,7 @@
 
         <hr>
         <h4 class="text-primary">Recognition Items</h4>
+        @if ($request->opt_out_recongnition != 'Y' )
         <div class="row pt-2">
             <div class="col-12">
                 <div class="font-weight-bold">
@@ -55,6 +56,7 @@
                 </div>
             </div>    
         </div>                 
+        @endif
 
         <div class="row pt-2">
             <div class="col-12">

--- a/resources/views/volunteer-profile/show.blade.php
+++ b/resources/views/volunteer-profile/show.blade.php
@@ -101,16 +101,18 @@
         
                 <div class="pt-2">
 
-                    <div class="row pt-2">
-                        <div class="col-12">
-                            <div class="font-weight-bold">
-                                {{ ($profile->address_type == 'G') ? 'Use my Global Address Listing' : 'Use the following address' }}
-                                </div> 
-                            <div>
-                                {{  $profile->full_address }}
-                            </div>
-                        </div>    
-                    </div>                 
+                    @if ($profile->opt_out_recongnition != 'Y')
+                        <div class="row pt-2">
+                            <div class="col-12">
+                                <div class="font-weight-bold">
+                                    {{ ($profile->address_type == 'G') ? 'Use my Global Address Listing' : 'Use the following address' }}
+                                    </div> 
+                                <div>
+                                    {{  $profile->full_address }}
+                                </div>
+                            </div>    
+                        </div>
+                    @endif
             
                     <div class="row pt-2">
                         <div class="col-12">


### PR DESCRIPTION
Steffi: I had noticed this earlier, but thought we still need the address while registering regardless of the selection to the checkbox
AC:
i) If user checks in to the checkbox, the address fields must become optional. The 'Use the following address field must remain hidden under the Recognition section of the 3. Confirmation page and the volunteer profile page
ii) If the user puts the address in the fields, and still checks in to the checkbox, the address fields must become optional and entered data must be neglected. The 'Use the following address field must remain hidden under the Recognition section of the 3. Confirmation page and the volunteer profile page

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/V1vHKJqAb069bDgtn8EwdGUAL9o7?Type=TaskLink&Channel=Link&CreatedTime=638543189974010000)