### PR TITLE
(TEST) [jp-0177] Distribute evenly and PECSF email does not appear as link

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -1008,7 +1008,16 @@ class BankDepositFormController extends Controller
     }
 
     function bc_gov_id(Request $request){
-        $record = EmployeeJob::where("emplid","=",$request->id)->join("business_units","business_units.code","employee_jobs.business_unit")->join("cities","cities.city","employee_jobs.office_city")->selectRaw("business_units.id as business_unit_id, employee_jobs.office_city, employee_jobs.region_id, cities.TGB_REG_DISTRICT as tgb_reg_district, employee_jobs.first_name, employee_jobs.last_name")->first();
+        // $record = EmployeeJob::where("emplid","=",$request->id)->join("business_units","business_units.code","employee_jobs.business_unit")->join("cities","cities.city","employee_jobs.office_city")->selectRaw("business_units.id as business_unit_id, employee_jobs.office_city, employee_jobs.region_id, cities.TGB_REG_DISTRICT as tgb_reg_district, employee_jobs.first_name, employee_jobs.last_name")->first();
+
+        $record = EmployeeJob::where("emplid","=",$request->id)
+                                ->with('bus_unit', 'city_by_office_city')
+                                ->select('business_unit_id', 'business_unit', 'dept_name','office_city', 'region_id', 'first_name', 'last_name')
+                                ->first();
+
+        $record->business_unit_id = $record ? $record->challenge_business_unit->id : null;
+        $record->tgb_reg_district = $record ? $record->city_by_office_city->TGB_REG_DISTRICT : null;
+
         if(!empty($record)){
             return response()->json($record, 200);
         }

--- a/app/Http/Controllers/ContactFaqController.php
+++ b/app/Http/Controllers/ContactFaqController.php
@@ -29,7 +29,7 @@ class ContactFaqController extends Controller
             'Volunteering' => [
                 [
                     'question' => 'Where do I find more information on volunteering with the PECSF Annual Campaign?  ',
-                    'answer' => 'You will find volunteering information in the  <a href="/volunteering">Volunteer Section</a> which includes contact information for lead coordinators, possible roles, training, resources and blogs.'
+                    'answer' => 'You will find volunteering information in the  <a href="/volunteering" style="text-decoration: underline;">Volunteer Section</a> which includes contact information for lead coordinators, possible roles, training, resources and blogs.'
                 ],
                 [
                     'question' => 'How much time on average do I have to commit to as a volunteer?',

--- a/app/Models/BankDepositForm.php
+++ b/app/Models/BankDepositForm.php
@@ -48,6 +48,7 @@ class BankDepositForm extends Model implements Auditable
     protected $appends = [
         'status',
         'charity_selection',
+        'challenge_business_unit',
     ];
 
     protected $casts = [
@@ -69,6 +70,21 @@ class BankDepositForm extends Model implements Auditable
 
     public function getCharitySelectionAttribute() {
         return ($this->regional_pool_id ? 'fsp' : 'dc');
+    }
+
+    public function getChallengeBusinessUnitAttribute()
+    {
+
+        // Special Rule -- To split GCPE employees from business unit BC022 
+        $bu = BusinessUnit::where('id', $this->business_unit)->first();
+        $business_unit_code = $bu ? $bu->linked_bu_code : null;
+        if ($bu->code == 'BC022' && str_starts_with($this->dept_name, 'GCPE')) {
+            $business_unit_code  = 'BGCPE';
+        }
+        $linked_bu = BusinessUnit::where('code', $business_unit_code)->first();
+
+        return $linked_bu;
+
     }
 
     function attachments(){

--- a/app/Models/BusinessUnit.php
+++ b/app/Models/BusinessUnit.php
@@ -33,6 +33,11 @@ class BusinessUnit extends Model implements Auditable
         return $this->hasOne(Organization::Class, 'bu_code', 'code');
     }
 
+    public function linked_business_unit()
+    {
+        return $this->hasOne(BusinessUnit::Class, 'code', 'linked_bu_code');
+    }
+
     public function created_by()
     {
         return $this->hasOne(User::Class, 'id', 'created_by_id');

--- a/app/Models/EmployeeJob.php
+++ b/app/Models/EmployeeJob.php
@@ -45,6 +45,7 @@ class EmployeeJob extends Model
         'years_of_service',
         'years_of_volunteer',
         'total_donations',
+        'challenge_business_unit',
     ];
 
     public const EMPL_STATUS_LIST = 
@@ -200,6 +201,22 @@ class EmployeeJob extends Model
 
 
         return $total_amount;
+    }
+
+
+    public function getChallengeBusinessUnitAttribute()
+    {
+
+        // Special Rule -- To split GCPE employees from business unit BC022 
+        $bu = BusinessUnit::where('code', $this->business_unit)->first();
+        $business_unit_code = $bu ? $bu->linked_bu_code : null;
+        if ($this->business_unit == 'BC022' && str_starts_with($this->dept_name, 'GCPE')) {
+            $business_unit_code  = 'BGCPE';
+        }
+        $linked_bu = BusinessUnit::where('code', $business_unit_code)->first();
+
+        return $linked_bu;
+
     }
 
 }

--- a/app/Models/Pledge.php
+++ b/app/Models/Pledge.php
@@ -49,6 +49,7 @@ class Pledge extends Model implements Auditable
 
     protected $appends = [
         'frequency',
+        'challenge_business_unit',
     ];
 
     // Class Method 
@@ -88,6 +89,21 @@ class Pledge extends Model implements Auditable
             $frequency = 'bi-weekly';
         }
         return $frequency;
+
+    }
+
+    public function getChallengeBusinessUnitAttribute()
+    {
+
+        // Special Rule -- To split GCPE employees from business unit BC022 
+        $bu = BusinessUnit::where('code', $this->business_unit)->first();
+        $business_unit_code = $bu ? $bu->linked_bu_code : null;
+        if ($this->business_unit == 'BC022' && str_starts_with($this->dept_name, 'GCPE')) {
+            $business_unit_code  = 'BGCPE';
+        }
+        $linked_bu = BusinessUnit::where('code', $business_unit_code)->first();
+
+        return $linked_bu;
 
     }
 

