### PR TITLE
(MASTER)  [jp-0177] Distribute evenly and PECSF email does not appear as link

### DIFF
--- a/app/Http/Controllers/ContactFaqController.php
+++ b/app/Http/Controllers/ContactFaqController.php
@@ -29,7 +29,7 @@ class ContactFaqController extends Controller
             'Volunteering' => [
                 [
                     'question' => 'Where do I find more information on volunteering with the PECSF Annual Campaign?  ',
-                    'answer' => 'You will find volunteering information in the  <a href="/volunteering">Volunteer Section</a> which includes contact information for lead coordinators, possible roles, training, resources and blogs.'
+                    'answer' => 'You will find volunteering information in the  <a href="/volunteering" style="text-decoration: underline;">Volunteer Section</a> which includes contact information for lead coordinators, possible roles, training, resources and blogs.'
                 ],
                 [
                     'question' => 'How much time on average do I have to commit to as a volunteer?',

--- a/resources/views/annual-campaign/partials/amount-distribution.blade.php
+++ b/resources/views/annual-campaign/partials/amount-distribution.blade.php
@@ -18,7 +18,7 @@
                 </label>
             </div>
         </div>
-        <button type="button" class="distribute-evenly btn btn-link">Distribute evenly</button>
+        <button type="button" class="distribute-evenly btn btn-link" style="text-decoration: underline;">Distribute evenly</button>
     </div>
     <table class="table table-sm">
         @foreach ($selected_charities as $charity)

--- a/resources/views/challenge/index.blade.php
+++ b/resources/views/challenge/index.blade.php
@@ -7,7 +7,8 @@
     @include('challenge.partials.tabs')
 
     <h6 class="mt-3">Visit this page daily during the PECSF campaign to see updated statistics, including organization participation rates!<br>
-        If you have questions about PECSF statistics, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca?subject=Statictics%20page">PECSF@gov.bc.ca</a>.</h6>
+        If you have questions about PECSF statistics, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca?subject=Statictics%20page"
+            style="text-decoration: underline;">PECSF@gov.bc.ca</a>.</h6>
 </div>
 @endsection
 
@@ -97,7 +98,7 @@
                         <button id="list-mode-btn" type="button" class="btn btn-primary">
                                 <span class="mx-2 px-2">List</span>
                         </button>
-                        <button type="button" class="btn btn-dark mx-0 px-0"></button>
+                        <button type="button" class="btn btn-dark mx-0 px-0" tabindex="-1"></button>
                         <button id="chart-mode-btn" type="button" class="btn btn-outline-secondary">
                                 <span class="px-2">Chart<span>
                         </button>
@@ -121,7 +122,7 @@
                 </thead>
             </table>
         </div>
-        <div id="chart-section" data-load="0"> 
+        <div id="chart-section" data-load="0" tabindex="0" aria-label="This is a chart about Partipation Rate"> 
             <div id="main" class="pt-2" style="width: auto;height:700px;"></div>
         </div>
 
@@ -350,6 +351,59 @@ $(function() {
 
     });
 
+    $(document).on('keyup', '#pills-tab', function(event) {
+
+        current = $(this).find('.nav-item .active');
+        all_items = $(this).find('.nav-item');
+        siblings = current.parent().siblings();
+
+        var tgt = event.currentTarget;
+        flag = false;
+
+        switch (event.key) {
+            case 'ArrowLeft':
+                if ( current.prev() )
+                    current.prev().trigger('click');
+                else 
+                    $(all_items[ allitems.length -1]).trigger('click');
+                // this.moveFocusToPreviousTab(tgt);
+                flag = true;
+                break;
+
+            case 'ArrowRight':
+            if (siblings.length > 0)
+                    $(siblings[0]).trigger('click');
+                else 
+                    $(all_items[0]).trigger('click');
+
+                // this.moveFocusToNextTab(tgt);
+                flag = true;
+                break;
+
+            case 'Home':
+                $(all_items[0]).trigger('click');
+                //this.moveFocusToTab(this.firstTab);
+                flag = true;
+                break;
+
+            case 'End':
+                $(all_items[ allitems.length -1]).trigger('click');
+                // this.moveFocusToTab(this.lastTab);
+                flag = true;
+                break;
+
+            default:
+                break;
+        }
+
+        if (flag) {
+            // event.stopPropagation();
+            // event.preventDefault();
+        }
+                
+    });
+ 
+
     $(document).on('keyup', '#organization_name', function() {
 
         term = $('#organization_name').val();
@@ -417,6 +471,12 @@ $(function() {
                     myChart.resize();
 
                     myChart.setOption({
+                        aria: {
+                            enabled: true,
+                            decal: {
+                               show: true
+                            }
+                        },
                         title: {
                             text: 'Participation Rate Chart',
                             textStyle: { fontSize: 20, fontWeight: 'bold' }, 

--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -6,7 +6,8 @@
             <div class="text-left mt-3">
                 <h1>Contact PECSF</h1>
                 <p>
-                    Got a question? We're here to help! If you don't see your question answered in the FAQ section below, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca">PECSF@gov.bc.ca</a>.
+                    Got a question? We're here to help! If you don't see your question answered in the FAQ section below, send us an e-mail at <a href="mailto:PECSF@gov.bc.ca"
+                            style=" text-decoration: underline;">PECSF@gov.bc.ca</a>.
                 </p>
             </div>
          </div>


### PR DESCRIPTION
1)Issue only for in campaign. The 'Distribute evenly' on the Amount Distribution page of the donations must appear as link. Maybe an underline may work too. Currently the text highlights and has a border when hovered which is good.
Example for reference is the PECSF email link in the blue banner text
2) Same issue as 1 at the page Statistics -> Leadership -> [PECSF@gov.bc.ca](mailto:PECSF@gov.bc.ca)
3) FAQ page -> [PECSF@gov.bc.ca](mailto:PECSF@gov.bc.ca)
4) FAQ -> Volunteering -> Volunteer Section

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/2E0P_58MSkeTcmiVaKkiSWUAMNtu?Type=TaskLink&Channel=Link&CreatedTime=638604634992310000)