### PR TITLE
[jp-0163] Historical gaming/fundraiser event appears on employee's donation history

### DIFF
--- a/app/Http/Controllers/DonationController.php
+++ b/app/Http/Controllers/DonationController.php
@@ -126,6 +126,10 @@ class DonationController extends Controller {
         $all_pledges = DB::table('pledge_history_summaries')
                             ->where('emplid', $user->emplid)
                             ->whereNotNull('emplid')
+                            ->where( function($query) {
+                                 $query->whereNull('pledge_history_summaries.event_type')
+                                       ->orWhereIn('pledge_history_summaries.event_type', ['Cash', 'Personal Cheque']);
+                            })
                             ->selectRaw("'BI' as source, NULL as user_id,  pledge_history_id as id,'pledge_history_summaries' as model, emplid, yearcd, source as type,
                                          campaign_type as donation_type, frequency, per_pay_amt as amount, pledge,
                                          (select regions.name from regions where regions.code = pledge_history_summaries.region) as region,


### PR DESCRIPTION
Test account user Employee 103 has a donation history in which the year 2020 displays 2 Annual pledges. - Bi-weekly and One-time. These 2 pledges should be made to the same number of charities as there is no way to make separate pledges. 
July 25 - Noticed that one entry is a gaming event 
Question: For consistency, do we remove the gaming and fundraising events from the donation history? The numbers are also added to the employee's total amount of donation made.

July 25 - PO response: fundraising and gaming events submitted by employees should not be included in personal donation history (no exceptions). Only "Event pledge" that should be included are cash/cheque donations.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/JXEq5PvVEkyK6eR6sIpodWUAOIxM?Type=TaskLink&Channel=Link&CreatedTime=638575326885660000)