### PR TITLE
 [jp-0211] Improve the Task Scheduling Status Monitoring for lower regions (Additional 2nd changes)

### DIFF
--- a/app/Http/Controllers/Api/SystemStatusController.php
+++ b/app/Http/Controllers/Api/SystemStatusController.php
@@ -115,7 +115,7 @@ class SystemStatusController extends Controller
                 if (App::environment('prod')) {
                     $last_change_date = $cy ? $cy->updated_at->startOfDay()->copy()->addDay(1)->addHours(3) : null;
                 } else {
-                    $last_change_date = $cy ? $cy->updated_at->startOfDay()->copy()->addDay(1)->addHours(9) : null;
+                    $last_change_date = $cy ? $cy->updated_at->startOfDay()->copy()->addDay(1)->addHours(8) : null;
                 }
 
                 if ( (now() > $last_change_date ) && (CampaignYear::isAnnualCampaignOpenNow() || (today()->dayOfWeek == 1))) {
@@ -143,7 +143,7 @@ class SystemStatusController extends Controller
                     if (App::environment('prod')) {
                         $t_hr = 2; 
                     } else {
-                        $t_hr = 9;
+                        $t_hr = 8;
                     }
 
                     if ($job_name == 'command:ImportCities') {


### PR DESCRIPTION
Due to the reschedule "ImportCities" and "ImportDepartments" process on lower regions to 8:30am, the program was incorrectly report an failure.

[ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/DPz-OaEOMUyo-PBj1Jz4rmUAPL9z?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)