### PR TITLE
(TEST) [jp-0225] Running Laravel schedule:run Across Multiple Pods Using the Native onOneServer() Method (adjust the schedule time)

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -120,7 +120,7 @@ class Kernel extends ConsoleKernel
                 // Non-Production - TEST region
                 $schedule->command('command:ExportDatabaseToBI')
                         ->weekdays()
-                        ->at('8:05')
+                        ->at('8:00')
                         ->environments(['TEST'])
                         ->sendOutputTo(storage_path('logs/ExportDatabaseToBI.log'))
                         ->onOneServer();                        
@@ -218,7 +218,7 @@ class Kernel extends ConsoleKernel
                         // Non-Production -- Demography data and user profiles                        
                         $schedule->command('command:ImportEmployeeJob')
                                 ->weekdays()
-                                ->at('4:05')
+                                ->at('4:00')
                                 ->sendOutputTo(storage_path('logs/ImportEmployeeJob.log'))
                                 ->onOneServer(); 
 


### PR DESCRIPTION
**Issue**

Platform Services team


We've noticed that there are frequent cronjobs in your project set that run every 5 min and use a PVC. This is using a lot of resources from Trident (the storage service on OpenShift) to mount/unmount these volumes over and over. As a result, this is causing pods in the Silver cluster to take a while to start as they have to wait for Trident to finish a long queue of jobs before getting to them.



To sustain the normal functioning of Trident on Silver, we ask you to change the frequent cronjobs with PVC mounts to a deployment instead. This will not only benefit all the teams on the platform, but also help you to reduce the overhead resource consumption of frequent pod restarts in your namespace.



Following is the list of cronjobs that we highly recommend you switch to a deployment:

- Cronjob: 1fd77b-test/web-app-storage

- Cronjob: 1fd77b-prod/web-app-storage


You can find a step by step guidance on how to switch from Cronjob to deployment here: https://developer.gov.bc.ca/docs/default/component/platform-developer-docs/docs/platform-automation/kyverno/#alternatives-to-cronjobs


**Action**
In order to reduce the overhead resource consumption of frequent pod restarts in your namespace, will try to run the scheduler on the multiple PODs and use the onOneServer method to ensure that the task should run on only one server. The first server to obtain the task will secure an atomic lock on the job to prevent other servers from running the same task at the same time.
https://laravel.com/docs/11.x/scheduling#running-tasks-on-one-server

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/DxHPN5m3bEyKbN4SDMhG2GUALFgk?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)

