### PR TITLE
(TEST) [jp-0225] Running Laravel schedule:run Across Multiple Pods Using the Native onOneServer() Method

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,8 +103,10 @@ COPY --chown=www-data:www-data server_files/mods-enabled/expires.load /etc/apach
 COPY --chown=www-data:www-data server_files/mods-enabled/headers.load /etc/apache2/mods-enabled/headers.load
 COPY --chown=www-data:www-data server_files/mods-enabled/rewrite.load /etc/apache2/mods-enabled/rewrite.load
 COPY --chown=www-data:www-data server_files/start.sh /usr/local/bin/start
+COPY --chown=www-data:www-data server_files/laravel-schedule.sh /usr/local/bin/laravel-schedule.sh
 
 RUN chmod +x /usr/local/bin/start
+RUN chmod +x /usr/local/bin/laravel-schedule.sh
 RUN chmod +x /var/www/html/entrypoint.sh
 
 # Create cache and session storage structure

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -44,48 +44,65 @@ class Kernel extends ConsoleKernel
         { 
 
                 $schedule->command('command:ExportPledgesToPSFT')
-                        ->dailyAt('00:50')->environments(['prod'])->sendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
+                        ->name('ExportPledgesToPSFT:1')
+                        ->dailyAt('00:50')->environments(['prod'])->sendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer();
 
                 // Note: The export processes are only execute in TEST and Production (1000 per hour limiation on ODS)                 
                 $schedule->command('command:ExportPledgesToPSFT')
                          ->when(function () {
                              return Pledge::hasDataToSend();
                          })
-                        ->dailyAt('01:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
+                         ->name('ExportPledgesToPSFT:2')
+                        ->dailyAt('01:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer();
                 $schedule->command('command:ExportPledgesToPSFT')
                         ->when(function () {
                                 return Pledge::hasDataToSend();
                         })
-                        ->dailyAt('02:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
+                        ->name('ExportPledgesToPSFT:3')
+                        ->dailyAt('02:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer();
                 $schedule->command('command:ExportPledgesToPSFT')
                         ->when(function () {
                                 return Pledge::hasDataToSend();
                         })
-                        ->dailyAt('03:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
+                        ->name('ExportPledgesToPSFT:4')
+                        ->dailyAt('03:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer();
                 $schedule->command('command:ExportPledgesToPSFT')
                         ->when(function () {
                                 return Pledge::hasDataToSend();
                         })
-                        ->dailyAt('04:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
+                        ->name('ExportPledgesToPSFT:5')
+                        ->dailyAt('04:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer();
                 $schedule->command('command:ExportPledgesToPSFT')
                         ->when(function () {
                                 return Pledge::hasDataToSend();
                         })
-                        ->dailyAt('05:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
+                        ->name('ExportPledgesToPSFT:6')
+                        ->dailyAt('05:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer();
                 $schedule->command('command:ExportPledgesToPSFT')
                         ->when(function () {
                                 return Pledge::hasDataToSend();
                         })
-                        ->dailyAt('06:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));                        
+                        ->name('ExportPledgesToPSFT:7')
+                        ->dailyAt('06:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer();                        
                 $schedule->command('command:ExportPledgesToPSFT')
                         ->when(function () {
                               return Pledge::hasDataToSend();
                         })
-                        ->dailyAt('7:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));                                                
+                        ->name('ExportPledgesToPSFT:8')
+                        ->dailyAt('7:50')->environments(['prod'])->appendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer(); 
 
                 // Non-Production (TEST region)
                 $schedule->command('command:ExportPledgesToPSFT')
-                        ->dailyAt('08:00')->environments(['TEST'])->sendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'));
+                        ->dailyAt('08:00')->environments(['TEST'])->sendOutputTo(storage_path('logs/ExportPledgesToPSFT.log'))
+                        ->onOneServer(); 
 
 
         }
@@ -97,14 +114,16 @@ class Kernel extends ConsoleKernel
                         ->weekdays()
                         ->at('1:15')
                         ->environments(['prod'])
-                        ->sendOutputTo(storage_path('logs/ExportDatabaseToBI.log'));
+                        ->sendOutputTo(storage_path('logs/ExportDatabaseToBI.log'))
+                        ->onOneServer();
 
                 // Non-Production - TEST region
                 $schedule->command('command:ExportDatabaseToBI')
                         ->weekdays()
                         ->at('8:05')
                         ->environments(['TEST'])
-                        ->sendOutputTo(storage_path('logs/ExportDatabaseToBI.log'));                        
+                        ->sendOutputTo(storage_path('logs/ExportDatabaseToBI.log'))
+                        ->onOneServer();                        
 
         }
 
@@ -121,7 +140,8 @@ class Kernel extends ConsoleKernel
                                 ->mondays()
                                 ->at('2:00')
                                 //  ->everyFifteenMinutes()
-                                ->sendOutputTo(storage_path('logs/ImportPayCalendar.log'));
+                                ->sendOutputTo(storage_path('logs/ImportPayCalendar.log'))
+                                ->onOneServer(); 
                 } else {        
                         // Non-Production -- Foundation table                        
                         $schedule->command('command:ImportPayCalendar')
@@ -129,7 +149,8 @@ class Kernel extends ConsoleKernel
                                 ->mondays()
                                 ->at('8:15')
                                 //  ->everyFifteenMinutes()
-                                ->sendOutputTo(storage_path('logs/ImportPayCalendar.log'));
+                                ->sendOutputTo(storage_path('logs/ImportPayCalendar.log'))
+                                ->onOneServer(); 
                 }
 
                 // Pledge History Data (refresh the current year +2 when Jan-Mar OR +1 when Apr - Dec
@@ -151,7 +172,8 @@ class Kernel extends ConsoleKernel
                                         // })
                                         ->weekdays()
                                         ->at('2:30')
-                                        ->sendOutputTo(storage_path('logs/ImportCities.log')); 
+                                        ->sendOutputTo(storage_path('logs/ImportCities.log'))
+                                        ->onOneServer();  
 
                                 // Production - Department
                                 $schedule->command('command:ImportDepartments')
@@ -160,7 +182,8 @@ class Kernel extends ConsoleKernel
                                         // })
                                         ->weekdays()
                                         ->at('2:45')
-                                        ->sendOutputTo(storage_path('logs/ImportDepartments.log'));
+                                        ->sendOutputTo(storage_path('logs/ImportDepartments.log'))
+                                        ->onOneServer(); 
                         } else {
 
                                 // Non-Production - Cities 
@@ -170,7 +193,8 @@ class Kernel extends ConsoleKernel
                                         // })
                                         ->weekdays()
                                         ->at('8:30')
-                                        ->sendOutputTo(storage_path('logs/ImportCities.log'));                         
+                                        ->sendOutputTo(storage_path('logs/ImportCities.log'))
+                                        ->onOneServer(); 
 
                                 // Non-Production - Departments
                                 $schedule->command('command:ImportDepartments')
@@ -179,7 +203,8 @@ class Kernel extends ConsoleKernel
                                         // })
                                         ->weekdays()
                                         ->at('8:45')
-                                        ->sendOutputTo(storage_path('logs/ImportDepartments.log'));
+                                        ->sendOutputTo(storage_path('logs/ImportDepartments.log'))
+                                        ->onOneServer();
                         }
                 }
 
@@ -194,23 +219,27 @@ class Kernel extends ConsoleKernel
                         $schedule->command('command:ImportEmployeeJob')
                                 ->weekdays()
                                 ->at('4:05')
-                                ->sendOutputTo(storage_path('logs/ImportEmployeeJob.log'));
+                                ->sendOutputTo(storage_path('logs/ImportEmployeeJob.log'))
+                                ->onOneServer(); 
 
                         $schedule->command('command:SyncUserProfile')
                                 ->weekdays()
                                 ->at('4:30')
-                                ->sendOutputTo(storage_path('logs/SyncUserProfile.log'));
+                                ->sendOutputTo(storage_path('logs/SyncUserProfile.log'))
+                                ->onOneServer(); 
                 } else {
                         // Non-Production -- Demography data and user profiles                        
                         $schedule->command('command:ImportEmployeeJob')
                                 ->weekdays()
                                 ->at('9:00')
-                                ->sendOutputTo(storage_path('logs/ImportEmployeeJob.log'));
+                                ->sendOutputTo(storage_path('logs/ImportEmployeeJob.log'))
+                                ->onOneServer(); 
 
                         $schedule->command('command:SyncUserProfile')
                                 ->weekdays()
                                 ->at('9:15')
-                                ->sendOutputTo(storage_path('logs/SyncUserProfile.log'));                        
+                                ->sendOutputTo(storage_path('logs/SyncUserProfile.log'))
+                                ->onOneServer();   
                 }
 
         }
@@ -218,15 +247,18 @@ class Kernel extends ConsoleKernel
         // Snapshot of eligible employees 
         $schedule->command('command:UpdateEligibleEmployeeSnapshot')
                 ->dailyAt('4:45')
-                ->appendOutputTo(storage_path('logs/UpdateEligibleEmployeeSnapshot.log'));
+                ->appendOutputTo(storage_path('logs/UpdateEligibleEmployeeSnapshot.log'))
+                ->onOneServer(); 
 
         $schedule->command('command:UpdateDailyCampaign')
                 ->dailyAt('5:00')
-                ->appendOutputTo(storage_path('logs/UpdateDailyCampaign.log'));
+                ->appendOutputTo(storage_path('logs/UpdateDailyCampaign.log'))
+                ->onOneServer(); 
         
         $schedule->command('command:SystemCleanUp')
                 ->dailyAt('5:30')
-                ->appendOutputTo(storage_path('logs/SystemCleanUp.log'));
+                ->appendOutputTo(storage_path('logs/SystemCleanUp.log'))
+                ->onOneServer();
 
         // Monitoring Process Queue every 5 mins 
         // $schedule->command('command:queueStatus')
@@ -237,7 +269,8 @@ class Kernel extends ConsoleKernel
         // Daily Testing 
         $schedule->command('notify:daily')
                 ->dailyAt('08:30')
-                ->appendOutputTo(storage_path('logs/daily.log'));
+                ->appendOutputTo(storage_path('logs/daily.log'))
+                ->onOneServer(); 
 
     }
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -273,16 +273,12 @@ class Kernel extends ConsoleKernel
                 ->onOneServer(); 
 
                 
-        // $schedule->call(function () {
-        //         $text = 'Running a task ' . PHP_EOL;
-        //         echo  $text ;
-        // })->name('TEST schedule task')
-        $schedule->exec("echo Schedule Task Test, run every 5 mins - " . now() . PHP_EOL )
-          ->name('TEST schedule task')
-          ->appendOutputTo(storage_path('logs/test.log'))
+        // This is for testing purpose on lower resgions
+        $schedule->exec("echo Schedule Task Test only run on one server, run every 2 mins - " . now() . PHP_EOL )
+          ->name('Test onOneServer task')
+          ->environments(['local', 'dev','TEST'])
           ->everyTwoMinutes()
-          ->onOneServer(); 
-          
+          ->onOneServer();        
 
     }
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -272,6 +272,18 @@ class Kernel extends ConsoleKernel
                 ->appendOutputTo(storage_path('logs/daily.log'))
                 ->onOneServer(); 
 
+                
+        // $schedule->call(function () {
+        //         $text = 'Running a task ' . PHP_EOL;
+        //         echo  $text ;
+        // })->name('TEST schedule task')
+        $schedule->exec("echo Schedule Task Test, run every 5 mins - " . now() . PHP_EOL )
+          ->name('TEST schedule task')
+          ->appendOutputTo(storage_path('logs/test.log'))
+          ->everyTwoMinutes()
+          ->onOneServer(); 
+          
+
     }
 
     /**

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -274,10 +274,10 @@ class Kernel extends ConsoleKernel
 
                 
         // This is for testing purpose on lower resgions
-        $schedule->exec("echo Schedule Task Test only run on one server, run every 2 mins - " . now() . PHP_EOL )
+        $schedule->exec("echo Schedule Task to verify un on one server every 15 mins - " . now() . PHP_EOL )
           ->name('Test onOneServer task')
           ->environments(['local', 'dev','TEST'])
-          ->everyTwoMinutes()
+          ->everyFifteenMinutes()
           ->onOneServer();        
 
     }

--- a/database/migrations/2025_04_28_150431_create_cache_table.php
+++ b/database/migrations/2025_04_28_150431_create_cache_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cache', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->mediumText('value');
+            $table->integer('expiration');
+        });
+
+        Schema::create('cache_locks', function (Blueprint $table) {
+            $table->string('key')->primary();
+            $table->string('owner');
+            $table->integer('expiration');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cache');
+        Schema::dropIfExists('cache_locks');
+    }
+};

--- a/openshift/app/pecsf-dc.yml
+++ b/openshift/app/pecsf-dc.yml
@@ -98,7 +98,7 @@ objects:
               lifecycle:
                 postStart:
                   exec:
-                    command: ["/bin/sh", "-c", "php /var/www/html/artisan queue:work --tries=3 --timeout=0 --memory=512 >> /var/www/html/storage/logs/queue-work.log & "]
+                    command: ["/bin/sh", "-c", "php /var/www/html/artisan queue:work --tries=3 --timeout=0 --memory=512 >> /var/www/html/storage/logs/queue-work.log & /usr/local/bin/laravel-schedule.sh >> /var/www/html/storage/logs/laravel-schedule.log 2>&1 & "]
               imagePullPolicy: Always
               ports:
                 - containerPort: 8000

--- a/server_files/laravel-schedule.sh
+++ b/server_files/laravel-schedule.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+while [ true ]; do
+  php /var/www/html/artisan schedule:run
+  sleep 60
+done


### PR DESCRIPTION
**Issue**

Platform Services team


We've noticed that there are frequent cronjobs in your project set that run every 5 min and use a PVC. This is using a lot of resources from Trident (the storage service on OpenShift) to mount/unmount these volumes over and over. As a result, this is causing pods in the Silver cluster to take a while to start as they have to wait for Trident to finish a long queue of jobs before getting to them.



To sustain the normal functioning of Trident on Silver, we ask you to change the frequent cronjobs with PVC mounts to a deployment instead. This will not only benefit all the teams on the platform, but also help you to reduce the overhead resource consumption of frequent pod restarts in your namespace.



Following is the list of cronjobs that we highly recommend you switch to a deployment:

- Cronjob: 1fd77b-test/web-app-storage

- Cronjob: 1fd77b-prod/web-app-storage


You can find a step by step guidance on how to switch from Cronjob to deployment here: https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-automation/kyverno/#alternatives-to-cronjobs


**Action**
In order to reduce the overhead resource consumption of frequent pod restarts in your namespace, will try to run the scheduler on the multiple PODs and use the onOneServer method to ensure that the task should run on only one server. The first server to obtain the task will secure an atomic lock on the job to prevent other servers from running the same task at the same time.
https://laravel.com/docs/11.x/scheduling#running-tasks-on-one-server

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/DxHPN5m3bEyKbN4SDMhG2GUALFgk?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)

