### PR TITLE
(TEST) [jp-0204] Annual Campaign - Attempt to read property 'id' on null

### DIFF
--- a/app/Http/Controllers/AnnualCampaignController.php
+++ b/app/Http/Controllers/AnnualCampaignController.php
@@ -523,7 +523,7 @@ class AnnualCampaignController extends Controller
             if ($campaign_year->isOpen()) {
                 $user = User::where('id', Auth::id())->first();
                 $pledge =  Pledge::where('emplid', $user->emplid)->orderBy('id', 'desc')->first();
-                $pledge_id = $pledge->id;
+                $pledge_id = $pledge ? $pledge->id : null;
             }
         }
 


### PR DESCRIPTION
Per system log, there are couple of error were logged

[2024-10-07 11:46:26] prod.ERROR: Attempt to read property "id" on null {"userId":53990,"exception":"[object] (ErrorException(code: 0): Attempt to read property "id" on null at /var/www/html/app/Http/Controllers/AnnualCampaignController.php:526)
[stacktrace]

Root cause
The code doesn't handle the bad data when user directly visit this link
https:///annual-campaign/thank-you without go through the annual campaign wizard

Solution
Enhance the code to handle the bad data without fire the error message on the log file.

[ticket](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/LuyLRuX0ikiN7gPUxJfX-WUAOGCF?Type=TaskLink&Channel=Link&CreatedTime=638664214307470000)