### PR TITLE
[jp-0154] SQL error -- Unknown column users.name in where clause

### DIFF
--- a/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
+++ b/app/Http/Controllers/Admin/SpecialCampaignPledgeController.php
@@ -73,8 +73,8 @@ class SpecialCampaignPledgeController extends Controller
                             })
                             ->when( $request->name, function($query) use($request) {
                                 $query->where('special_campaign_pledges.first_name', 'like', '%' . $request->name . '%')
-                                      ->orWhere('special_campaign_pledges.first_name', 'like', '%' . $request->name . '%')
-                                      ->orWhere('users.name', 'like', '%' . $request->name . '%');
+                                      ->orWhere('special_campaign_pledges.last_name', 'like', '%' . $request->name . '%')
+                                      ->orWhere('employee_jobs.name', 'like', '%' . $request->name . '%');
                             })
                             ->when( $request->city, function($query) use($request) {
                                 $query->where( function($q) use($request) {


### PR DESCRIPTION
Found an SQL error when check the production laravel log file 

[2024-07-05 10:15:36] prod.ERROR: SQLSTATE[42S22]: Column not found: 1054 Unknown column 'users.name' in 'where clause' (Connection: mysql, SQL: select count(*) as aggregate from `special_campaign_pledges` left join `employee_jobs` on `employee_jobs`.`emplid` = `special_campaign_pledges`.`emplid` where ((`employee_jobs`.`empl_rcd` = (select min(J2.empl_rcd) from `employee_jobs` as `J2` where `J2`.`emplid` = `employee_jobs`.`emplid`) or `employee_jobs`.`empl_rcd` is null) and `special_campaign_pledges`.`first_name` like %Nicole% or `special_campaign_pledges`.`first_name` like %Nicole% or `users`.`name` like %Nicole% and `yearcd` = 2024) and `special_campaign_pledges`.`deleted_at` is null) {"userId":33248,"exception":"[object] (Illuminate\\Database\\QueryException(code: 42S22): SQLSTATE[42S22]: Column not found: 1054 Unknown column 'users.name' in 'where clause' (Connection: mysql, SQL: select count(*) as aggregate from `special_campaign_pledges` left join `employee_jobs` on `employee_jobs`.`emplid` = `special_campaign_pledges`.`emplid` where ((`employee_jobs`.`empl_rcd` = (select min(J2.empl_rcd) from `employee_jobs` as `J2` where `J2`.`emplid` = `employee_jobs`.`emplid`) or `employee_jobs`.`empl_rcd` is null) and `special_campaign_pledges`.`first_name` like %Nicole% or `special_campaign_pledges`.`first_name` like %Nicole% or `users`.`name` like %Nicole% and `yearcd` = 2024) and `special_campaign_pledges`.`deleted_at` is null) at /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php:829)

The issue was replicated on local database and found the bug in page (http://localhost:8000/admin-pledge/special-campaign)

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ZOs4K_MYJ0W4dHgwNAjTiGUAC9ns?Type=TaskLink&Channel=Link&CreatedTime=638561385814870000)