### PR TITLE
(MASTER)  [jp-0186] Learn more about donating to PECSF does not appear as link 

### DIFF
--- a/resources/views/donations/index.blade.php
+++ b/resources/views/donations/index.blade.php
@@ -90,12 +90,13 @@
                     OR
                 </p>
             @endif
-            <x-button style="link" data-toggle="modal" data-target="#learn-more-modal">Learn more about donating to PECSF.</x-button>
+            <a class="btn btn-outline-primary btn-md" data-toggle="modal" data-target="#learn-more-modal">Learn more about donating to PECSF.</a>
         </div>
         @endif
         @if ($pledges_by_yearcd->count() > 0)
-            <div class="justify-content-center">
-                <a href="{{route('donations.list')}}?download_pdf=true"><button style="background:#fff;margin-left:auto;margin-right:auto;display:block;width:40%;border:#12406b 1px solid;padding:8px;text-align:center;">Export Summary</button></a>
+            <div class="text-center">
+                {{-- <a href="{{route('donations.list')}}?download_pdf=true"><button style="background:#fff;margin-left:auto;margin-right:auto;display:block;width:40%;border:#12406b 1px solid;padding:8px;text-align:center;">Export Summary</button></a> --}}
+                <a class="btn btn-outline-primary btn-md px-5" href="{{route('donations.list')}}?download_pdf=true">Export Summary</a>
             </div>
         @endif
     </div>


### PR DESCRIPTION
Issue for both outside and in campaign. The 'Learn more about donating to PECSF' below the Donate to PECSF button must appear as link. Maybe an underline may work too. Currently the text highlights and has a border when hovered which is good.
Example for reference is the PECSF email link in the blue banner text

[Ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/k_-cbRY3sUybPEzcuEkIvWUAELBa?Type=TaskLink&Channel=Link&CreatedTime=638612393770580000)