### PR TITLE
[jp-0171] Security update required -- 1 HIGH security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "PECSF",
             "dependencies": {
                 "@bcgov/bc-sans": "^1.0.1",
                 "@fortawesome/fontawesome-free": "^5.15.4",
@@ -2962,12 +2963,12 @@
             }
         },
         "node_modules/axios": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
-            "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
             "dev": true,
             "dependencies": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -4847,9 +4848,9 @@
             "dev": true
         },
         "node_modules/elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.5.7",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+            "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
             "dev": true,
             "dependencies": {
                 "bn.js": "^4.11.9",
@@ -13093,12 +13094,12 @@
             "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
         },
         "axios": {
-            "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.3.tgz",
-            "integrity": "sha512-fWyNdeawGam70jXSVlKl+SUNVcL6j6W79CuSIPfi6HnDUmSCH6gyUys/HrqHeA/wU0Az41rRgean494d0Jb+ww==",
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
+            "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
             "dev": true,
             "requires": {
-                "follow-redirects": "^1.15.0",
+                "follow-redirects": "^1.15.6",
                 "form-data": "^4.0.0",
                 "proxy-from-env": "^1.1.0"
             }
@@ -14636,9 +14637,9 @@
             "dev": true
         },
         "elliptic": {
-            "version": "6.5.4",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "version": "6.5.7",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.7.tgz",
+            "integrity": "sha512-ESVCtTwiA+XhY3wyh24QqRGBoP3rEdDUl3EDUUo9tft074fi19IrdpH7hLCMMP3CIj7jb3W96rn8lt/BqIlt5Q==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.11.9",


### PR DESCRIPTION
Aug 13- 1 HIGH vulnerabilities reported on Github.

Server-Side Request Forgery in axios
https://github.com/bcgov/PECSF/security/dependabot/93

Required to "Upgrade axios to fix 1 Dependabot alert in package-lock.json"

Package                 Affected versions            Patched version    
axios (npm)          >= 1.3.2, <= 1.7.3           1.7.4       

axios 1.7.2 allows SSRF via unexpected behavior where requests for path relative URLs get processed as protocol relative URLs.

Action:
====

> npm audit 
# npm audit report

axios  1.3.2 - 1.7.3
Severity: high
Server-Side Request Forgery in axios - https://github.com/advisories/GHSA-8hc4-vh64-cxmj
fix available via `npm audit fix`
node_modules/axios

8 vulnerabilities (2 low, 5 moderate, 1 high)

> npm audit fix

6 vulnerabilities (1 low, 5 moderate)

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Gm3cvqOou0WulhWlsKQAC2UAA7gE?Type=TaskLink&Channel=Link&CreatedTime=638592042632270000)
