### PR TITLE
[jp-0141] bug fix Volunteer Reg Programming - Opt out selected, address not required (clear error message if exists)

### DIFF
--- a/resources/views/volunteer-profile/partials/recognition-items.blade.php
+++ b/resources/views/volunteer-profile/partials/recognition-items.blade.php
@@ -116,6 +116,18 @@ $(function () {
                 $('select[name=city]').val('').trigger('change');
                 $('select[name=province]').val('');
                 $('input[name=postal_code]').val('');
+
+                // clear error messages
+                fields = ['address_type', 'address', 'city', 'province', 'postal_code', 'opt_out_recongnition'];
+
+                $.each( fields, function( index, field_name ) {
+                    $('#volunteer-profile-form [name='+ field_name +']').nextAll('span.text-danger').remove();
+                    $('#volunteer-profile-form [name='+ field_name +']').removeClass('is-invalid');
+                });
+
+                $('#city').parent().find('.select2-selection--single').removeClass('is-invalid');
+                $('#city').parent().find('span.text-danger').remove();
+
             }
          }
     });


### PR DESCRIPTION
Steffi: I had noticed this earlier, but thought we still need the address while registering regardless of the selection to the checkbox
AC:
i) If user checks in to the checkbox, the address fields must become optional. The 'Use the following address field must remain hidden under the Recognition section of the 3. Confirmation page and the volunteer profile page
ii) If the user puts the address in the fields, and still checks in to the checkbox, the address fields must become optional and entered data must be neglected. The 'Use the following address field must remain hidden under the Recognition section of the 3. Confirmation page and the volunteer profile page

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/V1vHKJqAb069bDgtn8EwdGUAL9o7?Type=TaskLink&Channel=Link&CreatedTime=638543189974010000)