### PR TITLE
(MASTER) [jp-0213] Update pecsf-dc.yml to remove deprecated restartPolicy

### DIFF
--- a/openshift/app/pecsf-dc.yml
+++ b/openshift/app/pecsf-dc.yml
@@ -99,7 +99,6 @@ objects:
                 postStart:
                   exec:
                     command: ["/bin/sh", "-c", "php /var/www/html/artisan queue:work --tries=3 --timeout=0 --memory=512 >> /var/www/html/storage/logs/queue-work.log & "]
-              restartPolicy: Always
               imagePullPolicy: Always
               ports:
                 - containerPort: 8000


### PR DESCRIPTION
**Issue**
Encountered the following error message when deploying project on openshit

    The DeploymentConfig "pecsf-new" is invalid: spec.template.spec.containers[0].restartPolicy: Forbidden: may not be set for non-init containers


**Action Required**
Removed restartPolicy due to deprecation for non-init containers in OpenShift 4.16


[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/InIDmG0_vk2vFLR9wnPid2UAFW6P?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)