### PR TITLE
(TEST) Update pecsf-dc.yml to remove deprecated restartPolicy

### DIFF
--- a/openshift/app/pecsf-dc.yml
+++ b/openshift/app/pecsf-dc.yml
@@ -99,7 +99,6 @@ objects:
                 postStart:
                   exec:
                     command: ["/bin/sh", "-c", "php /var/www/html/artisan queue:work --tries=3 --timeout=0 --memory=512 >> /var/www/html/storage/logs/queue-work.log & "]
-              restartPolicy: Always
               imagePullPolicy: Always
               ports:
                 - containerPort: 8000


### PR DESCRIPTION
Removed restartPolicy due to deprecation for non-init containers in OpenShift 4.16