### PR TITLE
(TEST) [jp-0169] Correct Deduct Pay dates in Donate Now

### DIFF
--- a/database/seeders/DataFixFor_jp_0169_DonateNowPledges1_to_6.php
+++ b/database/seeders/DataFixFor_jp_0169_DonateNowPledges1_to_6.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0169_DonateNowPledges1_to_6 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reassign charity on Evenet Pledge 173 
+        
+        echo 'Before change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw("id between 1 and 6 and emplid in ('010058','064306', '160588') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        // Data Fix
+        /*
+            EE                    Deduct Pay      Actual Deduct Pay Date  
+
+            010058                2024-01-05       2024-01-19 
+            064306                2024-01-05       2024-01-19 
+            160588                2024-01-05       2024-01-19 
+        */
+        DB::update("update donate_now_pledges set deduct_pay_from = '2024-01-19', updated_at = now() where id between 1 and 6 and emplid in ('010058','064306', '160588') 
+                        and deleted_at is null;");
+        
+        echo PHP_EOL;
+        echo PHP_EOL;
+        echo 'After change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw("id between 1 and 6 and emplid in ('010058','064306', '160588') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+    }
+}


### PR DESCRIPTION
The Donate Now Pledge (PECADD) for 3 Gov EEs’ deduct from pay dates do not match the actual deduction check dates. Greenfield shows the Deduction Pay as 2024-01-05, the actual deduction Pay should be 2024-01-19.  

Please update the Deduct Pay date in Greenfield for the three EEs below to the correct date. 

EE                    Deduct Pay      Actual Deduct Pay Date  

010058                2024-01-05       2024-01-19 
064306                2024-01-05       2024-01-19 
160588                2024-01-05       2024-01-19 

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/z1g9uyBIjUyXw2k7eoewTmUAHe6G?Type=TaskLink&Channel=Link&CreatedTime=638590857585870000)
