### PR TITLE
(TEST) [jp-0184] Prepopulate a $ sign in the custom amount field of the donation

### DIFF
--- a/resources/views/annual-campaign/partials/amount.blade.php
+++ b/resources/views/annual-campaign/partials/amount.blade.php
@@ -35,7 +35,12 @@
             <div class="custom-amount-bi-weekly mt-3" style="{{ $isCustomAmountBiWeekly ? '' : 'display:none '}}">
                 <label>
                     Custom amount
-                    <input type="text" name="bi_weekly_amount_custom" class="form-control" value="{{ $preselectedData['bi-weekly-amount'] }}">
+                    <div class="input-group input-group-sm mb-3 pt-2">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text">$</span>
+                        </div>
+                        <input type="text" name="bi_weekly_amount_custom" class="form-control" value="{{ $preselectedData['bi-weekly-amount'] }}">
+                    </div>
                 </label>
             </div>
         </div>
@@ -56,7 +61,12 @@
             <div class="custom-amount-one-time mt-3" style="{{ $isCustomAmountOneTime ? '' : 'display:none '}}">
                 <label>
                     Custom amount
-                    <input type="text" name="one_time_amount_custom" class="form-control" value="{{ $preselectedData['one-time-amount'] }}">
+                    <div class="input-group input-group-sm mb-3 pt-2">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text">$</span>
+                        </div>
+                        <input type="text" name="one_time_amount_custom" class="form-control" value="{{ $preselectedData['one-time-amount'] }}">
+                    </div>
                 </label>
             </div>
         </div>

--- a/tests/Feature/ChallengePageTest.php
+++ b/tests/Feature/ChallengePageTest.php
@@ -218,7 +218,7 @@ class ChallengePageTest extends TestCase
         $this->actingAs($this->user);
         $response = $this->get('challenge/org_participation_tracker');
 
-        if (Setting::isCampaignPeriodActive()) 
+        if (Setting::isOrgParticipationTrackerActive()) 
             $response->assertStatus(200);
         else
             $response->assertStatus(404);
@@ -316,7 +316,7 @@ class ChallengePageTest extends TestCase
         $row = Setting::first();
 
         $campaign_year = Setting::challenge_page_campaign_year();
-        $report_date = (today()->month >= 3 && today()->month <= 8) ?  today() : $row->campaign_end_date;
+        $report_date = (today() >= $row->campaign_end_date) ?  $row->campaign_end_date :  today();
                                   
         $filename = 'Daily_Campaign_Update_By_Dept_' . $report_date->format('Y-m-d') . '.xlsx';
 


### PR DESCRIPTION
Enhancement to be made at the Custom Amount field for both outside and in-campaign on the Amount page.
Currently, the text box appears blank and only displays the number entered.
Expected: Can we add a $ sign to the text box. Reference is the Dollar Amount field on the amount distribution page.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/qzS4CV_8nka-Ts0kgWAkvGUAAVSo?Type=TaskLink&Channel=Link&CreatedTime=638610786649270000)