### PR TITLE
(TEST) [jp-0230] To avoid the Intermittent error 'wget: unable to resolve host address' during the deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN chgrp -R 0 /app && \
 #
 FROM php:8.3-apache
 
+RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf
+
 WORKDIR /
 
 # Local proxy config (remove for server deployment)


### PR DESCRIPTION
**Issue**

The following Intermittent error when deploy a new project on to DEV, TEST or Production

[2/2] STEP 9/35: RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg

--2025-05-14 16:36:50-- https://packages.sury.org/php/apt.gpg
Resolving packages.sury.org (packages.sury.org)... failed: Temporary failure in name resolution.
wget: unable to resolve host address 'packages.sury.org'
error: build error: building at STEP "RUN wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg": while running runtime: exit status 4


**Research Result**

Docker sometimes struggles with DNS resolution, especially in corporate or custom network environments.

**Action**

_Workaround_

If this is during a Dockerfile RUN step (e.g. apt-get install), try adding:

RUN echo "nameserver 8.8.8.8" > /etc/resolv.conf

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/_3W0cqFIwEaIVcOPNnWx12UAI4D8?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)