--- a/resources/views/annual-campaign/partials/amount-distribution.blade.php
+++ b/resources/views/annual-campaign/partials/amount-distribution.blade.php
@@ -18,7 +18,7 @@
                 </label>
             </div>
         </div>
-        <button type="button" class="distribute-evenly btn btn-link">Distribute evenly</button>
+        <button type="button" class="distribute-evenly btn btn-link" style="text-decoration: underline;">Distribute evenly</button>
     </div>
     <table class="table table-sm">
         @foreach ($selected_charities as $charity)

--- a/resources/views/annual-campaign/wizard.blade.php
+++ b/resources/views/annual-campaign/wizard.blade.php
@@ -97,7 +97,8 @@
                     </div>
                     <div class="tab-pane fade step" id="nav-distribution" role="tabpanel" aria-labelledby="nav-distribution-tab">
                         <h3>4. Decide on the distributions</h3>
-                        <p>You can distribute your contributions to each charity here. Start from the top and specify the amount of percentage so that together they are total 100%.
+                        <p>
+                            You can distribute your contributions to each charity listed here. Start from the top and specify either the amount or percentage for each so that the total adds up to 100%.
                         </p>
 
                         <span id="step-distribution-page">

--- a/resources/views/challenge/index.blade.php
+++ b/resources/views/challenge/index.blade.php
@@ -7,7 +7,8 @@
     @include('challenge.partials.tabs')
 
     <h6 class="mt-3">Visit this page daily during the PECSF campaign to see updated statistics, including organization participation rates!<br>
-        If you have questions about PECSF statistics, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca?subject=Statictics%20page">PECSF@gov.bc.ca</a>.</h6>
+        If you have questions about PECSF statistics, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca?subject=Statictics%20page"
+            style="text-decoration: underline;">PECSF@gov.bc.ca</a>.</h6>
 </div>
 @endsection
 
@@ -97,7 +98,7 @@
                         <button id="list-mode-btn" type="button" class="btn btn-primary">
                                 <span class="mx-2 px-2">List</span>
                         </button>
-                        <button type="button" class="btn btn-dark mx-0 px-0"></button>
+                        <button type="button" class="btn btn-dark mx-0 px-0" tabindex="-1"></button>
                         <button id="chart-mode-btn" type="button" class="btn btn-outline-secondary">
                                 <span class="px-2">Chart<span>
                         </button>
@@ -121,7 +122,7 @@
                 </thead>
             </table>
         </div>
