### PR TITLE
(TEST) [jp-0155] Update Donate Now Pledge (Tran ID 117) 

### DIFF
--- a/database/seeders/DataFixFor_jp_0155_DonateNow117.php
+++ b/database/seeders/DataFixFor_jp_0155_DonateNow117.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0155_DonateNow117 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reassign charity on Evenet Pledge 173 
+        
+        echo 'Before change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw('id = 117 and deleted_at is null')
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        // Data Fix
+        DB::update("update donate_now_pledges set charity_id = 42650, updated_at = now() where id = 117 and deleted_at is null;");
+        
+        echo PHP_EOL;
+        echo PHP_EOL;
+        echo 'After change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw('id = 117 and deleted_at is null')
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+    }
+}


### PR DESCRIPTION
Tran ID 117 - There is a $50.00 Donate Now Pledge going to an inactive Charity, this needs to be updated to one of the pledge donors other chosen charities. If possible can the Donate Now pledge be split 50/50 between her two other charity choices or two Donate Now pledges be created. We are unable to make any adjustments through Greenfield.

Move from - Sahaara Foundation (Inactive Charity)
Move to - Foundation for Youth Rights to Education Canada (Active Charity)
Asian Canadian Cancer Fellowship Association (Active Charity)
Update July 10, 2024

Donate Now Pledge can't be split between multiple charities. Please allocate the full amount ($50.00) from Sahaara Foundation to Found for Youth Rights to Education Canada.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/mrJUWiXxr0GAP3A1jC_RW2UAJK6N?Type=TaskLink&Channel=Link&CreatedTime=638562321757330000)