### PR TITLE
[jp-0219] Volunteer Profile -- Incorrect figure on Years of BC Government Service

### DIFF
--- a/app/Models/EmployeeJob.php
+++ b/app/Models/EmployeeJob.php
@@ -135,9 +135,11 @@ class EmployeeJob extends Model
         $years_of_service = null;
 
         if ($this->hire_dt) {
-            $years_of_service = today()->diffInYears($this->hire_dt);
-        }
+            // $years_of_service = today()->diffInYears($this->hire_dt);
+            $diff = today()->diff($this->hire_dt);
+            $years_of_service =  $diff->y + round(($diff->m / 12),1);
 
+        } 
         return $years_of_service;
 
     }


### PR DESCRIPTION
Issue: Incorrect figure on Years of BC Government Service under Volunteer Profile Page

For example: Employee A on Volunteer Profile page

        -18.712328767123

        Year of BC Government Service

[ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/plCCgcTSRk2RHFdy-8WAZGUAHVUa?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)