-        <div id="chart-section" data-load="0"> 
+        <div id="chart-section" data-load="0" tabindex="0" aria-label="This is a chart about Partipation Rate"> 
             <div id="main" class="pt-2" style="width: auto;height:700px;"></div>
         </div>
 
@@ -350,6 +351,59 @@ $(function() {
 
     });
 
+    $(document).on('keyup', '#pills-tab', function(event) {
+
+        current = $(this).find('.nav-item .active');
+        all_items = $(this).find('.nav-item');
+        siblings = current.parent().siblings();
+
+        var tgt = event.currentTarget;
+        flag = false;
+
+        switch (event.key) {
+            case 'ArrowLeft':
+                if ( current.prev() )
+                    current.prev().trigger('click');
+                else 
+                    $(all_items[ allitems.length -1]).trigger('click');
+                // this.moveFocusToPreviousTab(tgt);
+                flag = true;
+                break;
+
+            case 'ArrowRight':
+            if (siblings.length > 0)
+                    $(siblings[0]).trigger('click');
+                else 
+                    $(all_items[0]).trigger('click');
+
+                // this.moveFocusToNextTab(tgt);
+                flag = true;
+                break;
+
+            case 'Home':
+                $(all_items[0]).trigger('click');
+                //this.moveFocusToTab(this.firstTab);
+                flag = true;
+                break;
+
+            case 'End':
+                $(all_items[ allitems.length -1]).trigger('click');
+                // this.moveFocusToTab(this.lastTab);
+                flag = true;
+                break;
+
+            default:
+                break;
+        }
+
+        if (flag) {
+            // event.stopPropagation();
+            // event.preventDefault();
+        }
+                
+    });
+ 
+
     $(document).on('keyup', '#organization_name', function() {
 
         term = $('#organization_name').val();
@@ -417,6 +471,12 @@ $(function() {
                     myChart.resize();
 
                     myChart.setOption({
+                        aria: {
+                            enabled: true,
+                            decal: {
+                               show: true
+                            }
+                        },
                         title: {
                             text: 'Participation Rate Chart',
                             textStyle: { fontSize: 20, fontWeight: 'bold' }, 

--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -6,7 +6,8 @@
             <div class="text-left mt-3">
                 <h1>Contact PECSF</h1>
                 <p>
-                    Got a question? We're here to help! If you don't see your question answered in the FAQ section below, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca">PECSF@gov.bc.ca</a>.
+                    Got a question? We're here to help! If you don't see your question answered in the FAQ section below, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca"
+                            style=" text-decoration: underline;">PECSF@gov.bc.ca</a>.
                 </p>
             </div>
          </div>

--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -30,7 +30,7 @@
                 @else
 
                     <p class="font-weight-bold">Thank you for choosing to support PECSF!</p>
-                    <p class="card-text text-left">Click the “Details” button below to see your campaign pledge.</p>
+                    {{-- <p class="card-text text-left">Click the “Details” button below to see your campaign pledge.</p> --}}
                     <p class="card-text text-left">
                         {{-- The Fall campaign has closed, to make changes to your PECSF pledge please email PECSF@gov.bc.ca --}}
                         If you need to change or stop your PECSF campaign payroll pledge deduction, please email <a href="mailto:PECSF@gov.bc.ca">PECSF@gov.bc.ca</a>.

--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -23,7 +23,7 @@
                         <a href="{{ route('annual-campaign.index') }}" class="btn btn-md btn-primary">Make a change to your PECSF pledge</a>
                     @else
                         <p class="card-text text-left">
-                            To make a pledge click the Donate button, copy a prior year's choices from your Donation History.
+                            To make a pledge, click the Donate button or copy a prior year's choice from your Donation History.
                         </p>
                         <a href="{{ route('annual-campaign.index') }}" class="btn btn-primary">Donate</a>
                     @endif
@@ -44,7 +44,7 @@
         </div>
     </div>
 
-    <div class="d-flex mt-3">
+    <div class="p-2 d-flex mt-3">
         <h1>My Donations</h1>
         <div class="flex-fill"></div>
         @if($totalPledgedDataTillNow > 0)
@@ -54,11 +54,11 @@
         @endif
         <x-button style="outline-primary" class="ml-2" data-toggle="modal" data-target="#learn-more-modal" >Why donate to PECSF?</x-button>
     </div>
-    <div class="d-flex flex-column">
+    <div class="p-2 d-flex flex-column">
         <p class="m-0">
-            Since you started giving through PECSF, you've donated ${{ number_format($totalPledgedDataTillNow,0) }}, as BC Public Servant.
+            Since you began donating through PECSF, your total contributions as a BC Public Servant amount to ${{ number_format($totalPledgedDataTillNow,0) }}.
         </p>
-        <small>reflects pledge totals from 2005 onwards</small>
+        <small>The donation history below reflects pledge totals from 2005 onwards.</small>
     </div>
 @endsection
 @section('content')

--- a/tests/Feature/AdminBankDepositFormTest.php
+++ b/tests/Feature/AdminBankDepositFormTest.php
@@ -406,7 +406,7 @@ class AdminBankDepositFormTest extends TestCase
                                     ]);
 
         $response->assertStatus(200);
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'challenge_business_unit']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('bank_deposit_form_organizations', Arr::except($charity->attributesToArray(),[] ));
@@ -489,7 +489,7 @@ class AdminBankDepositFormTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'charities', 'created_at', 'updated_at']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'charities', 'challenge_business_unit', 'created_at', 'updated_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('bank_deposit_form_organizations', Arr::except($charity->attributesToArray(),['created_at', 'updated_at'] ));

--- a/tests/Feature/AdminCampaignPledgeTest.php
+++ b/tests/Feature/AdminCampaignPledgeTest.php
@@ -228,7 +228,7 @@ class AdminCampaignPledgeTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(),['pledge_id'] ));
@@ -296,7 +296,7 @@ class AdminCampaignPledgeTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'updated_at', 'created_at']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(), ['updated_at', 'created_at']));
@@ -315,7 +315,7 @@ class AdminCampaignPledgeTest extends TestCase
 
         $response->assertStatus(204);
         // Assert the file was deleted ...
