### PR TITLE
(TEST) [jp-0148] Admin: Annual Campaign Pledge -- Pop-up message to confirm calendar year

### DIFF
--- a/app/Http/Controllers/Admin/CampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/CampaignPledgeController.php
@@ -164,8 +164,14 @@ class CampaignPledgeController extends Controller
         $campaign_years = CampaignYear::orderBy('calendar_year', 'desc')->get();
         $cities = City::orderBy('city')->get();
 
+        $default_campaign_year = CampaignYear::defaultCampaignYear();
+        // $temp_campaign_year = CampaignYear::where('calendar_year', today()->year +1 )->first();
+        // if ($temp_campaign_year && today() >= $temp_campaign_year->start_date ) {
+        //     $default_campaign_year = today()->year; 
+        // } 
+
         // load the view and pass
-        return view('admin-pledge.campaign.index', compact('organizations', 'campaign_years','cities', 'filter'));
+        return view('admin-pledge.campaign.index', compact('organizations', 'campaign_years','cities', 'filter', 'default_campaign_year'));
 
     }
 
@@ -194,7 +200,9 @@ class CampaignPledgeController extends Controller
         $edit_pecsf_allow = true;
         $canCancel = false;
 
-        return view('admin-pledge.campaign.wizard', compact('pool_option', 'fspools', 'organizations','campaignYears',
+        $default_campaign_year = CampaignYear::defaultCampaignYear();
+
+        return view('admin-pledge.campaign.wizard', compact('pool_option', 'fspools', 'organizations','campaignYears', 'default_campaign_year',
                     'edit_pecsf_allow',
                     'cities', 'pay_period_amount','one_time_amount','pay_period_amount_other', 'one_time_amount_other', 'canCancel'));
     }

--- a/app/Models/CampaignYear.php
+++ b/app/Models/CampaignYear.php
@@ -66,6 +66,18 @@ class CampaignYear extends Model implements Auditable
             return false;
         }
     }
+
+    public static function defaultCampaignYear() {
+
+        $default_campaign_year = today()->year - 1; 
+        $temp_campaign_year = CampaignYear::where('calendar_year', today()->year +1 )->first();
+        if ($temp_campaign_year && today() >= $temp_campaign_year->start_date ) {
+            $default_campaign_year = today()->year; 
+        } 
+
+        return $default_campaign_year;
+
+    }
    
 
     public function created_by()

--- a/resources/views/admin-pledge/campaign/index.blade.php
+++ b/resources/views/admin-pledge/campaign/index.blade.php
@@ -116,7 +116,7 @@
                         {{-- <option value="{{ $cy->id }}" {{ ($cy->calendar_year == date('Y')) ? 'selected' : '' }}>{{ $cy->calendar_year }} --}}
                             <option value="{{ $cy->id }}" {{ 
                                 isset($filter['campaign_year_id']) ? ($filter['campaign_year_id'] == $cy->id ? 'selected' : '') :
-                                ($cy->calendar_year == (date('Y') + 1) ? 'selected' : '') }}>
+                                ($cy->calendar_year == ($default_campaign_year +1) ? 'selected' : '') }}>
                                 {{ $cy->calendar_year }} 
                         </option>
                     @endforeach

--- a/resources/views/admin-pledge/campaign/partials/profile.blade.php
+++ b/resources/views/admin-pledge/campaign/partials/profile.blade.php
@@ -14,8 +14,8 @@
                     @empty($pledge)
                         <select id="campaign_year_id" class="form-control" name="campaign_year_id" style="max-width:200px;" aria-required="true">
                             @foreach ($campaignYears as $cy)
-                                <option value="{{ $cy->id }}"
-                                    {{ ($cy->calendar_year == date('Y')+1) ? 'selected' : '' }}>
+                                <option value="{{ $cy->id }}" calendar_year="{{ $cy->calendar_year }}"
+                                    {{ ($cy->calendar_year == ($default_campaign_year +1) ) ? 'selected' : '' }}>
                                     {{ $cy->calendar_year }}
                                 </option>
                             @endforeach

--- a/resources/views/admin-pledge/campaign/wizard.blade.php
+++ b/resources/views/admin-pledge/campaign/wizard.blade.php
@@ -384,7 +384,36 @@ $(function () {
     $(".next").on("click", function() {
         var nextstep = false;
         if (step == 1) {
-            nextstep = checkForm();
+
+            @empty($pledge) 
+
+                calendar_year = $('#campaign_year_id option:selected').attr('calendar_year')
+                Swal.fire( {
+                    title: 'Are you certain that you want the pledge to apply to Calendar Year ' + calendar_year + ' ?',
+                    // text: 'This action cannot be undone.',
+                    // icon: 'question',
+                    showDenyButton: true,
+                    // showCancelButton: true,
+                    confirmButtonText: 'Yes',
+                    denyButtonText: 'No',
+                    buttonsStyling: false,
+                    //confirmButtonClass: 'btn btn-danger',
+                    customClass: {
+                        confirmButton: 'btn btn-primary', //insert class here
+                        cancelButton: 'btn btn-danger ml-2', //insert class here
+                        denyButton: 'btn btn-outline-secondary ml-2',
+                    }
+                    //denyButtonText: `Don't save`,
+                }).then((result) => {
+                    /* Read more about isConfirmed, isDenied below */
+                    if (result.isConfirmed) {
+                        nextstep = checkForm();
+                    } 
+                })
+            @endempty
+            @isset($pledge) 
+                nextstep = checkForm();
+            @endisset
         } else if (step == 2) {
             nextstep = checkForm();
             recalculate_allocation();


### PR DESCRIPTION
*Requirements:*

- The default calendar year would indicate using the current year when the campaign is not yet open. Once the campaign for the next calendar year, such as 2025, opens, the system will default to calendar year 2025 (campaign year 2024).
- When click on the next step to 2nd page during create a annual campaign pledge, the pop message ask for confirmation of the calendar year choice 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/CG8nglc6skaMsuL9SP57smUADscE?Type=TaskLink&Channel=Link&CreatedTime=638548433963210000)