### PR TITLE
[jp-0176] Refreshing the Thank You page in the donations throws a 403 error

### DIFF
--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -516,6 +516,16 @@ class AnnualCampaignController extends Controller
     public function thankYou()
     {
         $pledge_id = session()->get('pledge_id');
+      
+        if (!($pledge_id)) {
+            $campaign_year = CampaignYear::where('calendar_year', '<=', today()->year + 1 )
+                                   ->orderBy('calendar_year', 'desc')->first();
+            if ($campaign_year->isOpen()) {
+                $user = User::where('id', Auth::id())->first();
+                $pledge =  Pledge::where('emplid', $user->emplid)->orderBy('id', 'desc')->first();
+                $pledge_id = $pledge->id;
+            }
+        }
 
         if ($pledge_id) {
             return view('annual-campaign.thankyou', compact('pledge_id') );


### PR DESCRIPTION
Issue
In an active campaign, user made a donation and landed on the Thank you page. Insisted on clicking on view donation history, if user clicks on the refresh page, a 403 error is received.

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/hugrTmeHT0eZBnTH8EyL4mUAA7Jj?Type=TaskLink&Channel=Link&CreatedTime=638604634520530000)