### PR TITLE
(TEST) [jp-0211] Improve the Task Scheduling Status Monitoring for lower regions

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -13,6 +13,7 @@ use App\Models\ScheduleJobAudit;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\App;
 use App\Http\Controllers\Controller;
 use Illuminate\Console\Scheduling\Schedule;
 
@@ -106,11 +107,16 @@ class SystemStatusController extends Controller
                 continue;
             }
             $last_job_name = $job_name;
-
+    
             // SPECIAL -- only run on Monday and weekdays if annual campaign period is open
             if ($job_name == 'command:ImportCities' || $job_name == 'command:ImportDepartments') {
+
                 $cy = CampaignYear::where('calendar_year', today()->year + 1)->first();
-                $last_change_date = $cy ? $cy->updated_at->startOfDay()->copy()->addDay(1)->addHours(3) : null;
+                if (App::environment('prod')) {
+                    $last_change_date = $cy ? $cy->updated_at->startOfDay()->copy()->addDay(1)->addHours(3) : null;
+                } else {
+                    $last_change_date = $cy ? $cy->updated_at->startOfDay()->copy()->addDay(1)->addHours(9) : null;
+                }
 
                 if ( (now() > $last_change_date ) && (CampaignYear::isAnnualCampaignOpenNow() || (today()->dayOfWeek == 1))) {
                     // it should be processed 


### PR DESCRIPTION
Due to the reschedule "ImportCities" and "ImportDepartments" process on lower regions to 8:30am, the program was incorrectly report an failure.

[ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/DPz-OaEOMUyo-PBj1Jz4rmUAPL9z?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)