### PR TITLE
(MASTER) [jp-0156] Daily Campaign Update tab - The date option field does not display a list of dates

### DIFF
--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -415,6 +415,16 @@ class ChallengeController extends Controller
         $date_options = [];
         $dept_date_options = [];
 
+        $date_options = DailyCampaign::select('as_of_date')
+                                    ->where('campaign_year', $campaign_year)
+                                    ->where(function($query) use($setting) {
+                                        return $query->WhereBetween('as_of_date',[$setting->campaign_start_date->format('Y-m-d'), $setting->campaign_end_date->format('Y-m-d')]);
+                                    })
+                                    // ->where('as_of_date', '<>', today() )
+                                    ->distinct()
+                                    ->orderBy('as_of_date', 'desc')
+                                    ->pluck('as_of_date');
+
         $final_date_options = DailyCampaign::select('as_of_date')
                                     ->where('campaign_year', $campaign_year)
                                     ->where(function($query) use($setting) {


### PR DESCRIPTION
The date option field does not display a list of dates under Daily Campaign Update tab (http://localhost:8000/challenge/daily_campaign)

Menu > Statistics

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Ann2P5OioEaRotvX-BSyeGUAKAeb?Type=TaskLink&Channel=Link&CreatedTime=638563077095330000)