### PR TITLE
 [jp-0211] Improve the Task Scheduling Status Monitoring for lower regions (Additional changes)

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -140,10 +140,16 @@ class SystemStatusController extends Controller
                 // Use the previous calculate date
             } else {
                 if ($job_name == 'command:ImportCities' || $job_name == 'command:ImportDepartments') {
-                    if ($job_name == 'command:ImportCities') {
-                        $hr = 2; $min = 30;
+                    if (App::environment('prod')) {
+                        $t_hr = 2; 
                     } else {
-                        $hr = 2; $min = 45;
+                        $t_hr = 9;
+                    }
+
+                    if ($job_name == 'command:ImportCities') {
+                        $hr = $t_hr; $min = 30;
+                    } else {
+                        $hr = $t_hr; $min = 45;
                     }
 
                     if (now() <= (today()->hour($hr)->minute($min)) ) {


### PR DESCRIPTION
Due to the reschedule "ImportCities" and "ImportDepartments" process on lower regions to 8:30am, the program was incorrectly report an failure.

[ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/DPz-OaEOMUyo-PBj1Jz4rmUAPL9z?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)