### PR TITLE
[jp-0168] Organization Participation Tracker must function on custom dates (fine tune wordings)

### DIFF
--- a/resources/views/admin-campaign/challenge/index.blade.php
+++ b/resources/views/admin-campaign/challenge/index.blade.php
@@ -30,7 +30,7 @@
         <div class="card-body">
 
             <div class="row pt-1">
-                <div class="col-md-12"><h4 class="text-primary">Eligible Employee Snapshot Process / Organization Participation Tractor Report</h4></div>
+                <div class="col-md-12"><h4 class="text-primary">Eligible Employee Snapshot Process / Organization Participation Tracker Report</h4></div>
             </div>
             <p class="font-italic  text-danger"><u>Note:</u> The date of the second snapshot is also used to determine when the Organization Tracker Report will become available online, continuing until the campaign's end date.</p>
             <div class="form-row pt-2">
@@ -50,7 +50,7 @@
             <div class="row pb-2">
                 <div class="col-md-12"><h4 class="text-primary">Statistics Page Updates</h4></div>
             </div>
-            <p class="font-italic  text-danger"><u>Note:</u> Click the "Finalize Statistics Page" button if you need to finalize immediately, instead of waiting for the scheduled process.</p>
+            <p class="font-italic  text-danger"><u>Note:</u> Click the "Finalize Statistics Page" button if you need to set a previous date for the finalization. For future final dates, the scheduled job will process as planned.</p>
             <div class="form-row">
                 <div class="form-group col-md-3">
                     <label for="challenge_start_date">Start Date</label>


### PR DESCRIPTION
Add new fields for Eligible Employee Snapshot date 1 and date 2 added. Those fields will be used for determine when generate Eligible Employee snapshot and make the Org Participation Tracker report availability.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/1sJEqPKXAk-oFMOCHAEUkWUAFmwH?Type=TaskLink&Channel=Link&CreatedTime=638581416337480000)