### PR TITLE
(MASTER) [jp-0200] BI export processes encountered a failure in lower regions due to a 502 Bad Gateway error (update schedule time)

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -165,7 +165,7 @@ class Kernel extends ConsoleKernel
                                 //         return (!(CampaignYear::isAnnualCampaignOpenNow())) and (today()->dayOfWeek != 1);
                                 // })
                                 ->weekdays()
-                                ->at('8:20')
+                                ->at('8:30')
                                 ->environments(['dev', 'TEST'])
                                 ->sendOutputTo(storage_path('logs/ImportCities.log'));                         
 
@@ -175,7 +175,7 @@ class Kernel extends ConsoleKernel
                                 //         return (!(CampaignYear::isAnnualCampaignOpenNow())) and (today()->dayOfWeek != 1);
                                 // })
                                 ->weekdays()
-                                ->at('8:25')
+                                ->at('8:45')
                                 ->environments(['dev', 'TEST'])
                                 ->sendOutputTo(storage_path('logs/ImportDepartments.log'));
 
@@ -201,13 +201,13 @@ class Kernel extends ConsoleKernel
                 // Non-Production -- Demography data and user profiles                        
                 $schedule->command('command:ImportEmployeeJob')
                         ->weekdays()
-                        ->at('8:30')
+                        ->at('9:00')
                         ->environments(['dev', 'TEST'])
                         ->sendOutputTo(storage_path('logs/ImportEmployeeJob.log'));
 
                 $schedule->command('command:SyncUserProfile')
                         ->weekdays()
-                        ->at('8:45')
+                        ->at('9:15')
                         ->environments(['dev', 'TEST'])
                         ->sendOutputTo(storage_path('logs/SyncUserProfile.log'));                        
 


### PR DESCRIPTION
The following two scheduled processes failed in lower regions with the error message '502 Bad Gateway':

Command: ImportCities
Command: ImportDepartments

This issue has been occurring since October 8 in the dev region and October 11 in the test region.

Root Cause:
The BI non-production region was shut down during non-business hours starting October 8, 2025.

Oct 11 - the app/console/kernel.php was updated to set different times for production and non-production regions

[Ticket](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/MCn4Pv0iPkypbAL5wgjvP2UAAFHP?Type=TaskLink&Channel=Link&CreatedTime=638642592408690000)