### PR TITLE
(TEST) [jp-0200] BI export processes encountered a failure in lower regions due to a 502 Bad Gateway error & reschedule some tasks

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -194,7 +194,7 @@ class Kernel extends ConsoleKernel
 
                 $schedule->command('command:SyncUserProfile')
                         ->weekdays()
-                        ->at('4:15')
+                        ->at('4:30')
                         ->environments(['prod'])
                         ->sendOutputTo(storage_path('logs/SyncUserProfile.log'));
 
@@ -215,11 +215,11 @@ class Kernel extends ConsoleKernel
 
         // Snapshot of eligible employees 
         $schedule->command('command:UpdateEligibleEmployeeSnapshot')
-                ->dailyAt('4:30')
+                ->dailyAt('4:45')
                 ->appendOutputTo(storage_path('logs/UpdateEligibleEmployeeSnapshot.log'));
 
         $schedule->command('command:UpdateDailyCampaign')
-                ->dailyAt('4:45')
+                ->dailyAt('5:00')
                 ->appendOutputTo(storage_path('logs/UpdateDailyCampaign.log'));
         
         $schedule->command('command:SystemCleanUp')


### PR DESCRIPTION
The following two scheduled processes failed in lower regions with the error message '502 Bad Gateway':
Command: ImportCities
Command: ImportDepartments
This issue has been occurring since October 8 in the dev region and October 11 in the test region.

Root Cause:
The BI non-production region was shut down during non-business hours starting October 8, 2025.

Important: noticed that the ImportJobData is taking longer (more than 20 mins) in Production, need to adjust the start time of some tasks.

[Ticket](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/MCn4Pv0iPkypbAL5wgjvP2UAAFHP?Type=TaskLink&Channel=Link&CreatedTime=638658992156280000)