### PR TITLE
(TEST) [upgrade_10_to_11] Dev - Upgrade Laravel version 10 to 11 and PHP version 8.1 to 8.3 (UPDATE package league/commonmark)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2914,16 +2914,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.5.3",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "b650144166dfa7703e62a22e493b853b58d874b0"
+                "reference": "d150f911e0079e90ae3c106734c93137c184f932"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/b650144166dfa7703e62a22e493b853b58d874b0",
-                "reference": "b650144166dfa7703e62a22e493b853b58d874b0",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d150f911e0079e90ae3c106734c93137c184f932",
+                "reference": "d150f911e0079e90ae3c106734c93137c184f932",
                 "shasum": ""
             },
             "require": {
@@ -2948,8 +2948,9 @@
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
                 "scrutinizer/ocular": "^1.8.1",
-                "symfony/finder": "^5.3 | ^6.0 || ^7.0",
-                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 || ^7.0",
+                "symfony/finder": "^5.3 | ^6.0 | ^7.0",
+                "symfony/process": "^5.4 | ^6.0 | ^7.0",
+                "symfony/yaml": "^2.3 | ^3.0 | ^4.0 | ^5.0 | ^6.0 | ^7.0",
                 "unleashedtech/php-coding-standard": "^3.1.1",
                 "vimeo/psalm": "^4.24.0 || ^5.0.0"
             },
@@ -2959,7 +2960,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.6-dev"
+                    "dev-main": "2.7-dev"
                 }
             },
             "autoload": {
@@ -3016,7 +3017,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-16T11:46:16+00:00"
+            "time": "2024-12-07T15:34:16+00:00"
         },
         {
             "name": "league/config",
@@ -13603,12 +13604,12 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5180,9 +5180,9 @@
             }
         },
         "node_modules/express": {
-            "version": "4.21.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-            "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
             "dev": true,
             "dependencies": {
                 "accepts": "~1.3.8",
@@ -5204,7 +5204,7 @@
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.10",
+                "path-to-regexp": "0.1.12",
                 "proxy-addr": "~2.0.7",
                 "qs": "6.13.0",
                 "range-parser": "~1.2.1",
@@ -5219,6 +5219,10 @@
             },
             "engines": {
                 "node": ">= 0.10.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/express/node_modules/debug": {
@@ -7389,9 +7393,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "dev": true,
             "funding": [
                 {
@@ -7864,9 +7868,9 @@
             "dev": true
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
             "dev": true
         },
         "node_modules/path-type": {
@@ -14925,9 +14929,9 @@
             }
         },
         "express": {
-            "version": "4.21.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-            "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+            "version": "4.21.2",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+            "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
             "dev": true,
             "requires": {
                 "accepts": "~1.3.8",
@@ -14949,7 +14953,7 @@
                 "methods": "~1.1.2",
                 "on-finished": "2.4.1",
                 "parseurl": "~1.3.3",
-                "path-to-regexp": "0.1.10",
+                "path-to-regexp": "0.1.12",
                 "proxy-addr": "~2.0.7",
                 "qs": "6.13.0",
                 "range-parser": "~1.2.1",
@@ -16566,9 +16570,9 @@
             }
         },
         "nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "dev": true
         },
         "negotiator": {
@@ -16921,9 +16925,9 @@
             "dev": true
         },
         "path-to-regexp": {
-            "version": "0.1.10",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-            "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+            "version": "0.1.12",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
             "dev": true
         },
         "path-type": {


### PR DESCRIPTION

**Upgrade Project -- Laravel from 10 to 11 and PHP from 8.1 to 8.3**

Laravel 11, released on March 12, 2024, brings a multitude of enhancements aimed at making web development more efficient and secure. Here’s a quick rundown of what you need to know:


- Release and Support: Regular updates till August 2024 and security patches until February 2025.

- Why Upgrade?:

- Faster performance due to improved routing and caching.

- Enhanced security features.

- New [developer tools](https://daily.dev/blog/firefox-enhancements-for-developers) and simplified upgrade process.

- Full compatibility with [PHP 8.2](https://daily.dev/blog/php-trends-for-2024).

- New Features:

- Simplified project structure with fewer preset directories.

- Configuration and settings streamlined into .env files.

- Enhanced data handling and middleware management.

- Improved scheduling and bug fixing tools.

- Optimizations for route organization and model relations.

- Advanced rate limiting and a new health check endpoint.


Upgrading to Laravel 11 not only streamlines your development process but also leverages the latest PHP features, ensuring your projects are fast, secure, and up-to-date.


**Why Upgrade to Laravel 11?**


Upgrading to Laravel 11 is a smart move for a few reasons:


- Faster Performance - Your apps will run faster because of improvements in how routes are handled, how queries are made, and how data is cached.

- Better Security - Laravel 11 includes new security features and fixes that help keep your app and its data safe.

- New Tools for Developers - There are better tools for debugging, new commands for Artisan (Laravel's command-line tool), and updated documentation to help you work more efficiently.

- Easy to Upgrade - Moving from Laravel 10 to 11 is straightforward because the new version is designed to work well with the older one.


By updating to Laravel 11, you can take advantage of the latest PHP 8.2 features, easier setup, and better testing tools. This means you can make stronger and safer apps more quickly.

DEC 9 -- Resolve Laravel 11 with symfony/mailer v7.2.0 issue 
https://github.com/laravel/framework/issues/53721

DEC 12 -- installed PEST and DUSK

DEC 13 -- UPDATE package league/commonmark

[Ticket ](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/EBq9aa_H1kiQA5C93KE-ymUAE6tv?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)
