### PR TITLE
(TEST) [jp-0172] eForm - Default Business Unit not assigned

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -1008,7 +1008,16 @@ class BankDepositFormController extends Controller
     }
 
     function bc_gov_id(Request $request){
-        $record = EmployeeJob::where("emplid","=",$request->id)->join("business_units","business_units.code","employee_jobs.business_unit")->join("cities","cities.city","employee_jobs.office_city")->selectRaw("business_units.id as business_unit_id, employee_jobs.office_city, employee_jobs.region_id, cities.TGB_REG_DISTRICT as tgb_reg_district, employee_jobs.first_name, employee_jobs.last_name")->first();
+        // $record = EmployeeJob::where("emplid","=",$request->id)->join("business_units","business_units.code","employee_jobs.business_unit")->join("cities","cities.city","employee_jobs.office_city")->selectRaw("business_units.id as business_unit_id, employee_jobs.office_city, employee_jobs.region_id, cities.TGB_REG_DISTRICT as tgb_reg_district, employee_jobs.first_name, employee_jobs.last_name")->first();
+
+        $record = EmployeeJob::where("emplid","=",$request->id)
+                                ->with('bus_unit', 'city_by_office_city')
+                                ->select('business_unit_id', 'business_unit', 'dept_name','office_city', 'region_id', 'first_name', 'last_name')
+                                ->first();
+
+        $record->business_unit_id = $record ? $record->challenge_business_unit->id : null;
+        $record->tgb_reg_district = $record ? $record->city_by_office_city->TGB_REG_DISTRICT : null;
+
         if(!empty($record)){
             return response()->json($record, 200);
         }

--- a/app/Models/BankDepositForm.php
+++ b/app/Models/BankDepositForm.php
@@ -48,6 +48,7 @@ class BankDepositForm extends Model implements Auditable
     protected $appends = [
         'status',
         'charity_selection',
+        'challenge_business_unit',
     ];
 
     protected $casts = [
@@ -69,6 +70,21 @@ class BankDepositForm extends Model implements Auditable
 
     public function getCharitySelectionAttribute() {
         return ($this->regional_pool_id ? 'fsp' : 'dc');
+    }
+
+    public function getChallengeBusinessUnitAttribute()
+    {
+
+        // Special Rule -- To split GCPE employees from business unit BC022 
+        $bu = BusinessUnit::where('id', $this->business_unit)->first();
+        $business_unit_code = $bu ? $bu->linked_bu_code : null;
+        if ($bu->code == 'BC022' && str_starts_with($this->dept_name, 'GCPE')) {
+            $business_unit_code  = 'BGCPE';
+        }
+        $linked_bu = BusinessUnit::where('code', $business_unit_code)->first();
+
+        return $linked_bu;
+
     }
 
     function attachments(){

--- a/app/Models/BusinessUnit.php
+++ b/app/Models/BusinessUnit.php
@@ -33,6 +33,11 @@ class BusinessUnit extends Model implements Auditable
         return $this->hasOne(Organization::Class, 'bu_code', 'code');
     }
 
+    public function linked_business_unit()
+    {
+        return $this->hasOne(BusinessUnit::Class, 'code', 'linked_bu_code');
+    }
+
     public function created_by()
     {
         return $this->hasOne(User::Class, 'id', 'created_by_id');

--- a/app/Models/EmployeeJob.php
+++ b/app/Models/EmployeeJob.php
@@ -45,6 +45,7 @@ class EmployeeJob extends Model
         'years_of_service',
         'years_of_volunteer',
         'total_donations',
+        'challenge_business_unit',
     ];
 
     public const EMPL_STATUS_LIST = 
@@ -200,6 +201,22 @@ class EmployeeJob extends Model
 
 
         return $total_amount;
+    }
+
+
+    public function getChallengeBusinessUnitAttribute()
+    {
+
+        // Special Rule -- To split GCPE employees from business unit BC022 
+        $bu = BusinessUnit::where('code', $this->business_unit)->first();
+        $business_unit_code = $bu ? $bu->linked_bu_code : null;
+        if ($this->business_unit == 'BC022' && str_starts_with($this->dept_name, 'GCPE')) {
+            $business_unit_code  = 'BGCPE';
+        }
+        $linked_bu = BusinessUnit::where('code', $business_unit_code)->first();
+
+        return $linked_bu;
+
     }
 
 }

