### PR TITLE
(MASTER) [jp-0232] Backdate deduction for Transaction ID 12799 to 2025

### DIFF
--- a/database/seeders/DataFixFor_jp_0232_Pledge_12799.php
+++ b/database/seeders/DataFixFor_jp_0232_Pledge_12799.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+
+class DataFixFor_jp_0232_Pledge_12799 extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Reassign charity on Evenet Pledge 173 
+        
+        echo 'Before change:';
+        $data = DB::table('pledges')
+                    ->whereRaw("id = 12799 and emplid in ('136279') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+        // Data Fix
+        /*
+            Backdate deduction for Transaction ID 12799 to 2025
+
+            Tran ID         EE                        
+
+            12799           136279   2026 --> 2025    
+
+        */
+        DB::update("update pledges set campaign_year_id = 21,
+                            ods_export_status = 'C', ods_export_at = now(),
+                            updated_at = now()
+                     where id = 12799 and emplid in ('136279') and deleted_at is null;");
+        
+        echo PHP_EOL;
+        echo PHP_EOL;
+        echo 'After change:';
+        $data = DB::table('pledges')
+                    ->whereRaw("id = 12799 and emplid in ('136279') and deleted_at is null;")
+                    ->get();
+        echo json_encode($data, JSON_PRETTY_PRINT);
+
+    }
+}


### PR DESCRIPTION
Bi weekly pledge for E# 136279 showing up on 40D report but was not in PECSF application ("no pledge")
June 5 - Ashley and Job have added pledge in system but it will only allow us to enter as 2026.

James can you please adjust transaction ID 12799 so it reflects 2025?

This would need to be fixed ahead of the next cheque run. Please let us know if you need more info!

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/2tlncXSSskqGmx17YRwuoGUAMHQP?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)