### PR TITLE
[jp-0197] Security update required -- 1 HIGH security vulnerability (Composer update phpoffice/phpspreadsheet)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5575,16 +5575,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.29.1",
+            "version": "1.29.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "59ee38f7480904cd6487e5cbdea4d80ff2758719"
+                "reference": "3a5a818d7d3e4b5bd2e56fb9de44dbded6eae07f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/59ee38f7480904cd6487e5cbdea4d80ff2758719",
-                "reference": "59ee38f7480904cd6487e5cbdea4d80ff2758719",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/3a5a818d7d3e4b5bd2e56fb9de44dbded6eae07f",
+                "reference": "3a5a818d7d3e4b5bd2e56fb9de44dbded6eae07f",
                 "shasum": ""
             },
             "require": {
@@ -5674,9 +5674,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.1"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.2"
             },
-            "time": "2024-09-03T00:55:32+00:00"
+            "time": "2024-09-29T07:04:47+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -12786,12 +12786,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.1"
     },
-    "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Creating a security update for phpoffice/phpspreadsheet
Dependabot is creating a security update to fix [4 Dependabot alerts](https://github.com/bcgov/PECSF/security/dependabot?q=is%3Aopen+package%3Aphpoffice%2Fphpspreadsheet+manifest%3Acomposer.lock+has%3Apatch) on phpoffice/phpspreadsheet in [composer.lock](https://github.com/bcgov/PECSF/blob/-/composer.lock).

Or, manually upgrade phpoffice/phpspreadsheet to version 1.29.2 or later. For example:

"require": {
  "phpoffice/phpspreadsheet": "1.29.2"
}

Package
                                                        Affected versions                   Patched version                    
phpoffice/phpspreadsheet (Composer)       < 1.29.2                                  1.29.2












