### PR TITLE
[jp-0208] Deployment error on openshift - 'oc: command not found'

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   #Print variables for logging and debugging purposes
   checkEnv:
     name: Check Env variables
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Print Env Vars
         run: |
@@ -26,7 +26,7 @@ jobs:
 
   build:
     name: Build APP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # if: ${{ github.event.pull_request.merged == true}}
     if: github.ref_name == 'dev' || github.ref_name  == 'test' || github.ref_name  == 'prod'
     env:
@@ -70,7 +70,7 @@ jobs:
   # Deploy App images in Dev
   deployDev:
     name: Deploy APP to Dev environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref_name == 'dev'
     env:
      BUILD_ID: ${{ github.event.number }}
@@ -146,7 +146,7 @@ jobs:
   # Deploy App images in Test
   deployTest:
     name: Deploy APP to Test environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref_name == 'test'
     env:
      BUILD_ID: ${{ github.event.number }}
@@ -221,7 +221,7 @@ jobs:
  # Deploy App images in Prod
   deployProd:
     name: Deploy APP to Prod environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref_name == 'prod'
     env:
      BUILD_ID: ${{ github.event.number }}


### PR DESCRIPTION
**Issue**:

Failed to deploy changes on DEV, TEST and Production with the following error message

Run oc login --token=*** --server=https://api.silver.devops.gov.bc.ca:6443/
10 /home/runner/work/_temp/deaa6f60-5e9c-4171-9e95-e8dec1c8239c.sh: line 1: oc: command not found
11 Error: Process completed with exit code 127.



**Action**:

If you update the workflow “runs-on” image to “ubuntu-22.04” or add the additional installation step that Kunal shared it should get the deployment working again. 


In this case, the file is: /.github/workflows/deploy.yml 


You can just change: 

runs-on: ubuntu-latest 


to: 

runs-on: ubuntu-22.04 


https://github.com/bcgov/performance/blob/d96c86a9a00f944c08afafecb399e1493e8ca432/.github/workflows/deploy.yml#L30

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/rSJgogNWb0ONbJTOU-b9ZmUABKHM?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)

