### PR TITLE
(TEST) [jp-0175] Correct the text displayed in the blue banner on My Donations

### DIFF
--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -30,7 +30,7 @@
                 @else
 
                     <p class="font-weight-bold">Thank you for choosing to support PECSF!</p>
-                    <p class="card-text text-left">Click the “Details” button below to see your campaign pledge.</p>
+                    {{-- <p class="card-text text-left">Click the “Details” button below to see your campaign pledge.</p> --}}
                     <p class="card-text text-left">
                         {{-- The Fall campaign has closed, to make changes to your PECSF pledge please email PECSF@gov.bc.ca --}}
                         If you need to change or stop your PECSF campaign payroll pledge deduction, please email <a href="mailto:PECSF@gov.bc.ca">PECSF@gov.bc.ca</a>.


### PR DESCRIPTION
When not in an active campaign, the text displayed in the blue banner on the My donations page is incorrect.
The text says 'Click the “Details” button below to see your campaign pledge.'
There is no details button on the page now, so can we please remove this line?

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/ezvXYHFZd0-PnZW8hi12omUADxJ2?Type=TaskLink&Channel=Link&CreatedTime=638603818208280000)