### PR TITLE
(MASTER) [jp-0185] PledgeExport process was failed on attempt to read property on null

### DIFF
--- a/app/Exports/PledgesExport.php
+++ b/app/Exports/PledgesExport.php
@@ -362,12 +362,12 @@ class PledgesExport implements FromQuery, WithHeadings, WithMapping, WithEvents
         );
 
         // Update Challenge Business Unit
-        $pledges = PledgeStaging::all();
+        $pledges = PledgeStaging::where('history_id', $this->history_id)->get();    
 
         foreach ($pledges as $pledge) {
 
             $bu = BusinessUnit::where('code', $pledge->business_unit_code)->first();
-            $business_unit_code = $bu->linked_bu_code;
+            $business_unit_code = $bu ? $bu->linked_bu_code : null;
             if ($business_unit_code == 'BC022' && str_starts_with($pledge->dept_name, 'GCPE')) {
                 $business_unit_code  = 'BGCPE';
             }


### PR DESCRIPTION
Issue:
The annual campaign pledge was created without emplid (special iDIR account) and cause the PledgeExport process was failed with the following error message

ErrorException: Attempt to read property "linked_bu_code" on null in /var/www/html/app/Exports/PledgesExport.php:370
Stack trace:
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php(255): Illuminate\Foundation\Bootstrap\HandleExceptions->handleError(2, 'Attempt to read...', '/var/www/html/a...', 370)

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/-k2Gv2kLfEmOl5VhRO84f2UAJk54?Type=TaskLink&Channel=Link&CreatedTime=638611580191850000)