### PR TITLE
(MASTER) [jp-0179] Inconsistency in the numbers on the volunteer profile and donation history page

### DIFF
--- a/app/Models/EmployeeJob.php
+++ b/app/Models/EmployeeJob.php
@@ -196,7 +196,11 @@ class EmployeeJob extends Model
 
         // BI History  
         $amount = PledgeHistorySummary::where('emplid', $this->emplid)
-                                    ->sum('pledge');
+                        ->where( function($query) {
+                                $query->whereNull('pledge_history_summaries.event_type')
+                                    ->orWhereIn('pledge_history_summaries.event_type', ['Cash', 'Personal Cheque']);
+                        })
+                        ->sum('pledge');
         $total_amount += $amount;
 
 


### PR DESCRIPTION
Employee103 - emp id 013238 had a 2025 annual pledge, which admin cancelled. The amounts on the donation history page and the volunteer profile page now differ. Not able to find the root cause.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/rVjfXqgFzEarpWXxUXV7UGUAMLSK?Type=TaskLink&Channel=Link&CreatedTime=638604641010020000)