### PR TITLE
(MASTER) Update base image to php:8.1-apache-bullseye 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN chgrp -R 0 /app && \
 #
 # Build Server Deployment Image
 #
-FROM php:8.1-apache
+FROM php:8.1-apache-bullseye
 
 WORKDIR /
 
@@ -71,7 +71,7 @@ RUN ln -sf /proc/self/fd/1 /var/log/apache2/access.log && \
 	\
 	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false;
 
-RUN echo "deb https://packages.sury.org/php/ buster main" | tee /etc/apt/sources.list.d/php.list
+RUN echo "deb https://packages.sury.org/php/ bullseye main" | tee /etc/apt/sources.list.d/php.list
 RUN docker-php-ext-install pdo pdo_mysql opcache
 
 RUN apt-get install -y \


### PR DESCRIPTION
Jul 4  - we have encountered Production migration failure. The Github Pull request Production deployment action was failed 
Jul 5 - reported to Kunal and start investigation. James has replicate this issue on DEV and TEST and noticed that the same issue. According to Kunal findings and email:

Looks like it is failing to get the php dist or buster
from https://packages.sury.org/php/dists 


403 Forbidden 


The last successful run for this build happened on June 28 where the package was successfully downloaded. 


I guess the difference between the Docker file or PDP and PECSF is that PECSF docker files runs an apt-get update command (where the build is failing) just after the debian buster package is added to the
/etc/apt/sources.list.d/php.list file. When the apt-get update command runs, it will use all the listed repos to check for updates. This is not the case in PDP. 



I also had a chat with the BC gov DevOps teams, and
they recommend changing the php version to php:8.1-apache-bullseye to be robust in future.
Please let me know what you think about it. Maybe you can test with the new tag
and see if everything works fine with the app and then move forward. 


Jul 8 - Kunal has replaced the php package in docker file on DEV and verified by James, no issue found.

Original 
FROM php:8.1-apache   
:
:
RUN echo "deb https://packages.sury.org/php/ buster main" | tee /etc/apt/sources.list.d/php.list 

New 
FROM php:8.1-apache-bullseye
:
:
RUN echo "deb https://packages.sury.org/php/ bullseye main" | tee /etc/apt/sources.list.d/php.list 

Jul 9 - new branch called "php-buster-image-fix-master" created from master, and applied the same fix and applied on TEST region.  

July 10 - Kristina/Chris Reviewed and approved. 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/E5ht-8v_H0-pHQi9x8wo2GUAPYTy?Type=TaskLink&Channel=Link&CreatedTime=638562284042170000)