### PR TITLE
[jp-0226] CRA Charity List upload - Alternative Address

### DIFF
--- a/app/Imports/CharitiesImport.php
+++ b/app/Imports/CharitiesImport.php
@@ -131,6 +131,27 @@ class CharitiesImport implements ToCollection, WithStartRow, WithChunkReading, W
                     // No Action
                 }
 
+                if ($charity && 
+                    trim(strtolower($charity->address)) == trim(strtolower($charity->alt_address1)) &&
+                    trim(strtolower($charity->city)) == trim(strtolower($charity->alt_city)) &&
+                    trim(strtolower($charity->province)) == trim(strtolower($charity->alt_province)) &&
+                    trim(strtolower($charity->country)) == trim(strtolower($charity->alt_country)) &&
+                    trim(strtolower($charity->postal_code)) == trim(strtolower(str_replace(' ', '', $charity->alt_postal_code)))) {
+
+                    $charity->use_alt_address = null;
+                    $charity->alt_address1 = null;
+                    $charity->alt_address2 = null;
+                    $charity->alt_city = null;
+                    $charity->alt_province = null;
+                    $charity->alt_country = null;
+                    $charity->alt_postal_code = null;
+                    $charity->save();
+
+                    $changes = $charity->getChanges();
+                    unset($changes["updated_at"]);
+                    $this->logMessage('[RESET ALT ADDRESS] on RN# ' . $charity->registration_number . ' - ' . json_encode($changes) );
+                }
+
                 $charityStaging = CharityStaging::create([
                     'history_id' => $this->history_id,
                     'registration_number' => $row[0],


### PR DESCRIPTION
**As a FMO administrator processing charity information,**

I want the system to automatically clear the "Use Alternative Address" flag when the Original Mailing Address and Alternative Address fields contain identical information,

So that we don't override freshly updated CRA addresses with obsolete ones, reducing returned mail, reprocessing time, and improving charity experience.
(it is expected that some cheques will still be returned)


**Rational:**

To help reduce incorrect address cheque returns,

Proposed change: If the Original Mailing Address and the Alternative Address fields are identical, automatically clear the Use Alternative Address flag.
Benefit: This prevents us from overriding a freshly updated CRA address with an obsolete one that was entered earlier, without requiring manual checks each upload cycle.
Impact: The override would still work whenever the two addresses differ, but it would fall back to the CRA address as soon as they match.

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/wEoPlKHL0E2bwm0MROUiqGUAClBn?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)