-        $this->assertSoftDeleted('pledges',  Arr::except($pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'updated_at', 'created_at'])  );
+        $this->assertSoftDeleted('pledges',  Arr::except($pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at'])  );
         foreach ($pledge->charities as $charity) {
             $this->assertSoftDeleted('pledge_charities', Arr::except($charity->attributesToArray(), ['updated_at', 'created_at']));
         }

--- a/tests/Feature/AdminSubmissionQueueTest.php
+++ b/tests/Feature/AdminSubmissionQueueTest.php
@@ -366,7 +366,7 @@ class AdminSubmissionQueueTest extends TestCase
         $pledge->approved = 1;
 
         $response->assertStatus(204);
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'updated_at', 'created_at']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         // $response->assertRedirect('login');
     }

--- a/tests/Feature/AdminVolunteerProfileTest.php
+++ b/tests/Feature/AdminVolunteerProfileTest.php
@@ -674,6 +674,8 @@ class AdminVolunteerProfileTest extends TestCase
             $address_type = $this->faker->randomElement( ['G', 'S'] );
         }
 
+        $opt_out_recongnition = $this->faker->randomElement( ['Y', 'N'] );
+
         // Test Transaction
         $profile = VolunteerProfile::factory()->make([
             'campaign_year' => today()->year,
@@ -688,11 +690,11 @@ class AdminVolunteerProfileTest extends TestCase
             'business_unit_code' => $business2->code,
 
             'address_type' =>  $address_type,
-            'address' => $address_type == 'G' ? null : substr($this->faker->address(), 0, 60),
-            'city' => $address_type == 'G' ? null : $city->city,
-            'province' => $address_type == 'G' ? null : $this->faker->randomElement( array_keys($province_list) ),
-            'postal_code' => $address_type == 'G' ? null : $this->faker->regexify('/^[A-Z]\d[A-Z]\ {1}\d[A-Z]\d$/'),
-
+            'address' => ($address_type == 'G' || $opt_out_recongnition == 'Y') ? null : substr($this->faker->address(), 0, 60),
+            'city' => ($address_type == 'G' || $opt_out_recongnition == 'Y') ? null : $city->city,
+            'province' => ($address_type == 'G' || $opt_out_recongnition == 'Y') ? null : $this->faker->randomElement( array_keys($province_list) ),
+            'postal_code' => ($address_type == 'G' || $opt_out_recongnition== 'Y') ? null : $this->faker->regexify('/^[A-Z]\d[A-Z]\ {1}\d[A-Z]\d$/'),
+            'opt_out_recongnition' => $opt_out_recongnition,
         ]);
 
         $form_data = $this->tranform_to_form_data($profile);

