### PR TITLE
(MASTER) [jp-0187] Missing sort feature on Status column on Maintain EE Pledge page

### DIFF
--- a/resources/views/admin-pledge/campaign/index.blade.php
+++ b/resources/views/admin-pledge/campaign/index.blade.php
@@ -356,7 +356,7 @@
                 {data: 'pay_period_amount', name: 'pay_period_amount',  'className': 'dt-right', render: $.fn.dataTable.render.number(',', '.', 2, '')},
                 {data: 'goal_amount', name: 'goal_amount', 'className': 'dt-right', render: $.fn.dataTable.render.number(',', '.', 2, '') },
                 {data: 'action', name: 'action', orderable: false, searchable: false, className: "dt-nowrap"},
-                {data: 'cancelled', name: 'cancelled',  orderable: false, searchable: false, className: "dt-nowrap",
+                {data: 'cancelled', name: 'cancelled', searchable: false, className: "dt-nowrap",
                     render: function ( data, type, row, meta ) {
                             if( data == null) {
                                 return '';


### PR DESCRIPTION
The 'Status' column on the page Maintain EE Pledges, is missing a sort icon as well as the sort functionality for the column

The sort icon besides the column header must appear
The admin must be able to click on the header to sort the column. Sorting must function throughout the table

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/AhgJ1sWdVEyhCBzs_wM-WGUACa0q?Type=TaskLink&Channel=Link&CreatedTime=638612394279750000)