### PR TITLE
jp-0217 Fix error Resolving packages.sury.org (packages.sury.org)…failed: Temporary failure in name resolution.(comment the line in docker file)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,7 @@ RUN apt-get install -y \
     && docker-php-ext-install zip
 
 RUN apt-get install -y apt-transport-https lsb-release ca-certificates 
-# RUN wget -O --no-check-certificate /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+# RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 
 RUN apt-get update && apt-get install -y \
         libfreetype6-dev \


### PR DESCRIPTION
Issue

Error when deployment package on Production region

[2/2] STEP 9/33: RUN wget -O --no-check-certificate /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
/etc/apt/trusted.gpg.d/php.gpg: Scheme missing.
--2025-02-08 23:44:29--  https://packages.sury.org/php/apt.gpg
Resolving packages.sury.org (packages.sury.org)... failed: Temporary failure in name resolution.
wget: unable to resolve host address 'packages.sury.org'
error: build error: building at STEP "RUN wget -O --no-check-certificate /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg": while running runtime: exit status 4
Action

To add a flag --no-check-certificate on wget command to resolve

--2025-02-08 23:15:08-- https://packages.sury.org/php/apt.gpg
Resolving packages.sury.org (packages.sury.org)... failed: Temporary failure in name resolution.
wget: unable to resolve host address 'packages.sury.org'
error: build error: building at STEP "RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg": while running runtime: exit status 4

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/HgEhvykm6kOvcmlklZ13EWUAKv2G?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)