### PR TITLE
(TEST) [jp-0208] Donate Now Pledge 242 and 243-- Correct Calendar Year and Pay deduct date (Merge branch 'jp-0209' into jp-0208)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
   #Print variables for logging and debugging purposes
   checkEnv:
     name: Check Env variables
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Print Env Vars
         run: |
@@ -26,7 +26,7 @@ jobs:
 
   build:
     name: Build APP
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # if: ${{ github.event.pull_request.merged == true}}
     if: github.ref_name == 'dev' || github.ref_name  == 'test' || github.ref_name  == 'prod'
     env:
@@ -70,7 +70,7 @@ jobs:
   # Deploy App images in Dev
   deployDev:
     name: Deploy APP to Dev environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref_name == 'dev'
     env:
      BUILD_ID: ${{ github.event.number }}
@@ -146,7 +146,7 @@ jobs:
   # Deploy App images in Test
   deployTest:
     name: Deploy APP to Test environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref_name == 'test'
     env:
      BUILD_ID: ${{ github.event.number }}
@@ -221,7 +221,7 @@ jobs:
  # Deploy App images in Prod
   deployProd:
     name: Deploy APP to Prod environment
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.ref_name == 'prod'
     env:
      BUILD_ID: ${{ github.event.number }}


### PR DESCRIPTION
Issue

Both Donate Now (242 and 243) for Christine Lewynsky Batcheller (EE#180829) )in PeopleSoft were created for the 2024 calendar year, with the pay date of November 16, 2024. However, it is not possible to backdate to December 2024 in Greenfield.

This is preventing Job from reconciling the 40D process for this pay period. Below are her preferred charity choices:

$20 one time to
SOAP FOR HOPE CANADA SOCIETY
Registration no. 769912676 RR 0001

$20 one time to
CANADIAN MENTAL HEALTH ASSOCIATION B.C. DIVISION
Registration no. 888441995 RR 0001

Action:

Both Transaction ID: 242 and 243

Please make the adjustment on the backend and update the payroll deduction:

Calendar Year : 2024
payroll deduction date : Nov 16, 2024
Mark to completed "to Peoplesoft" to avoid duplication

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/XnnUAwc5aEKJxfLQUAi2YmUALbpZ?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)