### PR TITLE
[jp-0205] Security update required -- HIGH security vulnerability (Rollback upgrade PHP 8.3 changes)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN chgrp -R 0 /app && \
 #
 # Build Server Deployment Image
 #
-FROM php:8.3-apache-bullseye
+FROM php:8.1-apache-bullseye
 
 WORKDIR /
 

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["framework", "laravel"],
     "license": "MIT",
     "require": {
-        "php": "^8.3",
+        "php": "^8.1",
         "axlon/laravel-postal-code-validation": "^3.3",
         "barryvdh/laravel-debugbar": "3.9",
         "barryvdh/laravel-dompdf": "^2.0",

--- a/server_files/php.ini
+++ b/server_files/php.ini
@@ -48,7 +48,6 @@ auto_detect_line_endings = On
 ;extension=exif      ; Must be after mbstring as it depends on it
 ;extension=mysqli
 ;extension=oci8_12c  ; Use with Oracle Database 12c Instant Client
-;extension=oci8_19  ; Use with Oracle Database 19 Instant Client																
 ;extension=odbc
 ;extension=openssl
 ;extension=pdo_firebird
@@ -171,10 +170,6 @@ ldap.max_links = -1
 ; size of the optimized code.
 ;opcache.save_comments=1
 
-; If enabled, compilation warnings (including notices and deprecations) will
-; be recorded and replayed each time a file is included. Otherwise, compilation
-; warnings will only be emitted when the file is first cached.
-;opcache.record_warnings=0
 ; Allow file existence override (file_exists, etc.) performance feature.
 ;opcache.enable_file_override=0
 
@@ -281,36 +276,3 @@ ldap.max_links = -1
 
 ; Absolute path used to store shared lockfiles (for *nix only).
 ;opcache.lockfile_path=/tmp
-
-[curl]
-; A default value for the CURLOPT_CAINFO option. This is required to be an
-; absolute path.
-;curl.cainfo =
-
-[openssl]
-; The location of a Certificate Authority (CA) file on the local filesystem
-; to use when verifying the identity of SSL/TLS peers. Most users should
-; not specify a value for this directive as PHP will attempt to use the
-; OS-managed cert stores in its absence. If specified, this value may still
-; be overridden on a per-stream basis via the "cafile" SSL stream context
-; option.
-;openssl.cafile=
-
-; If openssl.cafile is not specified or if the CA file is not found, the
-; directory pointed to by openssl.capath is searched for a suitable
-; certificate. This value must be a correctly hashed certificate directory.
-; Most users should not specify a value for this directive as PHP will
-; attempt to use the OS-managed cert stores in its absence. If specified,
-; this value may still be overridden on a per-stream basis via the "capath"
-; SSL stream context option.
-;openssl.capath=
-
-[ffi]
-; FFI API restriction. Possible values:
-; "preload" - enabled in CLI scripts and preloaded files (default)
-; "false"   - always disabled
-; "true"    - always enabled
-;ffi.enable=preload
-
-; List of headers files to preload, wildcard patterns allowed.
-;ffi.preload=


### PR DESCRIPTION
Dependabot alerts (Github) reported HIGH vulnerabilities. Run composer audit and npm audit, a couple of packages required update:

[ticket](https://planner.cloud.microsoft/bcgov.onmicrosoft.com/Home/Task/PLvpkEk1NkWbbNmfV_P6MWUAANE2?Type=TaskLink&Channel=Link&CreatedTime=638665269908590000)