### PR TITLE
(TEST) [jp-0222] Keycloak 26 upgrade -- legacy redirect_url parameter is no longer supported

### DIFF
--- a/app/Http/Controllers/Auth/KeycloakLoginController.php
+++ b/app/Http/Controllers/Auth/KeycloakLoginController.php
@@ -50,7 +50,8 @@ class KeycloakLoginController extends Controller
     
                     Log::error("User tried to login during system maintenance in progress : {$idir} - {$guid} - {$email} - {$name}");
 
-                    $back = urlencode(url('/login'));
+                    // $back = urlencode(url('/login'));
+                    $back = url('/login');
                     $back_url = env('KEYCLOAK_BASE_URL').'/realms/'.env('KEYCLOAK_REALM').'/protocol/openid-connect/logout?post_logout_redirect_uri='.$back; // Redirect to Keycloak
                     return redirect($back_url);
                 }
@@ -142,7 +143,8 @@ class KeycloakLoginController extends Controller
         if (empty(session('accessToken'))) {
             $back_url = ('/login');
         } else {
-            $back = urlencode(url('/login'));
+            // $back = urlencode(url('/login'));
+            $back = url('/login');
             $back_url = env('KEYCLOAK_BASE_URL').'/realms/'.env('KEYCLOAK_REALM').'/protocol/openid-connect/logout?post_logout_redirect_uri='.$back; // Redirect to Keycloak
         }
 


### PR DESCRIPTION
March 18 - Support for legacy redirect_url parameter is removed

In earlier versions of Keycloak, you might have seen the use of the redirect_url parameter (or sometimes redirect_uri) passed in different places in the authentication flow. However, with newer versions of Keycloak and improvements to the OpenID Connect (OIDC) specification, Keycloak has tightened the handling of these parameters.

The key change is that legacy support for redirect_url (sometimes used as an alternate name for redirect_uri) has been removed in favor of a more standardized, secure approach to handling redirects during authentication and logout processes.

Action Required
Per SSO team suggestion, we have to update to use post_logout_redirect_uri values to the Redirect URIs area.

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/WtvZ4kfyWU2wfXNOivvahWUACXp-?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)