### PR TITLE
(TEST) [jp-0157] Form does not clear when adding a new record on the Eligible Employee Summary Maintenance page

### DIFF
--- a/resources/views/admin-campaign/eligible-employee-summary/index.blade.php
+++ b/resources/views/admin-campaign/eligible-employee-summary/index.blade.php
@@ -257,13 +257,13 @@
         // Model for creating new business unit
         $('#ee-create-modal').on('show.bs.modal', function (e) {
             // do something...
-            var fields = ['campaign_year', 'as_of_date', 'donors', 'dollars', 'notes'];
+            var fields = ['campaign_year', 'organization_code', 'business_unit', 'ee_count', 'notes'];
             $.each( fields, function( index, field_name ) {
                 $(document).find('[name='+field_name+']').nextAll('span.text-danger').remove();
                 $(document).find('[name='+field_name+']').val('');
             });
             $('#ee-create-modal').find('[name=campaign_year]').val( {{ today()->year }} );
-            $('#ee-create-modal').find('[name=status]').val('A');
+            // $('#ee-create-modal').find('[name=status]').val('A');
 
         })
 


### PR DESCRIPTION
Issue on Admin -> Campaign setup -> Statistics Setup -> Eligible Employee Summary Maintenance page
If admin tries to enter a new record, the expected outcome is everytime admin clicks on Add a new Record, the form modal that opens must be blank.
Actual: If admin puts details in the modal and creates a new record -> Clicks on the Add new record button again, the previously entered data is not cleared.
If admin puts details in the modal and cancels -> Clicks on the Add new record button again, the previously entered data is not cleared.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/4P_WRMUX60COtG48LbGT4WUABCyS?Type=TaskLink&Channel=Link&CreatedTime=638563088217510000)