### PR TITLE
[jp-0225] Running Laravel schedule:run Across Multiple Pods Using the Native onOneServer() Method 

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -272,6 +272,18 @@ class Kernel extends ConsoleKernel
                 ->appendOutputTo(storage_path('logs/daily.log'))
                 ->onOneServer(); 
 
+                
+        // $schedule->call(function () {
+        //         $text = 'Running a task ' . PHP_EOL;
+        //         echo  $text ;
+        // })->name('TEST schedule task')
+        $schedule->exec("echo Schedule Task Test, run every 5 mins - " . now() . PHP_EOL )
+          ->name('TEST schedule task')
+          ->appendOutputTo(storage_path('logs/test.log'))
+          ->everyTwoMinutes()
+          ->onOneServer(); 
+          
+
     }
 
     /**


### PR DESCRIPTION
To replace OpenShift cronjob by using Laravel Task Scheduling for running schedule on servers.

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/DxHPN5m3bEyKbN4SDMhG2GUALFgk?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)