### PR TITLE
[jp-0159] Admin -- Enable administrators to modify the selected charities for the Donate Now pledge that transfers to PeopleSoft (fix bug) 

### DIFF
--- a/resources/views/admin-pledge/donate-now/create-edit.blade.php
+++ b/resources/views/admin-pledge/donate-now/create-edit.blade.php
@@ -327,7 +327,7 @@
                     <label for="one_time_amount" class="col-sm-3 col-form-label">The One-time payroll deductions :</label>
                     <div class="col-sm-2">
                         <input type="text" name="one_time_amount" class="form-control" id="one_time_amount" placeholder="amount"
-                            value="{{ $pledge ? $pledge->one_time_amount : '' }}"  {{  ($pledge->ods_export_status ? 'disabled' : '') }}>
+                            value="{{ $pledge ? $pledge->one_time_amount : '' }}"  {{  ($pledge->ods_export_status ? 'readonly tabindex=-1' : '') }}>
                     </div>
                 </div>
 


### PR DESCRIPTION
Business requirement:
Administrators need to update user charity choices due to the charities being inactive on the CRA listing.
Add a new function for administrators to modify the selected charities for the Donate Now Pledge that transfers to PeopleSoft.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/7H1v1YYLekecFT4OyuEl8mUAAKm_?Type=TaskLink&Channel=Link&CreatedTime=638567496540340000)