### PR TITLE
[jp-0153]  No current campaign year data shows on Statistics Page

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -69,9 +69,17 @@ class ChallengeController extends Controller
         //     $as_of_day = $setting->challenge_final_date;
         // }
 
+        $finalized = false;
+        $final_row = HistoricalChallengePage::select('year')
+                                ->where('year', $current_campaign_year)
+                                ->first(); 
+        if ($final_row && $as_of_day >= $setting->challenge_final_date) {
+            $finalized = true;
+        }
+
         if($request->ajax()) {
 
-            if (!($summary)) {
+            if (!($finalized)) {
             // if ($as_of_day != $setting->challenge_final_date ) {
 
                 // Use Dynamic data during the challenge period


### PR DESCRIPTION
James have encountered a bug on the statistics page, there are no current campaign year data displayed on statistics page, only the total donors and donation amounts

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/35mTk5emRkubU5S-aY18g2UAB5vX?Type=TaskLink&Channel=Link&CreatedTime=638560934054120000)