### PR TITLE
(TEST) [jp-0222] Keycloak 26 upgrade -- legacy redirect_url parameter is no longer supported (solve invalid redirect uri issue)

### DIFF
--- a/app/Http/Controllers/Auth/KeycloakLoginController.php
+++ b/app/Http/Controllers/Auth/KeycloakLoginController.php
@@ -9,7 +9,6 @@ use App\Models\Setting;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Config;
 use Laravel\Socialite\Facades\Socialite;
 
 class KeycloakLoginController extends Controller
@@ -56,7 +55,7 @@ class KeycloakLoginController extends Controller
                     // return redirect($back_url);
 
                     // The URL the user is redirected to after logout.
-                    $redirectUri = Config::get('app.url');
+                    $redirectUri = url('/login');
 
                     // Keycloak v18+ does support a post_logout_redirect_uri in combination with a
                     // client_id or an id_token_hint parameter or both of them.
@@ -156,7 +155,7 @@ class KeycloakLoginController extends Controller
             // $back_url = env('KEYCLOAK_BASE_URL').'/realms/'.env('KEYCLOAK_REALM').'/protocol/openid-connect/logout?redirect_url='.$back; // Redirect to Keycloak
             
             // The URL the user is redirected to after logout.
-            $redirectUri = Config::get('app.url');
+            $redirectUri = url('/login');
 
             // Keycloak v18+ does support a post_logout_redirect_uri in combination with a
             // client_id or an id_token_hint parameter or both of them.


### PR DESCRIPTION
March 18 - Support for legacy redirect_url parameter is removed

In earlier versions of Keycloak, you might have seen the use of the redirect_url parameter (or sometimes redirect_uri) passed in different places in the authentication flow. However, with newer versions of Keycloak and improvements to the OpenID Connect (OIDC) specification, Keycloak has tightened the handling of these parameters.

The key change is that legacy support for redirect_url (sometimes used as an alternate name for redirect_uri) has been removed in favor of a more standardized, secure approach to handling redirects during authentication and logout processes.

Action Required
Per SSO team suggestion, we have to update to use post_logout_redirect_uri values to the Redirect URIs area.

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/WtvZ4kfyWU2wfXNOivvahWUACXp-?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)