### PR TITLE
[upgrade_10_to_11] Dev - Upgrade Laravel version 10 to 11 and PHP version 8.1 to 8.3 (Update Dusk Test Cases)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /vendor
 .env
 .env.backup
+.env.demo
+.env.dusk.local
 .phpunit.result.cache
 docker-compose.override.yml
 Homestead.json

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,7 +32,7 @@ class AppServiceProvider extends ServiceProvider
     {
       Paginator::useBootstrap();
 		Schema::defaultStringLength(191);
-		if (config('app.env') !== 'local') {
+		if (config('app.env') !== 'local' && config('app.env') !== 'demo') {
             $this->app['request']->server->set('HTTPS','on');
             URL::forceScheme('https');
 		}

--- a/composer.lock
+++ b/composer.lock
@@ -484,6 +484,85 @@
             "time": "2024-02-09T16:56:22+00:00"
         },
         {
+            "name": "composer/pcre",
+            "version": "3.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/pcre.git",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan": "<1.11.10"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.12 || ^2",
+                "phpstan/phpstan-strict-rules": "^1 || ^2",
+                "phpunit/phpunit": "^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Pcre\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "PCRE wrapping library that offers type-safe preg_* replacements.",
+            "keywords": [
+                "PCRE",
+                "preg",
+                "regex",
+                "regular expression"
+            ],
+            "support": {
+                "issues": "https://github.com/composer/pcre/issues",
+                "source": "https://github.com/composer/pcre/tree/3.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-12T16:29:46+00:00"
+        },
+        {
             "name": "composer/semver",
             "version": "3.4.3",
             "source": {
@@ -5332,19 +5411,20 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.29.8",
+            "version": "1.29.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "089ffdfc04b5fcf25a3503d81a4e589f247e20e3"
+                "reference": "ffb47b639649fc9c8a6fa67977a27b756592ed85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/089ffdfc04b5fcf25a3503d81a4e589f247e20e3",
-                "reference": "089ffdfc04b5fcf25a3503d81a4e589f247e20e3",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/ffb47b639649fc9c8a6fa67977a27b756592ed85",
+                "reference": "ffb47b639649fc9c8a6fa67977a27b756592ed85",
                 "shasum": ""
             },
             "require": {
+                "composer/pcre": "^3.3",
                 "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-fileinfo": "*",
@@ -5431,9 +5511,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.8"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.9"
             },
-            "time": "2025-01-12T03:16:27+00:00"
+            "time": "2025-01-26T04:55:00+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/database/factories/BusinessUnitFactory.php
+++ b/database/factories/BusinessUnitFactory.php
@@ -2,8 +2,9 @@
 
 namespace Database\Factories;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
+use Carbon\Carbon;
 use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
 class BusinessUnitFactory extends Factory
 {
@@ -20,8 +21,9 @@ class BusinessUnitFactory extends Factory
             //
             'code' => $code,
             'name' => $this->faker->words(2, true),
+            'acronym' => $this->faker->regexify('[A-Z]{4}'),
             'status' => $this->faker->randomElement(['A', 'I']),
-            'effdt' => $this->faker->date(),
+            'effdt' => Carbon::parse($this->faker->date()),
             'notes' => $this->faker->sentence(),
             'linked_bu_code' => $code,
             'created_by_id' => 1,

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -14,9 +14,12 @@ class OrganizationFactory extends Factory
      */
     public function definition()
     {
+       
+        $code = $this->faker->regexify('/^[A-Z]{3}$/');
+
         return [
             //
-            'code' => $this->faker->randomElement(['LA', 'BCA', 'GOV', 'RET']),
+            'code' => $code,    // $this->faker->randomElement(['LA', 'BCA', 'GOV', 'RET']),
             'name' => $this->faker->words(2, true),
             'status' => $this->faker->randomElement(['A', 'I']),
             'effdt' => $this->faker->date(),

--- a/database/seeders/DataFixFor_jp_0212_CampaignPledge_5981_12581.php
+++ b/database/seeders/DataFixFor_jp_0212_CampaignPledge_5981_12581.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0212_CampaignPledge_5981_12581 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        
+        echo 'Before change:' . PHP_EOL;
+        $data = DB::table('pledges')
+                    ->whereRaw("id in (12625, 12581) and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        echo PHP_EOL;
+        echo 'Before change  (Donation -- 080964) :' . PHP_EOL;
+        $data = DB::table('donations')
+                    ->whereRaw("org_code = 'BCS' and pecsf_id = '080964' ")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        echo PHP_EOL;
+        echo 'Before change: (Donation -- 136016)' . PHP_EOL;
+        $data = DB::table('donations')
+                    ->whereRaw("org_code = 'LA' and pecsf_id = '136016' ")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        // Data Fix
+        /*
+            Tran ID         PECSF ID               YEAR    
+
+            12625           136016 --> 135016      2025        
+            12581           080964 --> 081027      2025      
+
+        */
+        DB::update("update pledges set pecsf_id = '135016', 
+                           updated_at = now() 
+                     where id = 5981 and pecsf_id = '136016' and deleted_at is null;");
+
+        DB::update("update donations set pecsf_id = '135016', 
+                     updated_at = now() 
+                     where org_code = 'LA' and pecsf_id = '136016';");
+
+        /* ======================= */
+        DB::update("update pledges set pecsf_id = '081027', 
+                     updated_at = now() 
+               where id = 12581 and pecsf_id = '080964' and deleted_at is null;");
+
+        DB::update("update donations set pecsf_id = '081027', 
+                    updated_at = now() 
+                    where org_code = 'BCS' and pecsf_id = '080964';");
+
+        echo PHP_EOL;
+        echo PHP_EOL;
+        echo 'After change:' . PHP_EOL;
+        $data = DB::table('pledges')
+                    ->whereRaw("id in (12625, 12581) and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        echo PHP_EOL;
+        echo 'After change  (Donation -- 081027) :' . PHP_EOL;
+        $data = DB::table('donations')
+                    ->whereRaw("org_code = 'BCS' and pecsf_id = '081027' ")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        echo PHP_EOL;
+        echo 'After change: (Donation -- 135016)' . PHP_EOL;
+        $data = DB::table('donations')
+                    ->whereRaw("org_code = 'LA' and pecsf_id = '135016' ")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+    }
+}

--- a/database/seeders/UserTableSeeder.php
+++ b/database/seeders/UserTableSeeder.php
@@ -296,6 +296,8 @@ class UserTableSeeder extends Seeder
       ]
     ];
 
+      User::truncate();
+
         $organization = Organization::where('code','GOV')->first();
 
         $password = env('SYNC_USER_PROFILE_SECRET') ? Hash::make( env('SYNC_USER_PROFILE_SECRET')) : '$2y$10$Qoiy/oe4.1bV/uqEi0uTteP.sYudg34zeC2mN7YLTs8ris0F5WskW';

--- a/openshift/app/pecsf-dc.yml
+++ b/openshift/app/pecsf-dc.yml
@@ -99,7 +99,6 @@ objects:
                 postStart:
                   exec:
                     command: ["/bin/sh", "-c", "php /var/www/html/artisan queue:work --tries=3 --timeout=0 --memory=512 >> /var/www/html/storage/logs/queue-work.log & "]
-              restartPolicy: Always
               imagePullPolicy: Always
               ports:
                 - containerPort: 8000

--- a/phpunit.dusk.xml
+++ b/phpunit.dusk.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         beStrictAboutTestsThatDoNotTestAnything="false"
+         colors="true"
+         processIsolation="false"
+         stopOnError="false"
+         stopOnFailure="false"
+         cacheDirectory=".phpunit.cache"
+         backupStaticProperties="false">
+    <testsuites>
+        <testsuite name="Browser Test Suite">
+            <directory suffix="Test.php">./tests/Browser</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Browser/BusinessUnitTest.php
+++ b/tests/Browser/BusinessUnitTest.php
@@ -1,0 +1,469 @@
+<?php
+
+
+use Carbon\Carbon;
+use App\Models\User;
+use App\Models\Setting;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use Faker\Factory as Faker;
+use Illuminate\Support\Str;
+
+use App\Models\BusinessUnit;
+use App\Models\CampaignYear;
+
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+
+
+// uses(Tests\DuskTestCase::class);
+// uses(Tests\DuskTestCase::class)->in('Unit', 'Feature');
+
+
+// uses(DatabaseTruncation::class);
+
+// test('example', function () {
+//     $this->browse(function (Browser $browser) {
+//         $browser->visit('/')
+//                 ->assertSee('Log in as a System Administrator');
+//     });
+// });
+
+
+
+beforeAll(function () {
+
+    // artisan('db:seed');
+    // artisan::call('db:seed', ['--class' => 'UserTableSeeder']);
+
+
+    // // Truncate tables and seed required data
+ 
+
+    // // Create a shared test user
+    // $this->user = User::Factory()->create([
+    //     'password' => bcrypt('password123'),
+    //     'source_type' => 'LCL',
+    // ]);
+
+    // $this->user->assignRole('admin');
+
+});
+
+
+beforeEach(function () {
+  
+    // Truncate the database and create a fresh user before each test
+    Setting::truncate();
+    CampaignYear::truncate();
+    BusinessUnit::truncate();
+      
+    $this->admin = User::whereHas("roles", function ($q) {$q->where("name", "admin");})->first();
+    $this->user  = User::doesntHave('roles')->orderBy('id')->first();
+
+    $this->setting = Setting::create([
+        ]);
+
+    $this->campaign_year = CampaignYear::create([
+            'calendar_year' => today()->year + 1,
+            'status' => 'A',
+            'start_date' => today(),
+            'end_date' => today()->year . '-12-31',
+            'number_of_periods' => 26,
+            'close_date' => today()->year . '-12-31',
+        ]);
+
+});
+
+afterEach(function () {
+    // Cleanup admin user
+    // $this->admin->delete();
+    
+    // Refresh the browser after each test
+    session()->flush();
+});
+
+
+// if (!function_exists('afterTruncatingDatabase')) {
+//     function afterTruncatingDatabase(callable $callback)
+//     {
+//         $callback();
+//     }
+// }
+
+/*
+it('fails to log in with invalid credentials', function () {
+    $this->browse(function (Browser $browser) {
+        $browser->visit('/login')
+            ->assertSee('Login')
+            ->click('a.sysadmin-login')
+            ->type('email', 'invaliduser@example.com')
+            ->type('password', 'wrongpassword')
+            ->press('#admin-login button[type="submit"]')
+            ->waitForText('These credentials do not match our records.')
+            ->assertSee('These credentials do not match our records.');
+    });
+});
+
+
+it('fails to log in with missing required fields', function () {
+    $this->browse(function (Browser $browser) {
+        $browser->visit('/login')
+            ->assertSee('Login')
+            ->click('a.sysadmin-login')
+            ->press('#admin-login button[type="submit"]')
+            ->waitForText('The email field is required.')
+            ->assertSee('The email field is required.')
+            ->assertSee('The password field is required.');
+    });
+});
+
+
+
+it('allows a logged in user to log out successfully', function () {
+    $this->browse(function (Browser $browser) {
+        $browser->visit('/login')
+            ->assertSee('Login')
+            ->click('a.sysadmin-login')
+            ->type('email', $this->user->email)
+            ->type('password', 'password123') // Use the known password
+            ->press('#admin-login button[type="submit"]')
+            ->waitForLocation('/')
+            ->assertPathIs('/')
+            ->waitForText('Statistics')
+            ->assertSee('Statistics');    
+   
+        $browser->visit('/')
+            ->click('li.user-menu button')
+            ->waitForText('Log Out') 
+            ->clicklink('Log Out')
+            ->waitForLocation('/login')
+            ->assertPathIs('/login')
+            ->waitForText('Login')
+            ->assertSee('Login');
+     
+
+    });
+});
+
+*/
+
+
+
+it('redirects anonymous user to the login page', function () {
+    $this->browse(function (Browser $browser) {
+
+        $browser->visit('/settings/business-units') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+
+        $browser->visit('/settings/business-units/create') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+
+        $response = $this->post('/settings/business-units', []);
+        $response->assertStatus(302);
+        $response->assertRedirect('login');
+
+        $browser->visit('/settings/business-units/1') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+        
+        $browser->visit('/settings/business-units/1/edit') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+        
+        $response = $this->put('/settings/business-units/1', []);
+        $response->assertStatus(302);
+        $response->assertRedirect('login');
+
+        $response = $this->delete('/settings/business-units/1');
+        $response->assertStatus(302);
+        $response->assertRedirect('login');
+            
+    });
+});
+
+
+it('denies access to protected business unit maintenance routes for unauthorized user', function () {
+    $this->browse(function (Browser $browser) {
+
+        $browser->loginAs($this->user)
+            ->visit('/settings/business-units') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+
+        $browser->loginAs($this->user)
+            ->visit('/settings/business-units/create') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+
+        $browser->loginAs($this->user)
+            ->visit('/settings/business-units/1') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+        
+        $browser->loginAs($this->user)
+            ->visit('/settings/business-units/1/edit') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+            
+    });
+});
+
+it('validateion error on create', function () {
+
+        $faker = Faker::create();
+
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->admin)
+                ->visit('/settings/business-units')
+                ->press('[data-target="#bu-create-modal"]')
+                ->waitForText('Add a new business unit')
+                ->assertSee('Add a new business unit')
+                ->press('#create-confirm-btn')
+                ->acceptDialog()
+            
+                ->waitFor('#bu-create-model-form span.text-danger')
+                ->assertSee('The code field is required.')
+                ->assertSee('The name field is required.') 
+                ->assertSee('The acronym field is required.')
+                ->assertSee('The effective date field must be in the past if the status is Active')
+                ->assertSee('The linked bu code field is required.')
+                ->logout('admin')
+               ;
+        });
+
+        $this->browse(function (Browser $browser) use($faker) {
+            $browser->loginAs($this->admin)
+                ->visit('/settings/business-units')
+                ->press('[data-target="#bu-create-modal"]')
+                ->waitForText('Add a new business unit')
+                ->assertSee('Add a new business unit')
+                // ->pause(1000)
+                ->type('#bu-create-model-form [name="code"]', 'BC' . $faker->regexify('[0-9]{9}') )
+                ->type('#bu-create-model-form [name="name"]', Str::random(80) )
+                ->type('#bu-create-model-form [name="acronym"]',  $faker->regexify('[a-z]{5}') )
+                ->type('#bu-create-model-form [name="effdt"]', Carbon::tomorrow()->format('m-d-Y') )
+                ->type('#bu-create-model-form [name="linked_bu_code"]', 'BC' . $faker->regexify('[0-9]{3}') )
+                ->press('#create-confirm-btn')
+                ->acceptDialog()
+            
+                ->waitFor('#bu-create-model-form span.text-danger')
+                ->assertSee('The code must not be greater than 5 characters.')
+                ->assertSee('The name must not be greater than 60 characters.') 
+                ->assertSee('The acronym field must be uppercase.')
+                ->assertSee('The acronym must not be greater than 4 characters.')
+                ->assertSee('The effective date field must be in the past if the status is Active')
+                ->assertSee('The associated business unit is invalid.')
+             
+                // ->assertSee('The effective date field must be in the past if the status is Active')
+                // ->assertSee('The linked bu code field is required.')
+                ->logout('admin')
+               ;
+        });
+
+});
+
+
+it('validation error on edit', function () {
+
+    $faker = Faker::create();
+
+    $businessUnit = BusinessUnit::factory()->create([]);
+
+    $this->browse(function (Browser $browser) use ($businessUnit, $faker) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/business-units')
+            ->waitForText(  $businessUnit->code )
+            ->click('a.edit-bu[data-id="'. $businessUnit->id .'"]')
+
+            ->waitForText( 'Edit an existing business unit' )
+            ->assertSee('Edit an existing business unit')
+            // ->pause(1000)
+            ->type('#bu-edit-model-form [name="name"]', '  ' )
+            ->type('#bu-edit-model-form [name="linked_bu_code"]', 'BC' . rand(100, 999) )
+            ->press('#save-confirm-btn')
+            ->acceptDialog()
+            ->waitFor('#bu-edit-model-form span.text-danger')
+   
+            // ->waitFor('The code field is required.')
+            ->assertSee('The name field is required.') 
+            // ->assertSee('The acronym field is required.')
+            ->assertSee('The associated business unit is invalid.')
+
+            ->logout('admin')
+           ;
+    });
+
+});
+
+//
+
+
+
+it('pagination on business units table via ajax call', function () {
+
+    BusinessUnit::factory(25)->create();
+    $sorted = BusinessUnit::orderBy('code')->get();
+
+    $this->browse(function (Browser $browser) use($sorted) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/business-units') // API endpoint
+            // ->screenshot('debug-pagation-page') 
+
+            ->waitForText(  'Showing 1 to 10' )
+            ->assertSee( $sorted[0]->code ) // Check if "name" key exists in JSON
+            ->assertSee( $sorted[0]->notes ) // Check if "name" key exists in JSON
+            ->click('a[data-dt-idx="2"]')
+            ->waitForText(  'Showing 11 to 20' )
+            ->assertSee( $sorted[10]->code ) // Ch
+
+            ->logout('admin')
+            ;
+
+    });
+
+});
+
+
+
+  
+it('administrator creates a new business unit', function () {
+
+    $yesterday = Carbon::yesterday(); 
+
+    $item = BusinessUnit::factory()->make([
+        'effdt' => $yesterday->format('Y-m-d'),
+    ]);
+
+    $this->browse(function (Browser $browser) use($yesterday, $item) {
+        // $browser->visit('/login')
+
+        //     ->assertSee('Login')
+        //     ->click('a.sysadmin-login')
+        //     ->type('email', $this->user->email)
+        //     ->type('password', env('SYNC_ADMIN_PROFILE_SECRET') ) // Use the known password
+        //     ->press('#admin-login button[type="submit"]')
+        //     ->waitForLocation('/')
+        //     ->assertPathIs('/')
+        //     ->waitForText('Statistics')
+        //     ->assertSee('Statistics');
+    
+        $browser->loginAs($this->admin)
+            ->visit('/settings/business-units')
+            ->waitForText('Showing 0 to ')
+            ->press('[data-target="#bu-create-modal"]')
+            ->waitForText('Add a new business unit')
+            ->assertSee('Add a new business unit')
+            ->pause(5000)
+            ->type('#bu-create-model-form [name="code"]', $item->code)
+            ->type('#bu-create-model-form [name="name"]', $item->name)
+            ->type('#bu-create-model-form [name="effdt"]', $yesterday->format('m-d-Y'))
+            ->select('#bu-create-model-form [name="status"]', $item->status)
+            ->type('#bu-create-model-form [name="acronym"]', $item->acronym)
+            ->type('#bu-create-model-form [name="linked_bu_code"]', $item->linked_bu_code)
+            ->type('#bu-create-model-form [name="notes"]', $item->notes)
+            ->press('#create-confirm-btn')
+            ->acceptDialog()
+            ->waitForText('Business Unit ' . $item->code . ' has been successfully created.')
+            ->assertSee('Business Unit ' . $item->code . ' has been successfully created.')
+            ->logout('admin');
+            ;
+
+        // Verify the same data in the database
+        $this->assertDatabaseHas('business_units', Arr::except( $item->attributesToArray(), ['created_by_id', 'updated_by_id']) );
+            
+    });
+});
+
+
+it('show a business unit', function () {
+
+    $item = BusinessUnit::factory()->create([]);
+
+    $this->browse(function (Browser $browser) use ($item) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/business-units')
+            ->waitForText('Showing 1 to 1 ')
+            // ->waitForText(  $businessUnit->code )
+            ->click('a.show-bu[data-id="'. $item->id .'"]')
+            
+            ->waitForText( 'Existing business unit details' )
+            ->assertSee('Existing business unit details')
+            ->assertSee( $item->code )
+            ->assertSee( $item->name )
+            ->assertSee( $item->notes )
+
+            ->logout('admin');
+            ;
+          
+    });
+});
+
+
+it('update a business unit', function () {
+
+    $faker = Faker::create();
+
+    $item = BusinessUnit::factory()->create([]);
+
+    $item->name = $faker->words(3, true);
+
+    $this->browse(function (Browser $browser) use ($item) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/business-units')
+            ->waitForText('Showing 1 to 1 ')
+            // ->waitForText(  $item->code )
+            ->click('a.edit-bu[data-id="'. $item->id .'"]')
+            
+            ->waitForText( 'Edit an existing business unit' )
+            ->assertSee('Edit an existing business unit')
+            ->type('#bu-edit-modal [name="name"]', $item->name)
+            ->press('#save-confirm-btn')
+            ->acceptDialog()
+            ->waitForLocation('/settings/business-units')
+            ->waitForText('Business Unit ' . $item->code . ' has been successfully updated.')
+            ->assertSee('Business Unit ' . $item->code . ' has been successfully updated.')
+            ->logout('admin');
+            ;
+
+        // Verify the same data in the database
+        $this->assertDatabaseHas('business_units', Arr::except( $item->attributesToArray(), 
+                    ['updated_by_id', 'created_at', 'updated_at']) );
+          
+    });
+});
+    
+it('deletes a business unit', function () {
+
+    $item = BusinessUnit::factory()->create([]);
+
+    $this->browse(function (Browser $browser) use ($item) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/business-units')
+            ->waitForText('Showing 1 to 1 ')
+            // ->waitForText(  $item->code )
+            ->click('a.delete-bu[data-id="'. $item->id .'"]')
+            // ->pause(10000)
+            ->waitForText( 'Are you sure you want to delete business unit code "' . $item->code  . '" ?' )
+            ->press('button.swal2-confirm')
+            // ->press('button.swal2-cancel')
+            ->waitForLocation('/settings/business-units')
+            ->waitForText('Business Unit ' . $item->code . ' has been successfully deleted.')
+            ->waitForText('No data available in table')
+            ->assertDontSee( $item->name )
+            ->logout('admin');
+            ;
+
+        $this->assertSoftDeleted('business_units',  Arr::except( $item->attributesToArray(), 
+                    ['created_by_id', 'updated_by_id', 'created_at', 'updated_at']) );
+        
+    });
+});
+

