### PR TITLE
[jp-0197] Security update required -- 1 HIGH security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10082,9 +10082,9 @@
             }
         },
         "node_modules/uplot": {
-            "version": "1.6.28",
-            "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.28.tgz",
-            "integrity": "sha512-6AQ/Hu2ZvwF1P6PtIELdWKFml8Vvf3PUqrkVndL4A1+s/0loHwXfsk3yMwy4WGkRAt0MAMpf0uKLa9h0Yt3miw=="
+            "version": "1.6.31",
+            "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
+            "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -18504,9 +18504,9 @@
             }
         },
         "uplot": {
-            "version": "1.6.28",
-            "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.28.tgz",
-            "integrity": "sha512-6AQ/Hu2ZvwF1P6PtIELdWKFml8Vvf3PUqrkVndL4A1+s/0loHwXfsk3yMwy4WGkRAt0MAMpf0uKLa9h0Yt3miw=="
+            "version": "1.6.31",
+            "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
+            "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
         },
         "uri-js": {
             "version": "4.4.1",


### PR DESCRIPTION
Oct 2 - 1 HIGH vulnerabilities reported npm audit:

uPlot Prototype Pollution vulnerability

Bump uplot from 1.6.28 to 1.6.31

Package               Affected versions              Patched version
uplot (npm)         < 1.6.31                             1.6.31

Versions of the package uplot before 1.6.31 are vulnerable to Prototype Pollution via the uplot.assign function due to missing check if the attribute resolves to the object prototype.

> npm audit
# npm audit report

uplot  <1.6.31
Severity: high
uPlot Prototype Pollution vulnerability - https://github.com/advisories/GHSA-34q8-jcq6-mc37
fix available via `npm audit fix`
node_modules/uplot

Severity: moderate
vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS) - https://github.com/advisories/GHSA-g3ch-rx76-35fx
fix available via `npm audit fix --force`
Will install vue-template-compiler@0.1.0, which is a breaking change
node_modules/vue-template-compiler

7 vulnerabilities (1 low, 5 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix


Action

> npm audit fix

changed 1 package, and audited 921 packages in 2s

118 packages are looking for funding
  run `npm fund` for details

# npm audit report

bootstrap  4.0.0 - 4.6.2
Severity: moderate
Bootstrap Cross-Site Scripting (XSS) vulnerability - https://github.com/advisories/GHSA-vc8w-jr9v-vj7f
fix available via `npm audit fix --force`
Will install bootstrap@5.3.3, which is a breaking change
node_modules/bootstrap
  admin-lte  3.0.0-alpha - 3.2.0
  Depends on vulnerable versions of bootstrap
  Depends on vulnerable versions of summernote
  Depends on vulnerable versions of tempusdominus-bootstrap-4
  node_modules/admin-lte
  tempusdominus-bootstrap-4  <=5.0.1 || >=5.39.0
  Depends on vulnerable versions of bootstrap
  node_modules/tempusdominus-bootstrap-4

summernote  <=0.8.20
Severity: moderate
SummerNote Cross Site Scripting Vulnerability - https://github.com/advisories/GHSA-cc55-mvqc-g9mg
fix available via `npm audit fix`
node_modules/summernote

sweetalert2  >=10.16.10 <11.0.0
sweetalert2 v10.16.10 and above contains hidden functionality - https://github.com/advisories/GHSA-457r-cqc8-9vj9
fix available via `npm audit fix`
node_modules/admin-lte/node_modules/sweetalert2

vue-template-compiler  >=2.0.0
Severity: moderate
vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS) - https://github.com/advisories/GHSA-g3ch-rx76-35fx
fix available via `npm audit fix --force`
Will install vue-template-compiler@0.1.0, which is a breaking change
node_modules/vue-template-compiler

6 vulnerabilities (1 low, 5 moderate)

Oct 2 - The package was updated and ran through all testing.
            
  Tests:    1260 passed (3347 assertions)
  Duration: 642.58s

Oct 2 - Deployed on DEV and TEST regions. Ready for testing. 
Oct 2 - The upgrade package are general and cover lots of area. I already did my test scripts (over 1260 test and 3347 assertions) and all passed, However, these scripts mainly focus on form data entry and database updates. There are no scripts for the UI. You might want to concentrate on testing the following core functions in the TEST region. Thank you so much. 
Testing for the following on TEST region
. IDIR login 
. Donations > Donate (Self Service)
. Volunteering > eForm (Self Service)
. Donations > Export Summary (Test PDF)
. Statistics > Leaderboard > Download as PDF
. Statistics > Leaderboard > Chart
. Admin > Pledge Administration > Maintain EE Pledges > Edit
. Admin > Pledge Administration > Maintain Event Pledges > Edit
. CRA Charities -> Charity List Maintenance -> File upload 
. Admin -> Reporting -> Pay Period Report -> Export
. Admin -> Reporting -> Program reports -> Annual pledges and Events -> Export
. System > Auditing > Table Audit Log
. System > Schedule Jobs (verify recent process run to completed)