### PR TITLE
(TEST) [jp-0221] Donor and Volunteer Analytics

### DIFF
--- a/app/Http/Controllers/System/UserActivityController.php
+++ b/app/Http/Controllers/System/UserActivityController.php
@@ -8,7 +8,7 @@ use Carbon\CarbonPeriod;
 use Illuminate\Http\Request;
 use App\Models\BankDepositForm;
 use App\Models\DonateNowPledge;
-use App\Models\visitsMonitoring;
+use App\Models\VisitsMonitoring;
 use App\Models\VolunteerProfile;
 use App\Http\Controllers\Controller;
 use App\Models\SpecialCampaignPledge;
@@ -24,7 +24,8 @@ class UserActivityController extends Controller
      */
     function __construct()
     {
-         $this->middleware('permission:setting');
+        //  $this->middleware('permission:setting');
+        $this->middleware('permission:security_setting');       // temporaily disabled
     }
 
     /**

--- a/resources/views/system-security/user-activity/transaction_timings.blade.php
+++ b/resources/views/system-security/user-activity/transaction_timings.blade.php
@@ -141,9 +141,9 @@
                 // data: ['Create', 'Update', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'],
                 selected: {
                     // selected'series 1'
-                    'create': {{ $y_axis_data[0] == 'create' ? 'true' : 'false '}},
+                    'create': {{ $y_axis_data ? ($y_axis_data[0] == 'create' ? 'true' : 'false') : 'false' }},
                     // unselected'series 2'
-                    'update': {{ $y_axis_data[0] == 'update' ? 'true' : 'false '}},
+                    'update': {{ $y_axis_data ? ($y_axis_data[0] == 'update' ? 'true' : 'false') : 'false' }},
                 },
             },
             dataZoom: @json($data_zoom),


### PR DESCRIPTION
Need to create an area in the administrative side of the PECSF application to view donor and volunteer analytics.

For example:
How many users access the application?
How many users set up a pledge?
How long did it take to set up a donation?
How many users visit the volunteering section?
What is the traffic on each volunteering page?

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/YduahGL_R02M1OR4rYu4E2UAOwGI?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)