--- a/tests/Browser/ExampleTest.php
+++ b/tests/Browser/ExampleTest.php
@@ -1,8 +1,40 @@
 <?php
 
+use App\Models\Setting;
 use Laravel\Dusk\Browser;
+use App\Models\CampaignYear;
+use App\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
 
-test('basic example', function () {
+// uses(DatabaseTruncation::class);
+
+beforeEach(function () {
+  
+    Setting::truncate();
+    CampaignYear::truncate();
+    User::truncate();
+
+    // Create a fresh test user
+    $this->setting = Setting::create([
+    ]);
+
+    $this->campaign_year = CampaignYear::create([
+        'calendar_year' => today()->year + 1,
+        'status' => 'A',
+        'start_date' => today(),
+        'end_date' => today()->year . '-12-31',
+        'number_of_periods' => 26,
+        'close_date' => today()->year . '-12-31',
+    ]);
+
+    $this->user = User::Factory()->create([
+        'password' => bcrypt('password123'),
+        'source_type' => 'LCL',
+    ]);
+
+});
+
+it('basic example', function () {
     $this->browse(function (Browser $browser) {
         $browser->visit('/')
                 ->assertSee('Log in as a System Administrator');

--- a/tests/Browser/ExampleTest.php
+++ b/tests/Browser/ExampleTest.php
@@ -12,7 +12,6 @@ beforeEach(function () {
   
     Setting::truncate();
     CampaignYear::truncate();
-    User::truncate();
 
     // Create a fresh test user
     $this->setting = Setting::create([

--- a/tests/Browser/LoginTest.php
+++ b/tests/Browser/LoginTest.php
@@ -1,10 +1,147 @@
 <?php
 
-use Laravel\Dusk\Browser;
 
-test('example', function () {
+use App\Models\User;
+use App\Models\Setting;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use App\Models\CampaignYear;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+
+// Use DuskTestCase for all tests
+
+
+// uses(DatabaseTruncation::class);
+
+// test('example', function () {
+//     $this->browse(function (Browser $browser) {
+//         $browser->visit('/')
+//                 ->assertSee('Log in as a System Administrator');
+//     });
+// });
+
+
+beforeEach(function () {
+  
+    // Truncate the database and create a fresh user before each test
+    Setting::truncate();
+    CampaignYear::truncate();
+      
+    $this->setting = Setting::create([
+        ]);
+
+    $this->campaign_year = CampaignYear::create([
+            'calendar_year' => today()->year + 1,
+            'status' => 'A',
+            'start_date' => today(),
+            'end_date' => today()->year . '-12-31',
+            'number_of_periods' => 26,
+            'close_date' => today()->year . '-12-31',
+        ]);
+
+    $this->user = User::Factory()->create([
+            'password' => bcrypt('password123'),
+            'source_type' => 'LCL',
+        ]);
+  
+});
+
+
+afterEach(function () {
+    // Cleanup admin user
+    // $this->admin->delete();
+    
+    // Refresh the browser after each test
+    session()->flush();
+});
+
+
+
+// if (!function_exists('afterTruncatingDatabase')) {
+//     function afterTruncatingDatabase(callable $callback)
+//     {
+//         $callback();
+//     }
+// }
+
+
+it('fails to log in with invalid credentials', function () {
     $this->browse(function (Browser $browser) {
+        $browser->visit('/login')
+            ->assertSee('Login')
+            ->click('a.sysadmin-login')
+            ->type('email', 'invaliduser@example.com')
+            ->type('password', 'wrongpassword')
+            ->press('#admin-login button[type="submit"]')
+            ->waitForText('These credentials do not match our records.')
+            ->assertSee('These credentials do not match our records.');
+    });
+});
+
+
+it('fails to log in with missing required fields', function () {
+    $this->browse(function (Browser $browser) {
+        $browser->visit('/login')
+            ->assertSee('Login')
+            ->click('a.sysadmin-login')
+            ->press('#admin-login button[type="submit"]')
+            ->waitForText('The email field is required.')
+            ->assertSee('The email field is required.')
+            ->assertSee('The password field is required.');
+    });
+});
+
+
+
+it('allows a logged in user to log out successfully', function () {
+    $this->browse(function (Browser $browser) {
+        $browser->visit('/login')
+            ->assertSee('Login')
+            ->click('a.sysadmin-login')
+            ->type('email', $this->user->email)
+            ->type('password', 'password123') // Use the known password
+            ->press('#admin-login button[type="submit"]')
+            ->waitForLocation('/')
+            ->assertPathIs('/')
+            ->waitForText('Statistics')
+            ->assertSee('Statistics');    
+   
         $browser->visit('/')
-                ->assertSee('Log in as a System Administrator');
+            ->click('li.user-menu button')
+            ->waitForText('Log Out') 
+            ->clicklink('Log Out')
+            ->waitForLocation('/login')
+            ->assertPathIs('/login')
+            ->waitForText('Login')
+            ->assertSee('Login');
+     
+
+    });
+});
+
+
+
+it('allows a user to log in successfully', function () {
+    $this->browse(function (Browser $browser) {
+        $browser->visit('/login')
+            ->assertSee('Login')
+            ->click('a.sysadmin-login')
+            ->type('email', $this->user->email)
+            ->type('password', 'password123') // Use the known password
+            ->press('#admin-login button[type="submit"]')
+            ->waitForLocation('/')
+            ->assertPathIs('/')
+            ->waitForText('Statistics')
+            ->assertSee('Statistics');
+            
+        $browser->visit('/')
+            ->click('li.user-menu button')
+            ->waitForText('Log Out') 
+            ->clicklink('Log Out')
+            ->waitForLocation('/login')
+            ->assertPathIs('/login')
+            ->waitForText('Login')
+            ->assertSee('Login');
+    
     });
 });

--- a/tests/Browser/OrganizationTest.php
+++ b/tests/Browser/OrganizationTest.php
@@ -1,0 +1,469 @@
+<?php
+
+
+use Carbon\Carbon;
+use App\Models\User;
+use App\Models\Setting;
+use Tests\DuskTestCase;
+use Laravel\Dusk\Browser;
+use Faker\Factory as Faker;
+use Illuminate\Support\Str;
+
+
+use App\Models\BusinessUnit;
+use App\Models\CampaignYear;
+
+use App\Models\Organization;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\Models\Permission;
+use Illuminate\Foundation\Testing\DatabaseTruncation;
+
+
+// uses(Tests\DuskTestCase::class);
+// uses(Tests\DuskTestCase::class)->in('Unit', 'Feature');
+
+
+// uses(DatabaseTruncation::class);
+
+// test('example', function () {
+//     $this->browse(function (Browser $browser) {
+//         $browser->visit('/')
+//                 ->assertSee('Log in as a System Administrator');
+//     });
+// });
+
+
+
+beforeAll(function () {
+
+    // artisan('db:seed');
+    // artisan::call('db:seed', ['--class' => 'UserTableSeeder']);
+
+
+    // // Truncate tables and seed required data
+ 
+
+    // // Create a shared test user
+    // $this->user = User::Factory()->create([
+    //     'password' => bcrypt('password123'),
+    //     'source_type' => 'LCL',
+    // ]);
+
+    // $this->user->assignRole('admin');
+
+});
+
+
+beforeEach(function () {
+  
+    // Truncate the database and create a fresh user before each test
+    Setting::truncate();
+    CampaignYear::truncate();
+    BusinessUnit::truncate();
+    Organization::truncate();
+      
+    $this->admin = User::whereHas("roles", function ($q) {$q->where("name", "admin");})->first();
+    $this->user  = User::doesntHave('roles')->orderBy('id')->first();
+
+    $this->setting = Setting::create([
+        ]);
+
+    $this->campaign_year = CampaignYear::create([
+            'calendar_year' => today()->year + 1,
+            'status' => 'A',
+            'start_date' => today(),
+            'end_date' => today()->year . '-12-31',
+            'number_of_periods' => 26,
+            'close_date' => today()->year . '-12-31',
+        ]);
+
+});
+
+afterEach(function () {
+    // Cleanup admin user
+    // $this->admin->delete();
+    
+    // Refresh the browser after each test
+    session()->flush();
+});
+
+
+
+it('redirects anonymous user to the login page', function () {
+    $this->browse(function (Browser $browser) {
+
+        $browser->visit('/settings/organizations') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+
+        $browser->visit('/settings/organizations/create') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+
+        $response = $this->post('/settings/organizations', []);
+        $response->assertStatus(302);
+        $response->assertRedirect('login');
+
+        $browser->visit('/settings/organizations/1') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+        
+        $browser->visit('/settings/organizations/1/edit') 
+            ->waitForLocation('/login')
+            ->assertPathIs('/login') // Assert it redirects to login
+            ->assertSee('Login'); // Assert login prompt is visible
+        
+        $response = $this->put('/settings/organizations/1', []);
+        $response->assertStatus(302);
+        $response->assertRedirect('login');
+
+        $response = $this->delete('/settings/organizations/1');
+        $response->assertStatus(302);
+        $response->assertRedirect('login');
+            
+    });
+});
+
+
+it('denies access to protected organizations maintenance routes for unauthorized user', function () {
+    $this->browse(function (Browser $browser) {
+
+        $browser->loginAs($this->user)
+            ->visit('/settings/organizations') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+
+        $browser->loginAs($this->user)
+            ->visit('/settings/organizations/create') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+
+        $browser->loginAs($this->user)
+            ->visit('/settings/organizations/1') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+        
+        $browser->loginAs($this->user)
+            ->visit('/settings/organizations/1/edit') 
+            ->assertSee('USER DOES NOT HAVE THE RIGHT PERMISSIONS.')
+            ->assertSee('403'); 
+            
+    });
+});
+
+it('validateion error on create', function () {
+
+        $faker = Faker::create();
+
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->admin)
+                ->visit('/settings/organizations')
+                ->press('[data-target="#organization-create-modal"]')
+                ->waitForText('Add a new organization')
+                ->assertSee('Add a new organization')
+                ->press('#create-confirm-btn')
+                ->acceptDialog()
+
+                ->waitFor('#organization-create-model-form span.text-danger')
+                ->assertSee('The code field is required.')
+                ->assertSee('The name field is required.') 
+                ->assertSee('The effective date field is required.')
+                ->assertSee('The business unit field is required.')
+                ->logout('admin')
+               ;
+        });
+
+        $this->browse(function (Browser $browser) use($faker) {
+            $browser->loginAs($this->admin)
+                ->visit('/settings/organizations')
+                ->press('[data-target="#organization-create-modal"]')
+                ->waitForText('Add a new organization')
+                ->assertSee('Add a new organization')
+                ->pause(1000)
+
+                ->type('#organization-create-model-form [name="code"]', Str::random(8)  )
+                ->type('#organization-create-model-form [name="name"]', Str::random(80) )
+                ->select('#organization-create-model-form [name="status"]', 'A' )
+                ->type('#organization-create-model-form [name="effdt"]', Carbon::tomorrow()->format('m-d-Y') )
+                ->select('#organization-create-model-form [name="bu_code"]', '' )
+                ->press('#create-confirm-btn')
+                ->acceptDialog()
+              
+                ->waitFor('#organization-create-model-form span.text-danger')
+                ->assertSee('The code format is invalid, max 3 characters long and all uppercase, no space.')
+                ->assertSee('The name must not be greater than 50 characters.') 
+                // ->assertSee('The effective date field must be in the past if the status is Active')
+                ->assertSee('The business unit field is required.')
+             
+                // ->assertSee('The effective date field must be in the past if the status is Active')
+                // ->assertSee('The linked bu code field is required.')
+                ->logout('admin')
+               ;
+        });
+
+});
+
+
+it('Government Org validation error on edit', function () {
+
+    $faker = Faker::create();
+
+    $yesterday = Carbon::yesterday(); 
+
+    $item = Organization::factory()->create([
+        'code' => 'GOV',
+        'effdt' => $yesterday->format('Y-m-d'),
+    ]);
+
+    $this->browse(function (Browser $browser) use ($item, $faker) {
+      
+        $browser->loginAs($this->admin)
+            ->visit('/settings/organizations')
+            ->waitForText('Showing 1 to ')
+            ->click('a.edit-organization[data-id="'. $item->id .'"]')
+
+            ->waitForText( 'Edit an existing organization' )
+            ->assertSee('Edit an existing organization')
+            // ->pause(1000)
+            ->type('#organization-edit-model-form [name="name"]', ' ' )
+            ->type('#organization-edit-model-form [name="effdt"]', ' ' )
+            ->press('#save-confirm-btn')
+            ->acceptDialog()
+            ->waitFor('#organization-edit-model-form span.text-danger')
+
+            ->assertSee('The name field is required.') 
+            ->assertSee('The effective date field is required.')
+
+            ->logout('admin')
+        ;
+    });
+});
+
+it('Non-GOV organization validation error on edit', function () {
+
+    $faker = Faker::create();
+
+    $yesterday = Carbon::yesterday(); 
+
+    $bu = BusinessUnit::factory()->create();
+
+    $item = Organization::factory()->create([
+        
+        'effdt' => $yesterday->format('Y-m-d'),
+        'bu_code' => $bu->code,
+    ]);
+
+    $this->browse(function (Browser $browser) use ($item, $faker) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/organizations')
+            ->waitForText('Showing 1 to ')
+            ->click('a.edit-organization[data-id="'. $item->id .'"]')
+
+            ->waitForText( 'Edit an existing organization' )
+            ->assertSee('Edit an existing organization')
+            // ->pause(1000)
+            ->type('#organization-edit-model-form [name="name"]', ' ' )
+            ->type('#organization-edit-model-form [name="effdt"]', ' ' )
+            ->select('#organization-edit-model-form [name="bu_code"]', '' )
+            ->press('#save-confirm-btn')
+            ->acceptDialog()
+            ->waitFor('#organization-edit-model-form span.text-danger')
+
+            ->assertSee('The name field is required.') 
+            ->assertSee('The effective date field is required.')
+            ->assertSee('The business unit field is required.')
+
+            ->logout('admin')
+        ;
+    });
+
+});
+
+//
+
+
+
+it('pagination on organizations table via ajax call', function () {
+
+    $faker = Faker::create();
+
+    $bus = BusinessUnit::factory(25)->create();
+
+    Organization::factory(25)->create([
+        'bu_code' => $faker->randomElement(  $bus->pluck('code')->toArray() ),
+    ]);
+    
+    $sorted = Organization::orderBy('code')->get();
+
+    $this->browse(function (Browser $browser) use($sorted) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/organizations') // API endpoint
+            ->screenshot('debug-pagation-page') 
+
+            ->waitForText(  'Showing 1 to 10' )
+            ->assertSee( $sorted[0]->code ) 
+            ->assertSee( $sorted[0]->name ) 
+
+            ->click('a[data-dt-idx="2"]')
+            ->waitForText(  'Showing 11 to 20' )
+            ->assertSee( $sorted[10]->code ) 
+            ->assertSee( $sorted[10]->name ) 
+
+            ->logout('admin')
+            ;
+
+    });
+
+});
+
+
+
+  
+it('administrator creates a new organization', function () {
+
+    $yesterday = Carbon::yesterday(); 
+
+    $bu = BusinessUnit::factory()->create();
+
+    $item = Organization::factory()->make([
+        'effdt' => $yesterday->format('Y-m-d'),
+        'bu_code' => $bu->code,
+    ]);
+
+    $this->browse(function (Browser $browser) use($item, $yesterday) {
+        // $browser->visit('/login')
+
+        //     ->assertSee('Login')
+        //     ->click('a.sysadmin-login')
+        //     ->type('email', $this->user->email)
+        //     ->type('password', env('SYNC_ADMIN_PROFILE_SECRET') ) // Use the known password
+        //     ->press('#admin-login button[type="submit"]')
+        //     ->waitForLocation('/')
+        //     ->assertPathIs('/')
+        //     ->waitForText('Statistics')
+        //     ->assertSee('Statistics');
+    
+        $browser->loginAs($this->admin)
+            ->visit('/settings/organizations')
+            ->press('[data-target="#organization-create-modal"]')
+            // ->waitForText('Add a new organization')
+            ->waitForText('Add a new organization')
+            ->assertSee('Add a new organization')
+            ->pause(1000)
+            ->type('#organization-create-model-form [name="code"]', $item->code)
+            ->type('#organization-create-model-form [name="name"]', $item->name)
+            ->type('#organization-create-model-form [name="effdt"]', $yesterday->format('mdY'))
+            ->select('#organization-create-model-form [name="status"]', $item->status)
+            ->select('#organization-create-model-form [name="bu_code"]', $item->business_unit->code)
+           
+            ->press('#create-confirm-btn')
+            ->acceptDialog()
+            ->waitForText('Organization code ' . $item->code . ' has been successfully created.')
+            ->assertSee('Organization code ' . $item->code . ' has been successfully created.')
+            ->logout('admin');
+            ;
+
+        // Verify the same data in the database
+        $this->assertDatabaseHas('organizations', Arr::except( $item->attributesToArray(), ['created_by_id', 'updated_by_id']) );
+            
+    });
+});
+
+
+it('show a organization', function () {
+
+    $yesterday = Carbon::yesterday(); 
+
+    $bu = BusinessUnit::factory()->create();
+
+    $item = Organization::factory()->create([
+        'effdt' => $yesterday->format('Y-m-d'),
+        'bu_code' => $bu->code,
+    ]);
+
+    $this->browse(function (Browser $browser) use ($item, $yesterday) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/organizations')
+            ->waitForText('Showing 1 to ')
+            ->click('a.show-organization[data-id="'. $item->id .'"]')
+            
+            ->waitForText( 'Existing organization details' )
+            ->assertSee('Existing organization details')
+            ->assertSee( $item->code )
+            ->assertSee( $item->name )
+            ->assertSee($yesterday->format('Y-m-d'))
+            ->logout('admin');
+            ;
+          
+    });
+});
+
+
+it('update an organization', function () {
+
+    $faker = Faker::create();
+
+    $yesterday = Carbon::yesterday(); 
+
+    $bu = BusinessUnit::factory()->create();
+
+    $item = Organization::factory()->create([
+        'effdt' => $yesterday->format('Y-m-d'),
+        'bu_code' => $bu->code,
+    ]);
+
+    $item->name = $faker->words(3, true);
+
+    $this->browse(function (Browser $browser) use ($item) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/organizations')
+            ->waitForText('Showing 1 to ')
+            ->click('a.edit-organization[data-id="'. $item->id .'"]')
+            
+            ->waitForText( 'Edit an existing organization' )
+            ->assertSee('Edit an existing organization')
+            ->type('#organization-edit-modal [name="name"]', $item->name)
+            ->press('#save-confirm-btn')
+            ->acceptDialog()
+            // ->waitForLocation('/settings/organizations')
+            ->waitForText('Organization code ' . $item->code . ' has been successfully updated.')
+            ->assertSee('Organization code ' . $item->code . ' has been successfully updated.')
+            ->logout('admin');
+            ;
+
+        // Verify the same data in the database
+        $this->assertDatabaseHas('organizations', Arr::except( $item->attributesToArray(), 
+                    ['updated_by_id', 'created_at', 'updated_at']) );
+          
+    });
+});
+    
+it('deletes a organization', function () {
+
+    $item = Organization::factory()->create([]);
+
+    $this->browse(function (Browser $browser) use ($item) {
+        $browser->loginAs($this->admin)
+            ->visit('/settings/organizations')
+            ->waitForText('Showing 1 to ')
+            ->click('a.delete-organization[data-id="'. $item->id .'"]')
+            // ->pause(10000)
+            ->waitForText( 'Are you sure you want to delete organization code "' . $item->code  . '" ?' )
+            ->press('button.swal2-confirm')
+            // ->press('button.swal2-cancel')
+            ->waitForLocation('/settings/organizations')
+            ->waitForText('Organization code ' . $item->code . ' has been successfully deleted.')
+            ->waitForText('No data available in table')
+            ->assertDontSee( $item->name )
+            ->logout('admin');
+            ;
+
+        $this->assertSoftDeleted('organizations',  Arr::except( $item->attributesToArray(), 
+                    ['created_by_id', 'updated_by_id', 'created_at', 'updated_at']) );
+        
+    });
+});
+


### PR DESCRIPTION
**Upgrade Project -- Laravel from 10 to 11 and PHP from 8.1 to 8.3**

Laravel 11, released on March 12, 2024, brings a multitude of enhancements aimed at making web development more efficient and secure. Here’s a quick rundown of what you need to know:


- Release and Support: Regular updates till August 2024 and security patches until February 2025.

- Why Upgrade?:

- Faster performance due to improved routing and caching.

- Enhanced security features.

- New [developer tools](https://daily.dev/blog/firefox-enhancements-for-developers) and simplified upgrade process.

- Full compatibility with [PHP 8.2](https://daily.dev/blog/php-trends-for-2024).

- New Features:

- Simplified project structure with fewer preset directories.

- Configuration and settings streamlined into .env files.

- Enhanced data handling and middleware management.

- Improved scheduling and bug fixing tools.

- Optimizations for route organization and model relations.

- Advanced rate limiting and a new health check endpoint.


Upgrading to Laravel 11 not only streamlines your development process but also leverages the latest PHP features, ensuring your projects are fast, secure, and up-to-date.


**Why Upgrade to Laravel 11?**


Upgrading to Laravel 11 is a smart move for a few reasons:


- Faster Performance - Your apps will run faster because of improvements in how routes are handled, how queries are made, and how data is cached.

- Better Security - Laravel 11 includes new security features and fixes that help keep your app and its data safe.

- New Tools for Developers - There are better tools for debugging, new commands for Artisan (Laravel's command-line tool), and updated documentation to help you work more efficiently.

- Easy to Upgrade - Moving from Laravel 10 to 11 is straightforward because the new version is designed to work well with the older one.


By updating to Laravel 11, you can take advantage of the latest PHP 8.2 features, easier setup, and better testing tools. This means you can make stronger and safer apps more quickly.

DEC 9 -- Resolve Laravel 11 with symfony/mailer v7.2.0 issue 
https://github.com/laravel/framework/issues/53721

DEC 12 -- installed PEST and DUSK

DEC 13 -- UPDATE package league/commonmark

Jan 21 -- UPDATE package phpoffice/phpspreadsheet)

Feb 4 - Add Dusk test cases 

[Ticket ](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/EBq9aa_H1kiQA5C93KE-ymUAE6tv?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)
