### PR TITLE
[jp-0137b] Enhancement - Challenge Page Export for end users (improve logic to control the display of Download as PDF button)

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -283,6 +283,11 @@ class ChallengeController extends Controller
         $finalized_years = HistoricalChallengePage::select('year')->distinct()->orderBy('year', 'desc')->pluck('year')->toArray();
 
         $year_options = $finalized_years;
+        if ($current_campaign_year == $finalized_years[0] && today() < $setting->challenge_final_date) {
+            // not yet finalized
+            array_shift($finalized_years);
+        }
+
         if ($current_campaign_year > $year_options[0]) {
             $found = DailyCampaign::where('campaign_year', $current_campaign_year)
                                     ->where('daily_type', 0)


### PR DESCRIPTION
Serveral enhancement on Statistic (Challenge) Page:

[jp-0137a] Enhancement - Daily Campaign Stats - Final Stats [Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/T_dTCzJqVkuFqO0pzhBQWGUALT5B?Type=TaskLink&Channel=Link&CreatedTime=638533030443900000)
[jp-0137b] Enhancement - Challenge Page Export for end users [Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Ntd_9k4HD0eXVRmABfNNKGUAJtWa?Type=TaskLink&Channel=Link&CreatedTime=638533030776710000)
[jp-0137c] Enhancement - Org Tracker - availability requirements [Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/aJ72fFrt1UavEam3ITiNEGUAHxK5?Type=TaskLink&Channel=Link&CreatedTime=638533030953040000)
[jp-0137d] Challenge Page rename – to “Statistics Page Data” (back-end/admin) [Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/dluCm66oh0ajrwyFxxPMbmUAJhj2?Type=TaskLink&Channel=Link&CreatedTime=638533031131670000)