### PR TITLE
(TEST) [jp-0191] Outside of campaign: Prepopulate a $ sign in the custom amount field of the donation

### DIFF
--- a/resources/views/donate-now/partials/amount.blade.php
+++ b/resources/views/donate-now/partials/amount.blade.php
@@ -60,7 +60,12 @@
         <div class="custom-amount-one-time mt-3" style="{{ (!in_array($one_time_amount, [6, 12, 20, 50])) ? '' : 'display:none '}}">
             <label>
                 Custom amount
-                <input type="text" name="one_time_amount_custom" class="form-control"  value="{{ $one_time_amount_custom }}">
+                <div class="input-group input-group-sm mb-3 pt-2">
+                    <div class="input-group-prepend">
+                        <span class="input-group-text">$</span>
+                    </div>
+                    <input type="text" name="one_time_amount_custom" class="form-control"  value="{{ $one_time_amount_custom }}">
+                </div>                
             </label>
         </div>
     </div>


### PR DESCRIPTION
We fixed this issue for in-campaign but didn't fix it for the field outside of the campaign.
Enhancement to be made at the Custom Amount field for both outside and in-campaign on the Amount page.
Currently, the text box appears blank and only displays the number entered.
Expected: Can we add a $ sign to the text box. Reference is the Dollar Amount field on the amount distribution page.

[Ticket](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/_cUd01RlAEO2XTWrsMKVl2UAKcWl?Type=TaskLink&Channel=Link&CreatedTime=638621602374220000)