### PR TITLE
(MASTER) [jp-0147] Fixing the pledge with Tran# 6185, update the calendar year to 2024 from 2025

### DIFF
--- a/database/seeders/DataFixFor_jp_0147_update_Plege6185.php
+++ b/database/seeders/DataFixFor_jp_0147_update_Plege6185.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0147_update_Plege6185 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+        DB::update("update pledges set campaign_year_id = 20, updated_at = now()  where id  = 6185 and campaign_year_id = 21;");
+    }
+}


### PR DESCRIPTION
Jun 21 - Per user request, the pledge ID 6185 should be under calendar year 2024 instead of 2025. This was caused by campaign year 2024 setup on the system with the improper default logic.

SQL script:

select * from pledges where id = 6185 and campaign_year_id = 21;

update pledges set campaign_year_id = 20, updated_at = now() where id = 6185 and campaign_year_id = 21;

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/vFrNMFdp0EC4wy1-wMIM3WUAKmLO?Type=TaskLink&Channel=Link&CreatedTime=638549256147830000)