### PR TITLE
(TEST) [jp-0146] Bug in Business Unit page, incorrect 'acronym' duplicate error shown when update

### DIFF
--- a/app/Http/Requests/BusinessUnitRequest.php
+++ b/app/Http/Requests/BusinessUnitRequest.php
@@ -30,7 +30,7 @@ class BusinessUnitRequest extends FormRequest
                          ],
             'name'    => 'required|max:60',
             'status'  => ['required', Rule::in(['A', 'I']) ],
-            'acronym' => 'required|max:4|alpha|uppercase|unique:business_units,acronym',
+            'acronym' => 'required|max:4|alpha|uppercase|unique:business_units,acronym,'.$this->id,
             'linked_bu_code' => [ 'required', 'max:5', 
                                     Rule::when( $this->code <> $this->linked_bu_code,
                                     [Rule::exists('business_units')->where(function ($query) {


### PR DESCRIPTION
Jun 21 - Bug found in the Business Unit page, when update the BU without changing the acronym, the duplicate error "The acronym has already been taken." shown.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/fpg-L2Kt2U2OTLt7ivkFgWUAH-Nt?Type=TaskLink&Channel=Link&CreatedTime=638545870733130000)