### PR TITLE
(TEST) [jp-0210] Donate Now Pledge 245 and 246-- Correct Calendar Year and Pay deduct date

### DIFF
--- a/database/seeders/DataFixFor_jp_0210_DonateNowPledges_245_246.php
+++ b/database/seeders/DataFixFor_jp_0210_DonateNowPledges_245_246.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0210_DonateNowPledges_245_246 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reassign charity on Evenet Pledge 173 
+        
+        echo 'Before change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw("id between 245 and 246 and emplid in ('168370') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        // Data Fix
+        /*
+            Tran ID         EE                          Deduct Pay      Actual Deduct Pay Date  
+
+            245             168370   2025 --> 2024      2025-03-31  --> 2024-12-14       
+            246             168370   2025 --> 2024      2025-03-31  --> 2024-12-14       
+
+        */
+        DB::update("update donate_now_pledges set yearcd = 2024, deduct_pay_from = '2024-12-14', 
+                           ods_export_status = 'C', ods_export_at = now(),
+                           updated_at = now() 
+                     where id between 245 and 246 and emplid in ('168370') and deleted_at is null;");
+        
+        echo PHP_EOL;
+        echo PHP_EOL;
+        echo 'After change:';
+        $data = DB::table('donate_now_pledges')
+                    ->whereRaw("id between 245 and 246 and emplid in ('168370') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+    }
+}


### PR DESCRIPTION
Issue

Both Donate Now (245 and 246) for Phelan,Michelle (EE#168370) in PeopleSoft were created for the 2024 calendar year, with the pay date of December 14, 2024. However, it is not possible to backdate to December 2024 in Greenfield.

This is preventing Job from reconciling the 40D process for this pay period. Below are her preferred charity choices:

$75 one time to
KAMLOOPS SEXUAL ASSAULT COUNSELLING CENTRE SOCIETY

$75 one time to
BRITISH COLUMBIA SOCIETY FOR THE PREVENTION OF CRUELTY TO ANIMALS

Action:

Both Transaction ID: 245 and 246

Please make the adjustment on the backend and update the payroll deduction:

Calendar Year : 2024
payroll deduction date : Nov 14, 2024
Mark to completed "to Peoplesoft" to avoid duplication

[ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/dbDow3d6Gk6CP3325VkL0WUAM7ml?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)