--- a/tests/Feature/AnnualCampaignTest.php
+++ b/tests/Feature/AnnualCampaignTest.php
@@ -236,7 +236,7 @@ class AnnualCampaignTest extends TestCase
         $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(),['pledge_id'] ));
@@ -307,7 +307,7 @@ class AnnualCampaignTest extends TestCase
         // $response->assertSessionHas('success');
         $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'updated_at', 'created_at']) );
+        $this->assertDatabaseHas('pledges', Arr::except( $pledge->attributesToArray(), ['frequency', 'charities', 'distinct_charities', 'challenge_business_unit', 'updated_at', 'created_at']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('pledge_charities', Arr::except($charity->attributesToArray(), ['updated_at', 'created_at']));

--- a/tests/Feature/BankDepositFormTest.php
+++ b/tests/Feature/BankDepositFormTest.php
@@ -275,7 +275,7 @@ class BankDepositFormTest extends TestCase
         // $response->assertSessionHas('success');
         // $response->assertSessionHasNoErrors();
 
-        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection']) );
+        $this->assertDatabaseHas('bank_deposit_forms', Arr::except( $pledge->attributesToArray(), ['status', 'charity_selection','challenge_business_unit']) );
 
         foreach ($pledge->charities as $charity) {
             $this->assertDatabaseHas('bank_deposit_form_organizations', Arr::except($charity->attributesToArray(),[] ));

--- a/tests/Feature/ChallengePageTest.php
+++ b/tests/Feature/ChallengePageTest.php
@@ -218,7 +218,10 @@ class ChallengePageTest extends TestCase
         $this->actingAs($this->user);
         $response = $this->get('challenge/org_participation_tracker');
 
-        $response->assertStatus(200);
+        if (Setting::isCampaignPeriodActive()) 
+            $response->assertStatus(200);
+        else
+            $response->assertStatus(404);
     }
  
     public function test_an_authorized_user_can_download_org_participation_tracker()
@@ -228,8 +231,12 @@ class ChallengePageTest extends TestCase
         $this->actingAs($this->user);
         $response = $this->get('challenge/org_participation_tracker_download', []);
  
-        $response->assertStatus(302);
-        $response->assertSessionHas( "message" );
+        if (Setting::isOrgParticipationTrackerActive()) {
+            $response->assertStatus(302);
+            $response->assertSessionHas( "message" );
+        } else {
+            $response->assertStatus(404);
+        }
 
     }
 
@@ -497,6 +504,8 @@ class ChallengePageTest extends TestCase
                 'challenge_start_date' => $year . '-09-01',
                 'challenge_end_date' => $year . '-11-15',
                 'challenge_final_date' => (today() < today()->year . '-03-01') ? today() : $year + 1 . '-02-28',
+                'ee_snapshot_date_1' => $year . '-09-01',
+                'ee_snapshot_date_2' => $year . '-10-15',
 
         ]);
 

--- a/tests/Feature/ChallengeSettingsTest.php
+++ b/tests/Feature/ChallengeSettingsTest.php
@@ -219,6 +219,9 @@ class ChallengeSettingsTest extends TestCase
             // 'campaign_end_date' => today()->year . '-12-31',
             'campaign_end_date' => today()->year . '-11-15',
             'campaign_final_date' => today()->year + 1 . '-02-14',
+
+            'ee_snapshot_date_1' => today()->year + 1 . '-09-01',
+            'ee_snapshot_date_2' => today()->year + 1 . '-10-15',
         ];
         
         $this->actingAs($this->admin);


### PR DESCRIPTION
1)Issue only for in campaign. The 'Distribute evenly' on the Amount Distribution page of the donations must appear as link. Maybe an underline may work too. Currently the text highlights and has a border when hovered which is good.
Example for reference is the PECSF email link in the blue banner text
2) Same issue as 1 at the page Statistics -> Leadership -> [PECSF@gov.bc.ca](mailto:PECSF@gov.bc.ca)
3) FAQ page -> [PECSF@gov.bc.ca](mailto:PECSF@gov.bc.ca)
4) FAQ -> Volunteering -> Volunteer Section

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/2E0P_58MSkeTcmiVaKkiSWUAMNtu?Type=TaskLink&Channel=Link&CreatedTime=638604634992310000)