--- a/app/Models/Pledge.php
+++ b/app/Models/Pledge.php
@@ -49,6 +49,7 @@ class Pledge extends Model implements Auditable
 
     protected $appends = [
         'frequency',
+        'challenge_business_unit',
     ];
 
     // Class Method 
@@ -88,6 +89,21 @@ class Pledge extends Model implements Auditable
             $frequency = 'bi-weekly';
         }
         return $frequency;
+
+    }
+
+    public function getChallengeBusinessUnitAttribute()
+    {
+
+        // Special Rule -- To split GCPE employees from business unit BC022 
+        $bu = BusinessUnit::where('code', $this->business_unit)->first();
+        $business_unit_code = $bu ? $bu->linked_bu_code : null;
+        if ($this->business_unit == 'BC022' && str_starts_with($this->dept_name, 'GCPE')) {
+            $business_unit_code  = 'BGCPE';
+        }
+        $linked_bu = BusinessUnit::where('code', $business_unit_code)->first();
+
+        return $linked_bu;
 
     }
 

--- a/tests/Feature/AdminBankDepositFormTest.php
+++ b/tests/Feature/AdminBankDepositFormTest.php
@@ -406,7 +406,7 @@ class AdminBankDepositFormTest extends TestCase
                                     ]);
 
         $response->assertStatus(200);
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'challenge_business_unit']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('bank_deposit_form_organizations', Arr::except($charity->attributesToArray(),[] ));
@@ -489,7 +489,7 @@ class AdminBankDepositFormTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'charities', 'created_at', 'updated_at']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'charities', 'challenge_business_unit', 'created_at', 'updated_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('bank_deposit_form_organizations', Arr::except($charity->attributesToArray(),['created_at', 'updated_at'] ));

--- a/tests/Feature/AdminCampaignPledgeTest.php
+++ b/tests/Feature/AdminCampaignPledgeTest.php
@@ -228,7 +228,7 @@ class AdminCampaignPledgeTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(),['pledge_id'] ));
@@ -296,7 +296,7 @@ class AdminCampaignPledgeTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'updated_at', 'created_at']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(), ['updated_at', 'created_at']));
@@ -315,7 +315,7 @@ class AdminCampaignPledgeTest extends TestCase
 
         $response->assertStatus(204);
         // Assert the file was deleted ...
-        $this->assertSoftDeleted('pledges',  Arr::except($pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'updated_at', 'created_at'])  );
+        $this->assertSoftDeleted('pledges',  Arr::except($pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at'])  );
         foreach ($pledge->charities as $charity) {
             $this->assertSoftDeleted('pledge_charities', Arr::except($charity->attributesToArray(), ['updated_at', 'created_at']));
         }

--- a/tests/Feature/AdminSubmissionQueueTest.php
+++ b/tests/Feature/AdminSubmissionQueueTest.php
@@ -366,7 +366,7 @@ class AdminSubmissionQueueTest extends TestCase
         $pledge->approved = 1;
 
         $response->assertStatus(204);
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'updated_at', 'created_at']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         // $response->assertRedirect('login');
     }

--- a/tests/Feature/AdminVolunteerProfileTest.php
+++ b/tests/Feature/AdminVolunteerProfileTest.php
@@ -674,6 +674,8 @@ class AdminVolunteerProfileTest extends TestCase
             $address_type = $this->faker->randomElement( ['G', 'S'] );
         }
 
