### PR TITLE
(MASTER) [jp-0214] Volunteering - Learn tile Improvement 

### DIFF
--- a/resources/views/volunteering/partials/learn-more-modal.blade.php
+++ b/resources/views/volunteering/partials/learn-more-modal.blade.php
@@ -339,7 +339,7 @@
                             @if ( \App\Models\CampaignYear::isVolunteerRegistrationOpenNow() )
                                 <x-button :href="route('volunteering.profile.create')" role="button" class="ready-btn d-none">I'm ready to volunteer!</x-button>
                             @else
-                                <x-button :href="route('volunteering.index')" role="button" class="ready-btn d-none">I'm ready to volunteer!</x-button>
+                                <x-button :href="route('volunteering.index')" role="button" class="ready-btn d-none">Close</x-button>
                             @endif
                         </div>
                     </div>


### PR DESCRIPTION
At the end of the "Learn" tile in the volunteering section of the application on slide 8. The text in the bottom right corner of the slide "I'm ready to volunteer!" when selected it goes back to the home page. During registration (June to September) this would take you to the register or renew function on the home page. Outside of registration, it should have a static message and refer volunteers to PECSF. If not that then "hide" the button.

Action
Update label on the button

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/M-rMRBHNckqtUGHwOlADW2UAJLm-?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)