### PR TITLE
(MASTER)  [jp-0188] Mouse cursor does not change on hovering over the Opt-out checkbox in Registering as volunteer

### DIFF
--- a/resources/views/volunteer-profile/partials/recognition-items.blade.php
+++ b/resources/views/volunteer-profile/partials/recognition-items.blade.php
@@ -82,6 +82,14 @@
 
 @push('css')
 
+<style>
+    input[name='opt_out_recongnition'] {
+        cursor: pointer;
+        transform: scale(1.5);
+        margin-left: 4px;
+    }
+</style>
+
 @endpush
 
 


### PR DESCRIPTION
When we hover over the checkbox, the mouse cursor must change to hand from arrow.

[ticket](https://tasks.office.com/bcgov.onmicrosoft.com/Home/Task/UCdIXnl8OUKzhIxhmUWK52UALMpa?Type=TaskLink&Channel=Link&CreatedTime=638612394930970000)