### PR TITLE
[jp-0208] Donate Now Pledge 242 and 243-- Correct Calendar Year and Pay deduct date

### DIFF
--- a/database/seeders/DataFixFor_jp_0208_DonateNowPledges_242_243.php
+++ b/database/seeders/DataFixFor_jp_0208_DonateNowPledges_242_243.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0208_DonateNowPledges_242_243 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reassign charity on Evenet Pledge 173 
+        
+        echo 'Before change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw("id between 242 and 243 and emplid in ('180829') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        // Data Fix
+        /*
+            Tran ID         EE                          Deduct Pay      Actual Deduct Pay Date  
+
+            242             180829   2025 --> 2024      2025-03-31  --> 2024-11-16       
+            243             180829   2025 --> 2024      2025-03-31  --> 2024-11-16       
+
+        */
+        DB::update("update donate_now_pledges set yearcd = 2024, deduct_pay_from = '2024-11-16', 
+                           ods_export_status = 'C', ods_export_at = now(),
+                           updated_at = now() 
+                     where id between 242 and 243 and emplid in ('180829') and deleted_at is null;");
+        
+        echo PHP_EOL;
+        echo PHP_EOL;
+        echo 'After change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw("id between 242 and 243 and emplid in ('180829') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+    }
+}


### PR DESCRIPTION
**Issue**

Both Donate Now (242 and 243) for Christine Lewynsky Batcheller (EE#180829) )in PeopleSoft were created for the 2024 calendar year, with the pay date of November 16, 2024. However, it is not possible to backdate to December 2024 in Greenfield.

This is preventing Job from reconciling the 40D process for this pay period. Below are her preferred charity choices:

$20 one time to
SOAP FOR HOPE CANADA SOCIETY
Registration no.  769912676 RR 0001

$20 one time to
CANADIAN MENTAL HEALTH ASSOCIATION B.C. DIVISION
Registration no.  888441995 RR 0001

**Action:**

Both Transaction ID: 242 and 243

Please make the adjustment on the backend and update the payroll deduction: 

Calendar Year : 2024
payroll deduction date : Nov 16, 2024
Mark to completed "to Peoplesoft" to avoid duplication


[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/XnnUAwc5aEKJxfLQUAi2YmUALbpZ?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)
