### PR TITLE
(TEST) [jp-0201] FAQ: Expand/collapsing one question highlights the button for the previously expanded/collapsed question

### DIFF
--- a/resources/views/contact/index.blade.php
+++ b/resources/views/contact/index.blade.php
@@ -87,7 +87,7 @@
         content: '-';
     }
 
-    button.btn-nav-accordion:focus {
+    button.btn-nav-accordion {
         border: none !important;
     }
 


### PR DESCRIPTION
Follow the following steps to reproduce:

- Go to the FAQ page
- Expand the first question
- Expand the second question and notice the collapse(-) button for the first question is highlighted with a border for a second on the click event
- Same thing happens if we collapse the buttons 
- Only the current button must highlight

[Ticket](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/OM-K1_9IoEGfG0WxoL9EzmUAMeoK?Type=TaskLink&Channel=Link&CreatedTime=638651268274410000)