### PR TITLE
(MASTER) [jp-0158] Business unit in event form does not pop up for BC063, BC725

### DIFF
--- a/app/Http/Controllers/Admin/EventSubmissionQueueController.php
+++ b/app/Http/Controllers/Admin/EventSubmissionQueueController.php
@@ -128,9 +128,10 @@ class EventSubmissionQueueController extends Controller
         $regional_pool_id = $pools->count() > 0 ? $pools->first()->id : null;
         // $business_units = BusinessUnit::orderBy('name')->get();
         $business_units = BusinessUnit::where("status","=","A")
-                        ->whereColumn("code","linked_bu_code")
+                        // ->whereColumn("code","linked_bu_code")
                         ->selectRaw("business_units.id, business_units.code, business_units.name, (select code from organizations where organizations.bu_code = business_units.code limit 1 ) as org_code ")
-                        ->groupBy("linked_bu_code")->orderBy("name")->get();
+                        // ->groupBy("linked_bu_code")
+                        ->orderBy("name")->get();
         $regions = Region::where("status","=","A")->orderBy('name')->get();
         $departments = Department::orderBy('department_name')->limit(10)->get();
         $campaign_year = CampaignYear::where('calendar_year', '<=', today()->year + 1 )->orderBy('calendar_year', 'desc')

--- a/app/Http/Controllers/Admin/MaintainEventPledgeController.php
+++ b/app/Http/Controllers/Admin/MaintainEventPledgeController.php
@@ -168,9 +168,10 @@ class MaintainEventPledgeController extends Controller
         $regional_pool_id = $pools->count() > 0 ? $pools->first()->id : null;
         // $business_units = BusinessUnit::where("status","=","A")->whereColumn("code","linked_bu_code")->groupBy("linked_bu_code")->orderBy("name")->get();
         $business_units = BusinessUnit::where("status","=","A")
-            ->whereColumn("code","linked_bu_code")
+            // ->whereColumn("code","linked_bu_code")
             ->selectRaw("business_units.id, business_units.code, business_units.name, (select code from organizations where organizations.bu_code = business_units.code limit 1 ) as org_code ")
-            ->groupBy("linked_bu_code")->orderBy("name")->get();
+            // ->groupBy("linked_bu_code")
+            ->orderBy("name")->get();
         $regions = Region::where("status","=","A")->get();
         $departments = Department::all();
         $campaign_year = CampaignYear::where('start_date', '<=', today() )->orderBy('calendar_year', 'desc')->first();

--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -56,9 +56,10 @@ class BankDepositFormController extends Controller
         $regional_pool_id = $pools->count() > 0 ? $pools->first()->id : null;
         // $business_units = BusinessUnit::where("status","=","A")->whereColumn("code","linked_bu_code")->groupBy("linked_bu_code")->orderBy("name")->get();
         $business_units = BusinessUnit::where("status","=","A")
-                        ->whereColumn("code","linked_bu_code")
+                        // ->whereColumn("code","linked_bu_code")
                         ->selectRaw("business_units.id, business_units.code, business_units.name, (select code from organizations where organizations.bu_code = business_units.code limit 1 ) as org_code ")
-                        ->groupBy("linked_bu_code")->orderBy("name")->get();
+                        // ->groupBy("linked_bu_code")
+                        ->orderBy("name")->get();
         $regions = Region::where("status","=","A")->orderby("name", "asc")->get();
         $departments = Department::all();
         $campaign_year = CampaignYear::where('start_date', '<=', today() )->orderBy('calendar_year', 'desc')->first();


### PR DESCRIPTION
When submitting an event form, if user enters the emp id, expected result is that other details in the form including the Business unit field must pop up automatically. But for BU BC063 & BC725, Ministry of Education and Child Care the business unit does not pop up.
For testing, the following emp id can be used:
148617
110051

Jul 11 - very good finding, the criteria on the sql shouldn't limit to the linked BU only.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/72NGI_hyRUe8o937UTPZY2UAN3kG?Type=TaskLink&Channel=Link&CreatedTime=638563114466450000)