### PR TITLE
(MASTER) [jp-0164] Remove the entries displaying 0 from the Statistics Page Data Report

### DIFF
--- a/app/Http/Controllers/Admin/ChallengePageDataReportController.php
+++ b/app/Http/Controllers/Admin/ChallengePageDataReportController.php
@@ -45,6 +45,7 @@ class ChallengePageDataReportController extends Controller
                 where campaign_year = ?
                 and as_of_date = ?
                 and daily_type = 0     
+                and (donors > 0 or dollars > 0) 
                 and business_unit in (select code from business_units where status = 'A')                
                 order by participation_rate desc, abs(change_rate);     
 


### PR DESCRIPTION
There are some BU that have 0 donors but still displays in the Statistics Page Data Report and also in the excel sheet when downloaded. Can we remove the one's with 0 entries?

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Dd-PVYgbnUG8U_uxS7T0nmUAGGjP?Type=TaskLink&Channel=Link&CreatedTime=638575373293410000)