+        $opt_out_recongnition = $this->faker->randomElement( ['Y', 'N'] );
+
         // Test Transaction
         $profile = VolunteerProfile::factory()->make([
             'campaign_year' => today()->year,
@@ -688,11 +690,11 @@ class AdminVolunteerProfileTest extends TestCase
             'business_unit_code' => $business2->code,
 
             'address_type' =>  $address_type,
-            'address' => $address_type == 'G' ? null : substr($this->faker->address(), 0, 60),
-            'city' => $address_type == 'G' ? null : $city->city,
-            'province' => $address_type == 'G' ? null : $this->faker->randomElement( array_keys($province_list) ),
-            'postal_code' => $address_type == 'G' ? null : $this->faker->regexify('/^[A-Z]\d[A-Z]\ {1}\d[A-Z]\d$/'),
-
+            'address' => ($address_type == 'G' || $opt_out_recongnition == 'Y') ? null : substr($this->faker->address(), 0, 60),
+            'city' => ($address_type == 'G' || $opt_out_recongnition == 'Y') ? null : $city->city,
+            'province' => ($address_type == 'G' || $opt_out_recongnition == 'Y') ? null : $this->faker->randomElement( array_keys($province_list) ),
+            'postal_code' => ($address_type == 'G' || $opt_out_recongnition== 'Y') ? null : $this->faker->regexify('/^[A-Z]\d[A-Z]\ {1}\d[A-Z]\d$/'),
+            'opt_out_recongnition' => $opt_out_recongnition,
         ]);
 
         $form_data = $this->tranform_to_form_data($profile);

--- a/tests/Feature/AnnualCampaignTest.php
+++ b/tests/Feature/AnnualCampaignTest.php
@@ -236,7 +236,7 @@ class AnnualCampaignTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(),['pledge_id'] ));
@@ -307,7 +307,7 @@ class AnnualCampaignTest extends TestCase
         // $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'updated_at', 'created_at']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(), ['updated_at', 'created_at']));

--- a/tests/Feature/BankDepositFormTest.php
+++ b/tests/Feature/BankDepositFormTest.php
@@ -275,7 +275,7 @@ class BankDepositFormTest extends TestCase
         // $response->assertSessionHas('success');
         // $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection','challenge_business_unit']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('bank_deposit_form_organizations', Arr::except($charity->attributesToArray(),[] ));

--- a/tests/Feature/ChallengePageTest.php
+++ b/tests/Feature/ChallengePageTest.php
@@ -218,7 +218,10 @@ class ChallengePageTest extends TestCase
         $this->actingAs($this->user);
         $response = $this->get('challenge/org_participation_tracker');
 
-        $response->assertStatus(200);
+        if (Setting::isCampaignPeriodActive()) 
+            $response->assertStatus(200);
+        else
+            $response->assertStatus(404);
     }
  
     public function test_an_authorized_user_can_download_org_participation_tracker()
@@ -228,8 +231,12 @@ class ChallengePageTest extends TestCase
         $this->actingAs($this->user);
         $response = $this->get('challenge/org_participation_tracker_download', []);
  
-        $response->assertStatus(302);
-        $response->assertSessionHas( "message" );
+        if (Setting::isOrgParticipationTrackerActive()) {
+            $response->assertStatus(302);
+            $response->assertSessionHas( "message" );
+        } else {
+            $response->assertStatus(404);
+        }
 
     }
 
@@ -497,6 +504,8 @@ class ChallengePageTest extends TestCase
                 'challenge_start_date' => $year . '-09-01',
                 'challenge_end_date' => $year . '-11-15',
                 'challenge_final_date' => (today() < today()->year . '-03-01') ? today() : $year + 1 . '-02-28',
+                'ee_snapshot_date_1' => $year . '-09-01',
+                'ee_snapshot_date_2' => $year . '-10-15',
 
         ]);
 

--- a/tests/Feature/ChallengeSettingsTest.php
+++ b/tests/Feature/ChallengeSettingsTest.php
@@ -219,6 +219,9 @@ class ChallengeSettingsTest extends TestCase
             // 'campaign_end_date' => today()->year . '-12-31',
             'campaign_end_date' => today()->year . '-11-15',
             'campaign_final_date' => today()->year + 1 . '-02-14',
+
+            'ee_snapshot_date_1' => today()->year + 1 . '-09-01',
+            'ee_snapshot_date_2' => today()->year + 1 . '-10-15',
         ];
         
         $this->actingAs($this->admin);


### PR DESCRIPTION
Issue:
When submitting an event form, if user enters the emp id, expected result is that other details in the form including the Business unit field must pop up automatically. But for BU BC063 & BC725, Ministry of Education and Child Care the business unit does not pop up.
For testing, the following emp id can be used:
148617
110051

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/yR-kl2f26EuJ5YKGmdXz0mUALE54?Type=TaskLink&Channel=Link&CreatedTime=638603689656190000)