### PR TITLE
[jp-0207] Time Zone Discrepancy Between UTC and PDT May Cause Data Sync Issues to BI System (ROLLBACK)

### DIFF
--- a/app/Console/Commands/ExportDatabaseToBI.php
+++ b/app/Console/Commands/ExportDatabaseToBI.php
@@ -127,7 +127,7 @@ class ExportDatabaseToBI extends Command
                         ->orderBy('end_time', 'desc')->first();
 
 
-            $last_start_time = $last_job ? $last_job->created_at : '2000-01-01' ; 
+            $last_start_time = $last_job ? $last_job->start_time : '2000-01-01' ; 
 
             $this->LogMessage("Table '{$table_name}' Detail to BI (Datawarehouse) start on " . now() );
             $this->Logmessage("");


### PR DESCRIPTION
ROLLBACK LAST CHANGES -- No Issue on OpenShift platform

Issue
The created_at and updated_at timestamp fields in each table on the OpenShift platform store values in UTC time, which are assigned by the system during create or update operations. However, the field used to compare values and determine which data is sent to the BI system is based on the PDT time zone. This creates an 8- or 9-hour time difference. If data changes within this time gap, it is possible that the changes may never be sent to the BI system.

Action
Use the updated_at value from the schedule_job_audits table for comparison, ensuring that the same time zone is used for accurate synchronization

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/s0ZdUDYmzkWIXGYDoggWrGUADtTQ?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)

