### PR TITLE
[jp-0196] eForm: Postal code format validation doesn't exit (addition changes)

### DIFF
--- a/app/Http/Controllers/BankDepositFormController.php
+++ b/app/Http/Controllers/BankDepositFormController.php
@@ -152,7 +152,7 @@ class BankDepositFormController extends Controller
             'address_1'    =>  'required_unless:event_type,Fundraiser,Gaming',
             'city'         =>  'required_unless:event_type,Fundraiser,Gaming',
             'province'     =>  'required_unless:event_type,Fundraiser,Gaming',
-            'postal_code'  =>  'required_unless:event_type,Fundraiser,Gaming|regex:/^[ABCEGHJKLMNPRSTVXY]{1}\d{1}[A-Z]{1} \d{1}[A-Z]{1}\d{1}$/',
+            'postal_code'  =>  ['required_unless:event_type,Fundraiser,Gaming', Rule::when( $request->postal_code, ['regex:/^[ABCEGHJKLMNPRSTVXY]{1}\d{1}[A-Z]{1} \d{1}[A-Z]{1}\d{1}$/']) ],
 
             'charity_selection' => ['required', Rule::in(['fsp', 'dc']) ],
             'regional_pool_id'       => ['required_if:charity_selection,fsp', Rule::when( $request->charity_selection == 'fsp', ['exists:f_s_pools,id']) ],
@@ -587,7 +587,8 @@ class BankDepositFormController extends Controller
             'address_1'    =>  'required_unless:event_type,Fundraiser,Gaming',
             'city'         =>  'required_unless:event_type,Fundraiser,Gaming',
             'province'     =>  'required_unless:event_type,Fundraiser,Gaming',
-            'postal_code'  =>  'required_unless:event_type,Fundraiser,Gaming|regex:/^[ABCEGHJKLMNPRSTVXY]{1}\d{1}[A-Z]{1} \d{1}[A-Z]{1}\d{1}$/',
+            'postal_code'  =>  ['required_unless:event_type,Fundraiser,Gaming', Rule::when( $request->postal_code, ['regex:/^[ABCEGHJKLMNPRSTVXY]{1}\d{1}[A-Z]{1} \d{1}[A-Z]{1}\d{1}$/']) ],
+
             'charity_selection' => ['required', Rule::in(['fsp', 'dc']) ],
             'regional_pool_id'       => ['required_if:charity_selection,fsp', Rule::when( $request->charity_selection == 'fsp', ['exists:f_s_pools,id']) ],
 


### PR DESCRIPTION
The eForm - Postal code field had a validation that only accepted postal code in the format X0X 0X0 and would throw an error displaying the format. This validation is not there on the field anymore.
Currently, field accepts any text. For reference check the event pledge with transaction id 293

[ticket](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/_jWVgfflgU6Xfof1dJPjE2UAPOSe?Type=TaskLink&Channel=Link&CreatedTime=638624696021130000)