### PR TITLE
[jp-0168] Organization Participation Tracker must function on custom dates

### DIFF
--- a/app/Console/Commands/UpdateEligibleEmployeeSnapshot.php
+++ b/app/Console/Commands/UpdateEligibleEmployeeSnapshot.php
@@ -116,7 +116,9 @@ class UpdateEligibleEmployeeSnapshot extends Command
         $year = $as_of_date->year;
 
         $this->LogMessage( "" );   
-        $this->LogMessage( "Note: The business rule for collecting the eligible employee data on Sep 1st and Oct 15th every year" );   
+        $this->LogMessage( "Note: The business rule for collecting the eligible employee data on " . 
+                    $setting->ee_snapshot_date_1->format('M j, Y') .
+                    ' and '. $setting->ee_snapshot_date_2->format('M j, Y') . ' (defined in Statistics Update page)');   
         $this->LogMessage( "" );   
         $this->LogMessage( "As of date           : " . $as_of_date->format('Y-m-d') );           
         $this->LogMessage( "" );   
@@ -125,8 +127,10 @@ class UpdateEligibleEmployeeSnapshot extends Command
 
         if ( $as_of_date && 
                 ( $this->option('date')  ||
-                 ($as_of_date->month ==  9 && $as_of_date->day ==  1) ||
-                 ($as_of_date->month == 10 && $as_of_date->day == 15)
+                   ($as_of_date == $setting->ee_snapshot_date_1)  ||
+                   ($as_of_date == $setting->ee_snapshot_date_2) 
+                //  ($as_of_date->month ==  9 && $as_of_date->day ==  1) ||
+                //  ($as_of_date->month == 10 && $as_of_date->day == 15)
                 ) ) {
 
             $sql = EmployeeJob::where( function($query) {
@@ -297,15 +301,19 @@ class UpdateEligibleEmployeeSnapshot extends Command
         $year = $as_of_date->year;
 
         $this->LogMessage( "" );   
-        $this->LogMessage( "Note: The business rule for generating the Organization Participation Tractor Report on Sep 1st and Oct 15th every year" );   
+        $this->LogMessage( "Note: The business rule for generating the Organization Participation Tractor Report on " .
+                                $setting->ee_snapshot_date_1->format('M j, Y') .
+                                ' and '. $setting->ee_snapshot_date_2->format('M j, Y') . ' (defined in Statistics Update page)');   
         $this->LogMessage( "" );   
         $this->LogMessage( "As of date           : " . $as_of_date->format('Y-m-d') );           
         $this->LogMessage( "" );   
 
         if ( $as_of_date && 
                 ( $this->option('date')  ||
-                ($as_of_date->month ==  9 && $as_of_date->day ==  1) ||
-                ($as_of_date->month == 10 && $as_of_date->day == 15)
+                ($as_of_date == $setting->ee_snapshot_date_1)  ||
+                ($as_of_date == $setting->ee_snapshot_date_2) 
+                // ($as_of_date->month ==  9 && $as_of_date->day ==  1) ||
+                // ($as_of_date->month == 10 && $as_of_date->day == 15)
                 ) ) {
 
             $campaign_year = today()->year;

--- a/app/Http/Controllers/Admin/ChallengeSettingsController.php
+++ b/app/Http/Controllers/Admin/ChallengeSettingsController.php
@@ -44,6 +44,9 @@ class ChallengeSettingsController extends Controller
             'campaign_start_date'       => 'required|date',
             'campaign_end_date'         => 'required|date|after:campaign_start_date',
             'campaign_final_date'       => 'required|date|after_or_equal:campaign_end_date',
+            'ee_snapshot_date_1'         => 'required|date',
+            'ee_snapshot_date_2'         => 'required|date|after:ee_snapshot_date_1',
+
         ],[
 
         ]);
@@ -96,6 +99,9 @@ class ChallengeSettingsController extends Controller
         $setting->campaign_start_date =  $request->campaign_start_date;
         $setting->campaign_end_date   =  $request->campaign_end_date;
         $setting->campaign_final_date =  $request->campaign_final_date;
+
+        $setting->ee_snapshot_date_1 = $request->ee_snapshot_date_1;
+        $setting->ee_snapshot_date_2 = $request->ee_snapshot_date_2;
         $setting->save();
         
         return response()->noContent();

--- a/app/Http/Controllers/ChallengeController.php
+++ b/app/Http/Controllers/ChallengeController.php
@@ -506,7 +506,7 @@ class ChallengeController extends Controller
 
     public function org_participation_tracker(Request $request)
     {
-        if (!(CampaignYear::isAnnualCampaignOpenNow())) {
+        if (!(Setting::isOrgParticipationTrackerActive())) {
             abort(404);
         }
 
@@ -528,7 +528,7 @@ class ChallengeController extends Controller
 
     public function org_participation_tracker_download(Request $request)
     {
-        if (!(CampaignYear::isAnnualCampaignOpenNow())) {
+        if (!(Setting::isOrgParticipationTrackerActive())) {
             abort(404);
         }
         
@@ -542,7 +542,8 @@ class ChallengeController extends Controller
                             ->where('business_unit_code', $bu)
                             ->first();
         
-        $start_date =  Carbon::createFromDate(null, 10, 15);  // Year defaults to current year
+        $setting = Setting::first();                           
+        $start_date = $setting->ee_snapshot_date_2 ?: Carbon::createFromDate(null, 10, 15);  // Year defaults to current year
 
         if ( ($cy < today()->year || today() >= $start_date) && $ee_by_bu) {
 
@@ -559,7 +560,7 @@ class ChallengeController extends Controller
         } else {
 
             return redirect()->route('challenge.org_participation_tracker')
-                    ->with('message', 'The organization partipation tracter report for campaign Year ' . $cy . ' will be accessible starting from October 15, ' . $cy);
+                    ->with('message', 'The organization partipation tracter report for campaign Year ' . $cy . ' will be accessible starting from ' . $setting->ee_snapshot_date_2->format('M j, Y') );
         }
 
     }

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -15,6 +15,7 @@ class Setting extends Model implements Auditable
         'system_lockdown_start', 'system_lockdown_end',
         'challenge_start_date', 'challenge_end_date', 'volunteer_start_date', 'volunteer_end_date','campaign_end_date','campaign_start_date',"campaign_final_date","challenge_final_date","volunteer_language",
         "campaign_processed_final_date","challenge_processed_final_date",
+        'ee_snapshot_date_1', 'ee_snapshot_date_2', 
 
     ];
 
@@ -31,7 +32,9 @@ class Setting extends Model implements Auditable
         'campaign_end_date' => 'date:Y-m-d',
         'campaign_final_date' => 'date:Y-m-d',
         'campaign_processed_final_date' => 'date:Y-m-d',
-       
+
+        'ee_snapshot_date_1' => 'date:Y-m-d', 
+        'ee_snapshot_date_2' => 'date:Y-m-d',
     ];
 
     protected $appends = [
@@ -76,6 +79,18 @@ class Setting extends Model implements Auditable
 
         $setting = self::first();
         if ($in_date > $setting->campaign_start_date && $in_date <= $setting->campaign_final_date) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static function isOrgParticipationTrackerActive( $in_date = null ) {
+
+        $in_date = $in_date ?? today();
+
+        $setting = self::first();
+        if ($in_date >= $setting->ee_snapshot_date_2 && CampaignYear::isAnnualCampaignOpenNow() ) {
             return true;
         }
 

--- a/database/migrations/2024_08_01_101435_add_snap_shot_date_in_settings_table.php
+++ b/database/migrations/2024_08_01_101435_add_snap_shot_date_in_settings_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            //
+            $table->date('ee_snapshot_date_1')->default('2024-09-01')->after('volunteer_language');
+            $table->date('ee_snapshot_date_2')->default('2024-10-15')->after('ee_snapshot_date_1');
+        });
+
+        DB::statement("ALTER TABLE settings MODIFY COLUMN created_at DATE AFTER ee_snapshot_date_2");
+        DB::statement("ALTER TABLE settings MODIFY COLUMN updated_at DATE AFTER created_at");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('settings', function (Blueprint $table) {
+            //
+            $table->dropColumn('ee_snapshot_date_1');
+            $table->dropColumn('ee_snapshot_date_2');
+        });
+
+        DB::statement("ALTER TABLE settings MODIFY COLUMN created_at DATE AFTER volunteer_end_date");
+        DB::statement("ALTER TABLE settings MODIFY COLUMN updated_at DATE AFTER created_at");
+
+    }
+};

--- a/resources/views/admin-campaign/challenge/index.blade.php
+++ b/resources/views/admin-campaign/challenge/index.blade.php
@@ -28,11 +28,29 @@
 
     <div class="card">
         <div class="card-body">
-            <p class="font-italic  text-danger"><u>Note:</u> For final date before March 1, it will be considered a previous campaign year (e.g 2024-02-20, the campiagn year is still 2023)</p>
 
+            <div class="row pt-1">
+                <div class="col-md-12"><h4 class="text-primary">Eligible Employee Snapshot Process / Organization Participation Tractor Report</h4></div>
+            </div>
+            <p class="font-italic  text-danger"><u>Note:</u> The date of the second snapshot is also used to determine when the Organization Tracker Report will become available online, continuing until the campaign's end date.</p>
+            <div class="form-row pt-2">
+                <div class="form-group col-md-3">
+                    <label for="ee_snapshot_date_1">1st Snapshot capture date</label>
+                    <input type="date" class="form-control input-control" name="ee_snapshot_date_1" 
+                                value="{{ $setting->ee_snapshot_date_1->toDateString() }}" />
+                </div>
+                <div class="form-group col-md-3">
+                    <label for="ee_snapshot_date_2">2nd Snapshot capture date</label>
+                    <input type="date" class="form-control input-control" name="ee_snapshot_date_2" 
+                                value="{{ $setting->ee_snapshot_date_2->toDateString() }}" />
+                </div>
+            </div>
+
+            <hr>
             <div class="row pb-2">
                 <div class="col-md-12"><h4 class="text-primary">Statistics Page Updates</h4></div>
             </div>
+            <p class="font-italic  text-danger"><u>Note:</u> Click the "Finalize Statistics Page" button if you need to finalize immediately, instead of waiting for the scheduled process.</p>
             <div class="form-row">
                 <div class="form-group col-md-3">
                     <label for="challenge_start_date">Start Date</label>
@@ -57,8 +75,9 @@
                         </button>
                 </div>
             </div>
-  
-            <div class="row pt-4">
+
+            <hr>
+            <div class="row pt-2">
                 <div class="col-md-12"><h4 class="text-primary">Daily Campaign Updates</h4></div>
             </div>
             <div class="form-row pt-2">
@@ -124,9 +143,11 @@
         if (confirm(info))
         {
             var fields = ['challenge_start_date', 'challenge_end_date','challenge_final_date',
-                          'campaign_start_date', 'campaign_end_date','campaign_final_date'];
+                          'campaign_start_date', 'campaign_end_date','campaign_final_date',
+                          'ee_snapshot_date_1', 'ee_snapshot_date_2'];
             $.each( fields, function( index, field_name ) {
                  $('#setting-edit-form [name='+field_name+']').nextAll('span.text-danger').remove();
+                 $('#setting-edit-form [name='+field_name+']').removeClass('is-invalid');
             });
 
             $.ajax({
@@ -148,6 +169,7 @@
 
                         $.each(response.responseJSON.errors, function(field_name,error){
                             $(document).find('[name='+field_name+']').after('<span class="text-strong text-danger">' +error+ '</span>')
+                            $(document).find('[name='+field_name+']').addClass('is-invalid');
                         })
                     }
                     console.log('Error');

--- a/resources/views/challenge/partials/tabs.blade.php
+++ b/resources/views/challenge/partials/tabs.blade.php
@@ -11,7 +11,7 @@
           Daily Campaign Update</a>
   </li>
   @endif
-  @if (\App\Models\CampaignYear::isAnnualCampaignOpenNow())
+  @if (\App\Models\Setting::isOrgParticipationTrackerActive() )
   <li class="nav-item nav-center-4">
       <a class="nav-link {{ str_contains( Route::current()->getName(), 'challenge.org_participation_tracker') ? 'active disabled' : ''}}" 
           href="{{  route('challenge.org_participation_tracker') }}" role="tab" aria-controls="pills-tracker" aria-selected="false">


### PR DESCRIPTION
Add new fields for Eligible Employee Snapshot date 1 and date 2 added. Those fields will be used for determine when generate Eligible Employee snapshot and make the Org Participation Tracker report availability.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/1sJEqPKXAk-oFMOCHAEUkWUAFmwH?Type=TaskLink&Channel=Link&CreatedTime=638581416337480000)

