### PR TITLE
(TEST) [jp-0223] Logging failed login attempts

### DIFF
--- a/app/Listeners/LogFailedLogin.php
+++ b/app/Listeners/LogFailedLogin.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Auth\Events\Failed;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+
+class LogFailedLogin
+{
+    /**
+     * Create the event listener.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     */
+    public function handle(Failed $event): void
+    {
+        // Log the failed login attempt
+        Log::error('Failed login attempt for user: ' . $event->credentials['email']);
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -23,6 +23,9 @@ class EventServiceProvider extends ServiceProvider
             // 'SocialiteProviders\\Azure\\AzureExtendSocialite@handle',
             \SocialiteProviders\Keycloak\KeycloakExtendSocialite::class.'@handle',
         ],
+        \Illuminate\Auth\Events\Failed::class => [
+            \App\Listeners\LogFailedLogin::class,
+        ],
     ];
 
     /**


### PR DESCRIPTION
Enhancement
Logging failed login attempts helps enhance security by detecting potential brute force attacks and unauthorized access attempts, while also improving troubleshooting, user support, and compliance with security standards. It provides an audit trail for monitoring suspicious activity and helps refine security measures like rate limiting and account lockouts.

Action Required
In Laravel 11, to log a message when a user fails to log in, you can make use of the built-in authentication events and logging capabilities.

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/qLQvnrn-AESkXa02kIJ4-2UAIYg8?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)