### PR TITLE
(TEST) [jp-0198] Command: ExportDatabaseToBI encountered an error while re-exporting all data

### DIFF
--- a/app/Console/Commands/ExportDatabaseToBI.php
+++ b/app/Console/Commands/ExportDatabaseToBI.php
@@ -136,11 +136,18 @@ class ExportDatabaseToBI extends Command
             $this->LogMessage("The schedule Job id          : " . $task->id);
             $this->LogMessage("The command name             : " . $job_name);
             
+            // exclude hidden fields
+            $select_columns = DB::connection()->getSchemaBuilder()->getColumnListing($table_name);
+            if ($hidden_fields) {
+                $select_columns = array_diff($select_columns, $hidden_fields);
+            }
+
             // Main Process for each table 
             $sql = DB::table($table_name)
                 ->when( $last_job && $delta_field, function($q) use($last_start_time, $delta_field, $hidden_fields ) {
                     return $q->where($delta_field, '>=', $last_start_time);
                 })
+                ->select($select_columns)
                 ->orderBy('id');
                 
             // Chucking


### PR DESCRIPTION
Scenario
1. Try to re-export all data from Greenfield to BI via ODS 

Table 'bank_deposit_form_organizations' data to BI sent completed on 2024-10-10 10:36:27
=========================================================================
Table 'bank_deposit_form_attachments' Detail to BI (Datawarehouse) start on 2024-10-10 10:36:27

Table Name                   : 'bank_deposit_form_attachments'
The Last send completed time : 2000-01-01
The schedule Job id          : 8135
The command name             : command:ExportDatabaseToBI:bank_deposit_form_attachments
PHP Fatal error:  Allowed memory size of 268435456 bytes exhausted (tried to allocate 1085440 bytes) in /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php on line 430

  Symfony\Component\ErrorHandler\Error\FatalError
  Allowed memory size of 268435456 bytes exhausted (tried to allocate 1085440 bytes)
  at vendor/laravel/framework/src/Illuminate/Database/Connection.php:430


Root cause: Because the uploaded file data stored in the table was too large to manage, we need to exclude the 'file' column.

[Ticket ](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/EYGKvRQTTUOQlgQw-x0yIWUAHm7R?Type=TaskLink&Channel=Link&CreatedTime=638641820709710000)