### PR TITLE
[jp-0151] Reassign Charity on Event Pledge Tran#173

### DIFF
--- a/database/seeders/DataFixFor_jp_0151_Event173.php
+++ b/database/seeders/DataFixFor_jp_0151_Event173.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0151_Event173 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reassign charity on Evenet Pledge 173 
+        
+        echo 'Before change:';
+        $data = DB::table('bank_deposit_form_organizations')
+                    ->whereRaw('id = 352 and deleted_at is null')
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        // Data Fix
+        DB::update("update bank_deposit_form_organizations set organization_name = 'First Nations Health Foundation', vendor_id = 133718, updated_at = now() where id = 352 and bank_deposit_form_id = 173 and deleted_at is null;");
+
+        echo PHP_EOL;
+        echo PHP_EOL;
+        echo 'After change:';
+        $data = DB::table('bank_deposit_form_organizations')
+                    ->whereRaw('id = 352 and deleted_at is null')
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+    }
+}


### PR DESCRIPTION
Reallocate pledge for LSA Fundraiser event due to inactive charity. (Tran ID 173, PECSF ID F23093). Showing on 40D Reconciliation Report. 

BC ABORIGINAL NETWORK ON DISABIITLY SOCIETY is no longer an active charity and needs to be reallocated to remove from 40D Rec. 

Move current allocation from:

BC ABORIGINAL NETWORK ON DISABIITLY SOCIETY (50%), ALZEIMER SOCIETY OF B.C. (50%)
to
FIRST NATIONS HEALTH FOUNDATION (50%), ALZEIMER SOCIETY OF B.C. (50%)

June 27 - Developed the script for reassign the charity on Event Pledge#173

From 
896694098RR0001 BC ABORIGINAL NETWORK ON DISABIITLY SOCIETY   (9290) 
To 
713653103RR0001   First Nations Health Foundation (133718)

[Ticket ](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/6fDO76PWGUeN3CON4dgXFWUAIS8R?Type=TaskLink&Channel=Link&CreatedTime=638551200543160000)