### PR TITLE
(TEST) [jp-0221] Donor and Volunteer Analytics (fix typo)

### DIFF
--- a/resources/views/system-security/partials/tabs.blade.php
+++ b/resources/views/system-security/partials/tabs.blade.php
@@ -37,7 +37,7 @@
         <a class="dropdown-item {{ str_contains( Route::current()->getName(), 'system.transaction-counts-overview') ? 'active' : ''}}"
           href="{{ route('system.transaction-counts-overview') }}">Transaction Counts Overview</a>
           <a class="dropdown-item {{ str_contains( Route::current()->getName(), 'system.transaction-timings') ? 'active' : ''}}"
-            href="{{ route('system.transaction-timings') }}">Transaction Timimgs</a>
+            href="{{ route('system.transaction-timings') }}">Transaction Timings</a>
       </div>
     </li>
 

--- a/resources/views/system-security/user-activity/transaction_timings.blade.php
+++ b/resources/views/system-security/user-activity/transaction_timings.blade.php
@@ -66,19 +66,19 @@
         <div class="row text-center px-5">
             <div class="col-md-4">
                 <div class="bg-primary text-white p-3 rounded">
-                    <h2 class="h5">Minimum Time in Second</h2>
+                    <h2 class="h5">Minimum Time in Seconds</h2>
                     <p class="h3" id="visit_min">{{ $visit_min }}</p>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="bg-success text-white p-3 rounded">
-                    <h2 class="h5">Average Time in Second</h2>
+                    <h2 class="h5">Average Time in Seconds</h2>
                     <p class="h3" id="visit_avg">{{ $visit_avg }}</p>
                 </div>
             </div>
             <div class="col-md-4">
                 <div class="bg-warning text-white p-3 rounded">
-                    <h2 class="h5">Maximum Time in Second</h2>
+                    <h2 class="h5">Maximum Time in Seconds</h2>
                     <p class="h3" id="visit_max">{{ $visit_max }}</p>
                 </div>
             </div>


### PR DESCRIPTION
Need to create an area in the administrative side of the PECSF application to view donor and volunteer analytics.

For example:
How many users access the application?
How many users set up a pledge?
How long did it take to set up a donation?
How many users visit the volunteering section?
What is the traffic on each volunteering page?

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/YduahGL_R02M1OR4rYu4E2UAOwGI?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)