### PR TITLE
(TEST) [jp-0182] Remove the overriden properties from text - Generosity in Action on home page

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -5,8 +5,8 @@
 <div class="container mb-4">
   <div class="row">
     <div class="col-12 col-xl-12 ">
-        <h1 class="text-center" style="color:#687278;">Welcome, {{ Auth::user()->name }}</h1>
-        <p class="text-center h5"  style="color:#687278;"><strong>Choose from the options below:</strong></p>
+        <h1 class="text-center  text-primary" >Welcome, {{ Auth::user()->name }}</h1>
+        <p class="text-center h5 text-secondary"><strong>Choose from the options below:</strong></p>
     </div>
   </div>
 </div>
@@ -107,7 +107,7 @@
             <div class="col-12 col-md-5 offset-md-1 pt-5">
                 <br><br>
                 <br><br>
-                <h3 class="mt-5 p1-5" style="font-size: 4em;">Generosity in Action</h3>
+                <p class="mt-5" style="font-size: 4em; line-height: 120%;">Generosity in Action</p>
             </div>
 
             <div class="col-12 col-md-6">

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -5,7 +5,7 @@
 <div class="container mb-4">
   <div class="row">
     <div class="col-12 col-xl-12 ">
-        <h1 class="text-center  text-primary" >Welcome, {{ Auth::user()->name }}</h1>
+        <h1 class="text-center  text-primary" >Welcome to PECSF</h1>
         <p class="text-center h5 text-secondary"><strong>Choose from the options below:</strong></p>
     </div>
   </div>


### PR DESCRIPTION
As discussed with James, this text is marked as h3 and also overridden by the font-size: 4rem
Can we remove the overridden property and adjust the font size. Since its not a heading we want to remove the h3 tag too and add a bigger font size to the text.
Also, match the text colour with the text on the Volunteering dashboard

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/Tzo1l4Unv0e1fmmBe0AGcGUAPgUQ?Type=TaskLink&Channel=Link&CreatedTime=638610775182950000)