### PR TITLE
(TEST) [jp-0233] Security update required (June, 2025)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3078,16 +3078,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.6.1",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad"
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/d990688c91cedfb69753ffc2512727ec646df2ad",
-                "reference": "d990688c91cedfb69753ffc2512727ec646df2ad",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
+                "reference": "6fbb36d44824ed4091adbcf4c7d4a3923cdb3405",
                 "shasum": ""
             },
             "require": {
@@ -3124,7 +3124,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.7-dev"
+                    "dev-main": "2.8-dev"
                 }
             },
             "autoload": {
@@ -3181,7 +3181,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-29T14:10:59+00:00"
+            "time": "2025-05-05T12:20:28+00:00"
         },
         {
             "name": "league/config",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,17 +4,18 @@
     "requires": true,
     "packages": {
         "": {
+            "name": "PECSF",
             "dependencies": {
                 "@bcgov/bc-sans": "^1.0.1",
                 "@fortawesome/fontawesome-free": "^5.15.4",
-                "admin-lte": "~3.1.0",
+                "admin-lte": "^4.0.0-beta3",
                 "dropzone": "^5.9.0",
                 "font-awesome": "^4.7.0",
                 "icheck-bootstrap": "^3.0.1"
             },
             "devDependencies": {
                 "axios": "^1.0",
-                "bootstrap": "^4.0.0",
+                "bootstrap": "^5.3.6",
                 "jquery": "^3.2",
                 "laravel-mix": "^6.0.49",
                 "lodash": "^4.17.19",
@@ -23,9 +24,9 @@
                 "resolve-url-loader": "^5.0.0",
                 "sass": "^1.32.11",
                 "sass-loader": "^10.1.1",
-                "vue": "^2.5.17",
+                "vue": "^3.5.16",
                 "vue-loader": "^17.4.2",
-                "vue-template-compiler": "^2.6.10"
+                "vue-template-compiler": "^0.1.0"
             }
         },
         "node_modules/@ampproject/remapping": {
@@ -42,14 +43,14 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -340,18 +341,18 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
@@ -381,25 +382,25 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
             "dev": true,
             "dependencies": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.27.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+            "version": "7.27.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+            "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
             "dev": true,
             "dependencies": {
-                "@babel/types": "^7.26.5"
+                "@babel/types": "^7.27.3"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -1512,26 +1513,23 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
             "dev": true,
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
             "dependencies": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1556,13 +1554,13 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+            "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -1664,11 +1662,6 @@
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
             "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
             "dev": true
-        },
-        "node_modules/@lgaitan/pace-progress": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@lgaitan/pace-progress/-/pace-progress-1.0.7.tgz",
-            "integrity": "sha512-GMoTcF6WBpno7a7Iyx7M79os26d5bCDbh7YTZmXZM8YuLR3DDtwo0/CBYddStGD6QIBTieFDz4IAQiO0dAdRGw=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2001,18 +1994,16 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
-        "node_modules/@swc/helpers": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
-            "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
-            "dependencies": {
-                "tslib": "^2.4.0"
+        "node_modules/@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "dev": true,
+            "peer": true,
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/popperjs"
             }
-        },
-        "node_modules/@sweetalert2/theme-bootstrap-4": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@sweetalert2/theme-bootstrap-4/-/theme-bootstrap-4-4.0.5.tgz",
-            "integrity": "sha512-pe5mQ98sgrphNVq6Xe5BsWxsfI1Z8zT9C2oux6+4B6Qt30qYo58Q+bnzRs8pV95O9/URt/QJZyl+R8SabMeW6g=="
         },
         "node_modules/@trysound/sax": {
             "version": "0.2.0",
@@ -2022,11 +2013,6 @@
             "engines": {
                 "node": ">=10.13.0"
             }
-        },
-        "node_modules/@ttskch/select2-bootstrap4-theme": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ttskch/select2-bootstrap4-theme/-/select2-bootstrap4-theme-1.5.2.tgz",
-            "integrity": "sha512-gAj8qNy/VYwQDBkACm0USM66kxFai8flX83ayRXPNhzZckEgSqIBB9sM74SCM3ssgeX+ZVy4BifTnLis+KpIyg=="
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -2364,19 +2350,117 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@vue/compiler-sfc": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-            "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
+        "node_modules/@vue/compiler-core": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.16.tgz",
+            "integrity": "sha512-AOQS2eaQOaaZQoL1u+2rCJIKDruNXVBZSiUD3chnUrsoX5ZTQMaCvXlWNIfxBJuU15r1o7+mpo5223KVtIhAgQ==",
             "dev": true,
             "dependencies": {
-                "@babel/parser": "^7.23.5",
-                "postcss": "^8.4.14",
-                "source-map": "^0.6.1"
-            },
-            "optionalDependencies": {
-                "prettier": "^1.18.2 || ^2.0.0"
+                "@babel/parser": "^7.27.2",
+                "@vue/shared": "3.5.16",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
             }
+        },
+        "node_modules/@vue/compiler-core/node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/@vue/compiler-dom": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.16.tgz",
+            "integrity": "sha512-SSJIhBr/teipXiXjmWOVWLnxjNGo65Oj/8wTEQz0nqwQeP75jWZ0n4sF24Zxoht1cuJoWopwj0J0exYwCJ0dCQ==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-core": "3.5.16",
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "node_modules/@vue/compiler-sfc": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.16.tgz",
+            "integrity": "sha512-rQR6VSFNpiinDy/DVUE0vHoIDUF++6p910cgcZoaAUm3POxgNOOdS/xgoll3rNdKYTYPnnbARDCZOyZ+QSe6Pw==",
+            "dev": true,
+            "dependencies": {
+                "@babel/parser": "^7.27.2",
+                "@vue/compiler-core": "3.5.16",
+                "@vue/compiler-dom": "3.5.16",
+                "@vue/compiler-ssr": "3.5.16",
+                "@vue/shared": "3.5.16",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.17",
+                "postcss": "^8.5.3",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/@vue/compiler-ssr": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.16.tgz",
+            "integrity": "sha512-d2V7kfxbdsjrDSGlJE7my1ZzCXViEcqN6w14DOsDrUCHEA6vbnVCpRFfrc4ryCP/lCKzX2eS1YtnLE/BuC9f/A==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-dom": "3.5.16",
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "node_modules/@vue/reactivity": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.16.tgz",
+            "integrity": "sha512-FG5Q5ee/kxhIm1p2bykPpPwqiUBV3kFySsHEQha5BJvjXdZTUfmya7wP7zC39dFuZAcf/PD5S4Lni55vGLMhvA==",
+            "dev": true,
+            "dependencies": {
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "node_modules/@vue/runtime-core": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.16.tgz",
+            "integrity": "sha512-bw5Ykq6+JFHYxrQa7Tjr+VSzw7Dj4ldR/udyBZbq73fCdJmyy5MPIFR9IX/M5Qs+TtTjuyUTCnmK3lWWwpAcFQ==",
+            "dev": true,
+            "dependencies": {
+                "@vue/reactivity": "3.5.16",
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "node_modules/@vue/runtime-dom": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.16.tgz",
+            "integrity": "sha512-T1qqYJsG2xMGhImRUV9y/RseB9d0eCYZQ4CWca9ztCuiPj/XWNNN+lkNBuzVbia5z4/cgxdL28NoQCvC0Xcfww==",
+            "dev": true,
+            "dependencies": {
+                "@vue/reactivity": "3.5.16",
+                "@vue/runtime-core": "3.5.16",
+                "@vue/shared": "3.5.16",
+                "csstype": "^3.1.3"
+            }
+        },
+        "node_modules/@vue/server-renderer": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.16.tgz",
+            "integrity": "sha512-BrX0qLiv/WugguGsnQUJiYOE0Fe5mZTwi6b7X/ybGB0vfrPH9z0gD/Y6WOR1sGCgX4gc25L1RYS5eYQKDMoNIg==",
+            "dev": true,
+            "dependencies": {
+                "@vue/compiler-ssr": "3.5.16",
+                "@vue/shared": "3.5.16"
+            },
+            "peerDependencies": {
+                "vue": "3.5.16"
+            }
+        },
+        "node_modules/@vue/shared": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.16.tgz",
+            "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==",
+            "dev": true
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.14.1",
@@ -2620,73 +2704,9 @@
             }
         },
         "node_modules/admin-lte": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-3.1.0.tgz",
-            "integrity": "sha512-JkmmkjbGgB5RCPwpaUCEktpZz/Ez/vBdfCNx8J3u8doaRRUUV1/oj4PuIiOV+xrNMt05q87131xoGySr/eA4uA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@fortawesome/fontawesome-free": "^5.15.3",
-                "@lgaitan/pace-progress": "^1.0.7",
-                "@sweetalert2/theme-bootstrap-4": "^4.0.3",
-                "@ttskch/select2-bootstrap4-theme": "^1.5.2",
-                "bootstrap": "^4.6.0",
-                "bootstrap-colorpicker": "^3.2.0",
-                "bootstrap-slider": "^11.0.2",
-                "bootstrap-switch": "3.3.4",
-                "bootstrap4-duallistbox": "^4.0.2",
-                "bs-custom-file-input": "^1.3.4",
-                "bs-stepper": "^1.7.0",
-                "chart.js": "^2.9.4",
-                "codemirror": "^5.60.0",
-                "datatables.net": "^1.10.24",
-                "datatables.net-autofill-bs4": "^2.3.5",
-                "datatables.net-bs4": "^1.10.24",
-                "datatables.net-buttons-bs4": "^1.7.0",
-                "datatables.net-colreorder-bs4": "^1.5.3",
-                "datatables.net-fixedcolumns-bs4": "^3.3.2",
-                "datatables.net-fixedheader-bs4": "^3.1.8",
-                "datatables.net-keytable-bs4": "^2.6.1",
-                "datatables.net-responsive-bs4": "^2.2.7",
-                "datatables.net-rowgroup-bs4": "^1.1.2",
-                "datatables.net-rowreorder-bs4": "^1.2.7",
-                "datatables.net-scroller-bs4": "^2.0.3",
-                "datatables.net-searchbuilder-bs4": "^1.0.1",
-                "datatables.net-searchpanes-bs4": "^1.2.2",
-                "datatables.net-select-bs4": "^1.3.2",
-                "daterangepicker": "^3.1.0",
-                "dropzone": "^5.8.1",
-                "ekko-lightbox": "^5.3.0",
-                "fastclick": "^1.0.6",
-                "filterizr": "^2.2.4",
-                "flag-icon-css": "^3.5.0",
-                "flot": "^4.2.2",
-                "fs-extra": "^9.1.0",
-                "fullcalendar": "^5.5.1",
-                "icheck-bootstrap": "^3.0.1",
-                "inputmask": "^5.0.5",
-                "ion-rangeslider": "^2.3.1",
-                "jquery": "^3.6.0",
-                "jquery-knob-chif": "^1.2.13",
-                "jquery-mapael": "^2.2.0",
-                "jquery-mousewheel": "^3.1.13",
-                "jquery-ui-dist": "^1.12.1",
-                "jquery-validation": "^1.19.3",
-                "jqvmap-novulnerability": "^1.5.1",
-                "jsgrid": "^1.5.3",
-                "jszip": "^3.6.0",
-                "moment": "^2.29.1",
-                "overlayscrollbars": "^1.13.1",
-                "pdfmake": "^0.1.70",
-                "popper.js": "^1.16.1",
-                "raphael": "^2.3.0",
-                "select2": "^4.0.13",
-                "sparklines": "^1.3.0",
-                "summernote": "^0.8.18",
-                "sweetalert2": "^10.15.6",
-                "tempusdominus-bootstrap-4": "^5.39.0",
-                "toastr": "^2.1.4",
-                "uplot": "^1.6.7"
-            }
+            "version": "4.0.0-beta3",
+            "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-4.0.0-beta3.tgz",
+            "integrity": "sha512-q2VoAOu1DtZ7z41M2gQ05VMNYkFCAMxFU+j/HUMwCOlr/e3VhO+qww2SGJw4OxBw5nZQ7YV78+wK2RiB7ConzQ=="
         },
         "node_modules/ajv": {
             "version": "6.12.6",
@@ -2813,21 +2833,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/array-buffer-byte-length": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "is-array-buffer": "^3.0.5"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -2891,14 +2896,6 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
         },
-        "node_modules/at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "node_modules/autoprefixer": {
             "version": "10.4.20",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -2934,20 +2931,6 @@
             },
             "peerDependencies": {
                 "postcss": "^8.1.0"
-            }
-        },
-        "node_modules/available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "dependencies": {
-                "possible-typed-array-names": "^1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/axios": {
@@ -3038,6 +3021,7 @@
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3169,9 +3153,10 @@
             "dev": true
         },
         "node_modules/bootstrap": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-            "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+            "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -3183,44 +3168,13 @@
                 }
             ],
             "peerDependencies": {
-                "jquery": "1.9.1 - 3",
-                "popper.js": "^1.16.1"
+                "@popperjs/core": "^2.11.8"
             }
-        },
-        "node_modules/bootstrap-colorpicker": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-3.4.0.tgz",
-            "integrity": "sha512-7vA0hvLrat3ptobEKlT9+6amzBUJcDAoh6hJRQY/AD+5dVZYXXf1ivRfrTwmuwiVLJo9rZwM8YB4lYzp6agzqg==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "dependencies": {
-                "bootstrap": ">=4.0",
-                "jquery": ">=2.2",
-                "popper.js": ">=1.10"
-            }
-        },
-        "node_modules/bootstrap-slider": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-11.0.2.tgz",
-            "integrity": "sha512-CdwS+Z6X79OkLes9RfDgPB9UIY/+81wTkm6ktdSB6hdyiRbjJLFQIjZdnEr55tDyXZfgC7U6yeSXkNN9ZdGqjA=="
-        },
-        "node_modules/bootstrap-switch": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
-            "integrity": "sha512-7YQo+Ir6gCUqC36FFp1Zvec5dRF/+obq+1drMtdIMi9Xc84Kx63Evi0kdcp4HfiGsZpiz6IskyYDNlSKcxsL7w==",
-            "peerDependencies": {
-                "bootstrap": "^3.1.1",
-                "jquery": ">=1.9.0"
-            }
-        },
-        "node_modules/bootstrap4-duallistbox": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/bootstrap4-duallistbox/-/bootstrap4-duallistbox-4.0.2.tgz",
-            "integrity": "sha512-vQdANVE2NN0HMaZO9qWJy0C7u04uTpAmtUGO3KLq3xAZKCboJweQ437hDTszI6pbYV2olJCGZMbdhvIkBNGeGQ=="
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -3244,14 +3198,6 @@
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
             "dev": true
-        },
-        "node_modules/brotli": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-            "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-            "dependencies": {
-                "base64-js": "^1.1.2"
-            }
         },
         "node_modules/browserify-aes": {
             "version": "1.2.0",
@@ -3366,22 +3312,6 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
-        "node_modules/bs-custom-file-input": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/bs-custom-file-input/-/bs-custom-file-input-1.3.4.tgz",
-            "integrity": "sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/bs-stepper": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/bs-stepper/-/bs-stepper-1.7.0.tgz",
-            "integrity": "sha512-+DX7UKKgw2GI6ucsSCRd19VHYrxf/8znRCLs1lQVVLxz+h7EqgIOxoHcJ0/QTaaNoR9Cwg78ydo6hXIasyd3LA==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/buffer": {
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -3424,6 +3354,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
             "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "dev": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.0",
                 "es-define-property": "^1.0.0",
@@ -3441,6 +3372,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
             "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -3453,6 +3385,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
             "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "dev": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "get-intrinsic": "^1.2.6"
@@ -3538,32 +3471,6 @@
             "dev": true,
             "engines": {
                 "node": "*"
-            }
-        },
-        "node_modules/chart.js": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
-            "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
-            "dependencies": {
-                "chartjs-color": "^2.1.0",
-                "moment": "^2.10.2"
-            }
-        },
-        "node_modules/chartjs-color": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
-            "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-            "dependencies": {
-                "chartjs-color-string": "^0.6.0",
-                "color-convert": "^1.9.3"
-            }
-        },
-        "node_modules/chartjs-color-string": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
-            "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-            "dependencies": {
-                "color-name": "^1.0.0"
             }
         },
         "node_modules/chokidar": {
@@ -3653,14 +3560,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/clone": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -3675,34 +3574,17 @@
                 "node": ">=6"
             }
         },
-        "node_modules/codemirror": {
-            "version": "5.65.18",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.18.tgz",
-            "integrity": "sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA=="
-        },
         "node_modules/collect.js": {
             "version": "4.36.1",
             "resolved": "https://registry.npmjs.org/collect.js/-/collect.js-4.36.1.tgz",
             "integrity": "sha512-jd97xWPKgHn6uvK31V6zcyPd40lUJd7gpYxbN2VOVxGWO4tyvS9Li4EpsFjXepGTo2tYcOTC4a8YsbQXMJ4XUw==",
             "dev": true
         },
-        "node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/color-convert/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-        },
         "node_modules/color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "node_modules/colord": {
             "version": "2.9.3",
@@ -3900,7 +3782,8 @@
         "node_modules/core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "node_modules/cosmiconfig": {
             "version": "7.1.0",
@@ -4009,11 +3892,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/crypto-js": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
         },
         "node_modules/css-declaration-sorter": {
             "version": "6.4.1",
@@ -4235,337 +4113,6 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "dev": true
         },
-        "node_modules/datatables.net": {
-            "version": "1.13.11",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.11.tgz",
-            "integrity": "sha512-AE6RkMXziRaqzPcu/pl3SJXeRa6fmXQG/fVjuRESujvkzqDCYEeKTTpPMuVJSGYJpPi32WGSphVNNY1G4nSN/g==",
-            "dependencies": {
-                "jquery": "1.8 - 4"
-            }
-        },
-        "node_modules/datatables.net-autofill": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-autofill/-/datatables.net-autofill-2.7.0.tgz",
-            "integrity": "sha512-zy7Jglke0VXu7RzyGYufMLLlSJkhr+rWJubBw0cozlaXtrqR2CNjY8LBBJA19GwBeoDCNrbojNge0YN8l44b8g==",
-            "dependencies": {
-                "datatables.net": ">=1.11",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-autofill-bs4": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-autofill-bs4/-/datatables.net-autofill-bs4-2.7.0.tgz",
-            "integrity": "sha512-vVMvZeioGhmvd7URJAvXnOYod/ZWKhCDsLB7Onw7SaJmeawf4CaY7lAU79ee0531Kf0FWuLOKlZcaEt8p1w4qQ==",
-            "dependencies": {
-                "datatables.net-autofill": "2.7.0",
-                "datatables.net-bs4": ">=1.11",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-bs4": {
-            "version": "1.13.11",
-            "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-1.13.11.tgz",
-            "integrity": "sha512-1LnxzQDFKpwvBETc8wtUtQ+pUXhs6NJomNST5pRzzHAccckkj9rZeOp3mevKDnDJKuNhBM1Y0rIeZGylJnqh9A==",
-            "dependencies": {
-                "datatables.net": "1.13.11",
-                "jquery": "1.8 - 4"
-            }
-        },
-        "node_modules/datatables.net-buttons": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-buttons/-/datatables.net-buttons-1.7.1.tgz",
-            "integrity": "sha512-D2OxZeR18jhSx+l0xcfAJzfUH7l3LHCu0e606fV7+v3hMhphOfljjZYLaiRmGiR9lqO/f5xE/w2a+OtG/QMavw==",
-            "dependencies": {
-                "datatables.net": "^1.10.15",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-buttons-bs4": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-buttons-bs4/-/datatables.net-buttons-bs4-1.7.1.tgz",
-            "integrity": "sha512-s+fwsgAAWp7mOKwuztPH06kaw2JNAJ71VNTw/TqGQTL6BK9FshweDKZSRIB/ePcc/Psiy8fhNEj3XHxx4OO6BA==",
-            "dependencies": {
-                "datatables.net-bs4": "^1.10.15",
-                "datatables.net-buttons": "1.7.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-colreorder": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.7.2.tgz",
-            "integrity": "sha512-F8TYMFXtWLtsjciwS7hkP/Fbp3XS6WHuHLc+iMFtQqiQmbMo/59GK7YSxKuxSoqTTJU/opaPXQYjODnIuNEc/g==",
-            "dependencies": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-colreorder-bs4": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs4/-/datatables.net-colreorder-bs4-1.7.2.tgz",
-            "integrity": "sha512-iVlvHwD82ZCDuaDaAXsD6OukNjgWNe44+f0yu43a1bOwK1ncXYiBSohlEuIhynHnESexN2vg4saj4a0rEMNx+w==",
-            "dependencies": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-colreorder": "1.7.2",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-fixedcolumns": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedcolumns/-/datatables.net-fixedcolumns-3.3.3.tgz",
-            "integrity": "sha512-xo6MeI2xc/Ufk4ffrpao+OiPo8/GPB8cO80gA6NFgYBVw6eP9pPa2NsV+gSWRVr7d3A8iZC7mUZT5WdtliNHEA==",
-            "dependencies": {
-                "datatables.net": "^1.10.15",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-fixedcolumns-bs4": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedcolumns-bs4/-/datatables.net-fixedcolumns-bs4-3.3.3.tgz",
-            "integrity": "sha512-d0dqCYk93wnCT382hW2Y1YMwgJXpTfdTu3Tb+UKQvt7OApxKYuWUFfKde+wHtIhqodswZ1jrMfYmxZHJYAysZQ==",
-            "dependencies": {
-                "datatables.net-bs4": "^1.10.15",
-                "datatables.net-fixedcolumns": "3.3.3",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-fixedheader": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedheader/-/datatables.net-fixedheader-3.4.1.tgz",
-            "integrity": "sha512-c9FJAShG5r8RJDIszWQvMFe6Ie+njfbHB9GhzOPjEF7zhbsMUQEkoYq1qW3ppOxY5psadDrT+D3f4iGM589u6w==",
-            "dependencies": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-fixedheader-bs4": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedheader-bs4/-/datatables.net-fixedheader-bs4-3.4.1.tgz",
-            "integrity": "sha512-Oq6yCpswdFRn+nwrjOjD0nmpH3F0glz/ppgdT8vA6U/8qkguze4d3qZyEYd7osqrCeX9ccUZR9ptpqRYb6sVtg==",
-            "dependencies": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-fixedheader": "3.4.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-keytable": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-keytable/-/datatables.net-keytable-2.12.1.tgz",
-            "integrity": "sha512-MR/qvBxVXld3i+YZfLAv/yCMvzh1trEIMpLo7YU0DP/CIWewHhkFeTS0G3tJgLjBes4v4tyR0Zjf6R9aMtMBEw==",
-            "dependencies": {
-                "datatables.net": ">=1.11.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-keytable-bs4": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-keytable-bs4/-/datatables.net-keytable-bs4-2.12.1.tgz",
-            "integrity": "sha512-7ZUNFTfbjeQl9w7Yu2G2zNs3UFpc07rpJm84AE43ecLg+pj7w9tXxRQlvkz4G1uL6DqkUswOBiCpySUy3R2QLw==",
-            "dependencies": {
-                "datatables.net-bs4": ">=1.11.0",
-                "datatables.net-keytable": "2.12.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-responsive": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-responsive/-/datatables.net-responsive-2.5.1.tgz",
-            "integrity": "sha512-hyJb2faIzEWUX5Yn4HOSq/6NNB9SXDVbI4OU9ny+XU/2ghZEz4676spOgzpDHTdWvCfM+t1mbUsT70fDiTTr9w==",
-            "dependencies": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-responsive-bs4": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-responsive-bs4/-/datatables.net-responsive-bs4-2.5.1.tgz",
-            "integrity": "sha512-cOVCG9zRioqJiqZUPXel5/vxKGt8EFhxgzVafDNy2hY3ZO+UMMuRKcs2br/QMoojbXzpKNf2rL/lM7NoXKVKZA==",
-            "dependencies": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-responsive": "2.5.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-rowgroup": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowgroup/-/datatables.net-rowgroup-1.5.1.tgz",
-            "integrity": "sha512-yDn+UCG9vrztt4obqt0YogyjH/i1D5Fyxnt4r5++T/ZaYhjKLU8zG9hkQXMx81M7RgeOtkv0eEpo/c+72w8T0w==",
-            "dependencies": {
-                "datatables.net": "^2",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-rowgroup-bs4": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowgroup-bs4/-/datatables.net-rowgroup-bs4-1.5.1.tgz",
-            "integrity": "sha512-1TMpTrQR8nXXZp5JBwemNAVEMWznE5/k2jJ1dVsXGyngtiZ2aVy0ls5vqQHaOPJuG0O0aIP7l+rU0+T4umHdow==",
-            "dependencies": {
-                "datatables.net-bs4": "^2",
-                "datatables.net-rowgroup": "1.5.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-rowgroup-bs4/node_modules/datatables.net": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-            "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-            "dependencies": {
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-rowgroup-bs4/node_modules/datatables.net-bs4": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-2.2.1.tgz",
-            "integrity": "sha512-YJpbGGTqrOhS6p8BolGv16mdmljaq4ewhc0dbm3yd02UQ86A2cWQ2tDq6lE966tvRD43JE0PPAc5wLgsRozReg==",
-            "dependencies": {
-                "datatables.net": "2.2.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-rowgroup/node_modules/datatables.net": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-            "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-            "dependencies": {
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-rowreorder": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowreorder/-/datatables.net-rowreorder-1.5.0.tgz",
-            "integrity": "sha512-Kkq57tdJHrUCYkS8vywhL5tqKtl2q3K3p8A6wkIdwMX2b8YVjtywhQbXvvVLZnlMQsdX194FXVK1AgAwcm4hFg==",
-            "dependencies": {
-                "datatables.net": ">=1.11.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-rowreorder-bs4": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowreorder-bs4/-/datatables.net-rowreorder-bs4-1.5.0.tgz",
-            "integrity": "sha512-4C9tzLRaisO+IOdJ1n6NRQ8ak0zC0IbX50Ed5hg+5PT7VJLI9klH+GBwE6hpF28UTWk7E6somzOwnRHLexqXdA==",
-            "dependencies": {
-                "datatables.net-bs4": ">=1.11.0",
-                "datatables.net-rowreorder": "1.5.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-scroller": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-scroller/-/datatables.net-scroller-2.4.3.tgz",
-            "integrity": "sha512-ce6Qa7ObGQmLJYvm6eMglf54L+01/Omn3N1pw7SiQjGYv8AKRRp1ex+U0NWmx3QaWp0iEeTnBaM4G6ay4juYZg==",
-            "dependencies": {
-                "datatables.net": "1.11 - 2",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-scroller-bs4": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-scroller-bs4/-/datatables.net-scroller-bs4-2.4.3.tgz",
-            "integrity": "sha512-ca02sqd8VJTafqZhCOETXvvyACFh08aUl4JD+gxg7/1JKjvki0hnpyUkU5SBYgV0aNT1B2ecK+PZf4E/dWjtFg==",
-            "dependencies": {
-                "datatables.net-bs4": "1.11 - 2",
-                "datatables.net-scroller": "2.4.3",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchbuilder": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchbuilder/-/datatables.net-searchbuilder-1.8.1.tgz",
-            "integrity": "sha512-kjbPw8pC3NPBzP1BtG4WHGaMJet27WYLWZnBERuw5F/b6F4I2FAaxUiNuq8Ryu3EmWyWlgnfTeHums4XNwc8fg==",
-            "dependencies": {
-                "datatables.net": "^2.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchbuilder-bs4": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchbuilder-bs4/-/datatables.net-searchbuilder-bs4-1.8.1.tgz",
-            "integrity": "sha512-JiAqQ1/L7JpaBvs1m6BfPX0mf93X0oaGwqPNpB7ff1mIW0R62uyLyNmtc0lis53GqrZ1ejZemzWxwwnSHwY37g==",
-            "dependencies": {
-                "datatables.net-bs4": "^2.1",
-                "datatables.net-searchbuilder": "1.8.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchbuilder-bs4/node_modules/datatables.net": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-            "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-            "dependencies": {
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchbuilder-bs4/node_modules/datatables.net-bs4": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-2.2.1.tgz",
-            "integrity": "sha512-YJpbGGTqrOhS6p8BolGv16mdmljaq4ewhc0dbm3yd02UQ86A2cWQ2tDq6lE966tvRD43JE0PPAc5wLgsRozReg==",
-            "dependencies": {
-                "datatables.net": "2.2.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchbuilder/node_modules/datatables.net": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-            "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-            "dependencies": {
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchpanes": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchpanes/-/datatables.net-searchpanes-2.3.3.tgz",
-            "integrity": "sha512-iARaOcKPCotCx5Ip5TrJl+lvhYOpEXHzp7xMukcD2fmOkTPgK0CMRKQPF7eJx1aY4nWtm9ythBt6v1TRpEnO1w==",
-            "dependencies": {
-                "datatables.net": "^2",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchpanes-bs4": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchpanes-bs4/-/datatables.net-searchpanes-bs4-1.4.0.tgz",
-            "integrity": "sha512-Floxzmw2cQkUQdI7Vv4IWtLqLmwPrmY6MPncbEWq4YvkSeaZW7OHzSmZLLUjMn2P6Huvz59WUVcwL0lSDui6GQ==",
-            "dependencies": {
-                "datatables.net-bs4": ">=1.10.25",
-                "datatables.net-searchpanes": ">=1.3.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-searchpanes/node_modules/datatables.net": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-            "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-            "dependencies": {
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-select": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.7.1.tgz",
-            "integrity": "sha512-yC+GoBDVsnbaFTYKmZ2v5Bftc66zSZCYHbPYZb/ccdvxytEEudjc9R3wn6fgkOrVx3C2X/8keQc4a7EJvdOErg==",
-            "dependencies": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/datatables.net-select-bs4": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-select-bs4/-/datatables.net-select-bs4-1.7.1.tgz",
-            "integrity": "sha512-iHG4C8RdJIpsGIGDCXofUflHN1fa2N0E83MZPuqQXh1ZBkeJzd700rnru2mJXbvFc+wM9vf0Xxr6C5YsYFprgA==",
-            "dependencies": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-select": "1.7.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "node_modules/daterangepicker": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/daterangepicker/-/daterangepicker-3.1.0.tgz",
-            "integrity": "sha512-DxWXvvPq4srWLCqFugqSV+6CBt/CvQ0dnpXhQ3gl0autcIDAruG1PuGG3gC7yPRNytAD1oU1AcUOzaYhOawhTw==",
-            "dependencies": {
-                "jquery": ">=1.10",
-                "moment": "^2.9.0"
-            }
-        },
         "node_modules/de-indent": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -4589,42 +4136,6 @@
                 }
             }
         },
-        "node_modules/deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "dependencies": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
-                "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/deep-equal/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-        },
         "node_modules/default-gateway": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -4641,6 +4152,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
             "dependencies": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -4666,6 +4178,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
             "dependencies": {
                 "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
@@ -4734,11 +4247,6 @@
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
-        },
-        "node_modules/dfa": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
         },
         "node_modules/diffie-hellman": {
             "version": "5.0.3",
@@ -4910,6 +4418,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -4924,11 +4433,6 @@
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true
-        },
-        "node_modules/ekko-lightbox": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/ekko-lightbox/-/ekko-lightbox-5.3.0.tgz",
-            "integrity": "sha512-mbacwySuVD3Ad6F2hTkjSTvJt59bcVv2l/TmBerp4xZnLak8tPtA4AScUn4DL42c1ksTiAO6sGhJZ52P/1Qgew=="
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.84",
@@ -5028,6 +4532,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -5036,33 +4541,10 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
-        },
-        "node_modules/es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "dependencies": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/es-get-iterator/node_modules/isarray": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/es-module-lexer": {
             "version": "1.6.0",
@@ -5074,6 +4556,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0"
             },
@@ -5139,6 +4622,12 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5156,16 +4645,6 @@
             "engines": {
                 "node": ">= 0.6"
             }
-        },
-        "node_modules/ev-emitter": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
-            "integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
-        },
-        "node_modules/eve-raphael": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
-            "integrity": "sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug=="
         },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
@@ -5319,11 +4798,6 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
-        "node_modules/fast-memoize": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-            "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
-        },
         "node_modules/fast-uri": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
@@ -5339,11 +4813,6 @@
                     "url": "https://opencollective.com/fastify"
                 }
             ]
-        },
-        "node_modules/fastclick": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fastclick/-/fastclick-1.0.6.tgz",
-            "integrity": "sha512-cXyDBT4g0uWl/Xe75QspBDAgAWQ0lkPi/zgp6YFEUHj6WV6VIZl7R6TiDZhdOVU3W4ehp/8tG61Jev1jit+ztQ=="
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
@@ -5434,15 +4903,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/filterizr": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/filterizr/-/filterizr-2.2.4.tgz",
-            "integrity": "sha512-hqyEdg7RrvJMVFOeF0yysS75HP6jLu0wBSUtSPAc3BysAtHpwcXaPnR1kYp2uZtd3YXyhH6JRfF9+H4SRvrqXg==",
-            "dependencies": {
-                "fast-memoize": "^2.5.1",
-                "imagesloaded": "^4.1.4"
-            }
-        },
         "node_modules/finalhandler": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -5506,12 +4966,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/flag-icon-css": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-3.5.0.tgz",
-            "integrity": "sha512-pgJnJLrtb0tcDgU1fzGaQXmR8h++nXvILJ+r5SmOXaaL/2pocunQo2a8TAXhjQnBpRLPtZ1KCz/TYpqeNuE2ew==",
-            "deprecated": "The project has been renamed to flag-icons"
-        },
         "node_modules/flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
@@ -5520,11 +4974,6 @@
             "bin": {
                 "flat": "cli.js"
             }
-        },
-        "node_modules/flot": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/flot/-/flot-4.2.6.tgz",
-            "integrity": "sha512-Iz4HCet1ZBQnjGwECz4jseD1zMnh7m2XJIMI6A62l8h2SeceLYOEmYGNQto1XhkSM9fUmqzyKhWwJ+RolWLydg=="
         },
         "node_modules/follow-redirects": {
             "version": "1.15.9",
@@ -5552,30 +5001,6 @@
             "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg==",
             "engines": {
                 "node": ">=0.10.3"
-            }
-        },
-        "node_modules/fontkit": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
-            "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
-            "dependencies": {
-                "@swc/helpers": "^0.3.13",
-                "brotli": "^1.3.2",
-                "clone": "^2.1.2",
-                "deep-equal": "^2.0.5",
-                "dfa": "^1.2.0",
-                "restructure": "^2.0.1",
-                "tiny-inflate": "^1.0.3",
-                "unicode-properties": "^1.3.1",
-                "unicode-trie": "^2.0.0"
-            }
-        },
-        "node_modules/for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "dependencies": {
-                "is-callable": "^1.1.3"
             }
         },
         "node_modules/form-data": {
@@ -5623,20 +5048,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "dependencies": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/fs-monkey": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.6.tgz",
@@ -5663,23 +5074,11 @@
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
-        "node_modules/fullcalendar": {
-            "version": "5.11.5",
-            "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-5.11.5.tgz",
-            "integrity": "sha512-eaVD6zOvuFXVpoMKlg2FQAj8e+PcpitBMwlzwRJJr1zOi/dXMYAksx2hLzwtsr93FVUNSSo16xwMTTZz6+prKQ=="
-        },
         "node_modules/function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -5706,6 +5105,7 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
             "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+            "dev": true,
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-define-property": "^1.0.1",
@@ -5729,6 +5129,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
             "dependencies": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -5820,6 +5221,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5830,7 +5232,8 @@
         "node_modules/graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "node_modules/growly": {
             "version": "1.3.0",
@@ -5843,17 +5246,6 @@
             "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
             "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
             "dev": true
-        },
-        "node_modules/has-bigints": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -5868,6 +5260,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
             "dependencies": {
                 "es-define-property": "^1.0.0"
             },
@@ -5879,20 +5272,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "dependencies": {
-                "has-symbols": "^1.0.3"
-            },
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5933,6 +5313,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -6148,9 +5529,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
             "dev": true,
             "dependencies": {
                 "@types/http-proxy": "^1.17.8",
@@ -6190,17 +5571,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/icheck-bootstrap/-/icheck-bootstrap-3.0.1.tgz",
             "integrity": "sha512-Rj3SybdcMcayhsP4IJ+hmCNgCKclaFcs/5zwCuLXH1WMo468NegjhZVxbSNKhEjJjnwc4gKETogUmPYSQ9lEZQ=="
-        },
-        "node_modules/iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "dependencies": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
         },
         "node_modules/icss-utils": {
             "version": "5.1.0",
@@ -6261,14 +5631,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/imagesloaded": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.4.tgz",
-            "integrity": "sha512-ltiBVcYpc/TYTF5nolkMNsnREHW+ICvfQ3Yla2Sgr71YFwQ86bDwV9hgpFhFtrGPuwEx5+LqOHIrdXBdoWwwsA==",
-            "dependencies": {
-                "ev-emitter": "^1.0.0"
-            }
-        },
         "node_modules/img-loader": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-4.0.0.tgz",
@@ -6309,11 +5671,6 @@
             "engines": {
                 "node": ">=4.0.0"
             }
-        },
-        "node_modules/immediate": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
         },
         "node_modules/immutable": {
             "version": "5.0.3",
@@ -6370,25 +5727,8 @@
         "node_modules/inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/inputmask": {
-            "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
-            "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ=="
-        },
-        "node_modules/internal-slot": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "hasown": "^2.0.2",
-                "side-channel": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "node_modules/interpret": {
             "version": "2.2.0",
@@ -6397,14 +5737,6 @@
             "dev": true,
             "engines": {
                 "node": ">= 0.10"
-            }
-        },
-        "node_modules/ion-rangeslider": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/ion-rangeslider/-/ion-rangeslider-2.3.1.tgz",
-            "integrity": "sha512-6V+24FD13/feliI485gnRHZYD9Ev64M5NAFTxnVib516ATHa9PlXQrC+nOiPngouRYTCLPJyokAJEi3e1Umi5g==",
-            "peerDependencies": {
-                "jquery": ">=1.8"
             }
         },
         "node_modules/ipaddr.js": {
@@ -6416,56 +5748,11 @@
                 "node": ">= 10"
             }
         },
-        "node_modules/is-arguments": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-array-buffer": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
-        },
-        "node_modules/is-bigint": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-            "dependencies": {
-                "has-bigints": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -6479,37 +5766,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/is-boolean-object": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-            "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
-        },
-        "node_modules/is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -6518,21 +5779,6 @@
             "dev": true,
             "dependencies": {
                 "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-date-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -6586,17 +5832,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -6604,21 +5839,6 @@
             "dev": true,
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-number-object": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-plain-obj": {
@@ -6645,48 +5865,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/is-regex": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-set": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-shared-array-buffer": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-            "dependencies": {
-                "call-bound": "^1.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -6697,63 +5875,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/is-string": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-symbol": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "has-symbols": "^1.1.0",
-                "safe-regex-test": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakmap": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-weakset": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-            "dependencies": {
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-wsl": {
@@ -6771,7 +5892,8 @@
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -6820,56 +5942,8 @@
         "node_modules/jquery": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
-        },
-        "node_modules/jquery-knob-chif": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/jquery-knob-chif/-/jquery-knob-chif-1.2.13.tgz",
-            "integrity": "sha512-dveq9MZCr68bRrsziuRusKS+/ciT1yOOHdENOSTcXVRM9MsEyCK/DjqR9nc7V3on41269PFdDE2Fuib8Cw4jAA=="
-        },
-        "node_modules/jquery-mapael": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/jquery-mapael/-/jquery-mapael-2.2.0.tgz",
-            "integrity": "sha512-B5cVcCkfs7Ezia1Zs8bEfVacYD/GvaASyqQeidApR/NJ1C4igcExk9VULVsgLcTPkxohcZrrz5uCaPXvuKeZWw==",
-            "dependencies": {
-                "jquery": "^3.0 || ^2.0 || ^1.0",
-                "raphael": "^2.2.0 || ^2.1.1"
-            },
-            "optionalDependencies": {
-                "jquery-mousewheel": "^3.1"
-            },
-            "peerDependencies": {
-                "jquery": "^3.0 || ^2.0 || ^1.0"
-            }
-        },
-        "node_modules/jquery-mousewheel": {
-            "version": "3.1.13",
-            "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",
-            "integrity": "sha512-GXhSjfOPyDemM005YCEHvzrEALhKDIswtxSHSR2e4K/suHVJKJxxRCGz3skPjNxjJjQa9AVSGGlYjv1M3VLIPg=="
-        },
-        "node_modules/jquery-ui-dist": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.13.3.tgz",
-            "integrity": "sha512-qeTR3SOSQ0jgxaNXSFU6+JtxdzNUSJKgp8LCzVrVKntM25+2YBJW1Ea8B2AwjmmSHfPLy2dSlZxJQN06OfVFhg==",
-            "dependencies": {
-                "jquery": ">=1.8.0 <4.0.0"
-            }
-        },
-        "node_modules/jquery-validation": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.21.0.tgz",
-            "integrity": "sha512-xNot0rlUIgu7duMcQ5qb6MGkGL/Z1PQaRJQoZAURW9+a/2PGOUxY36o/WyNeP2T9R6jvWB8Z9lUVvvQWI/Zs5w==",
-            "peerDependencies": {
-                "jquery": "^1.7 || ^2.0 || ^3.1"
-            }
-        },
-        "node_modules/jqvmap-novulnerability": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/jqvmap-novulnerability/-/jqvmap-novulnerability-1.5.1.tgz",
-            "integrity": "sha512-O6Jr7AGiut9iNJMelPdy8pH83tNXadOqmhJm5FZy9gtaZ5uuhZK3VNu+YLFuTpXeZI8YXUvlFUYbJJi5XHA+tw==",
-            "dependencies": {
-                "jquery": "^3.4.0"
-            }
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "dev": true
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
@@ -6888,11 +5962,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/jsgrid": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/jsgrid/-/jsgrid-1.5.3.tgz",
-            "integrity": "sha512-/BJgQp7gZe8o/VgNelwXc21jHc9HN+l7WPOkBhC9b9jPXFtOrU9ftNLPVBmKYCNlIulAbGTW8SDJI0mpw7uWxQ=="
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -6922,22 +5991,12 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
             "dependencies": {
                 "universalify": "^2.0.0"
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/jszip": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-            "dependencies": {
-                "lie": "~3.3.0",
-                "pako": "~1.0.2",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "^1.0.5"
             }
         },
         "node_modules/junk": {
@@ -7066,14 +6125,6 @@
                 "shell-quote": "^1.8.1"
             }
         },
-        "node_modules/lie": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-            "dependencies": {
-                "immediate": "~3.0.5"
-            }
-        },
         "node_modules/lilconfig": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
@@ -7081,23 +6132,6 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/linebreak": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
-            "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
-            "dependencies": {
-                "base64-js": "0.0.8",
-                "unicode-trie": "^2.0.0"
-            }
-        },
-        "node_modules/linebreak/node_modules/base64-js": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-            "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
-            "engines": {
-                "node": ">= 0.4"
             }
         },
         "node_modules/lines-and-columns": {
@@ -7183,6 +6217,15 @@
                 "yallist": "^3.0.2"
             }
         },
+        "node_modules/magic-string": {
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "dev": true,
+            "dependencies": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
         "node_modules/make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -7211,6 +6254,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -7443,25 +6487,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/moment": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/moment-timezone": {
-            "version": "0.5.46",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
-            "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
-            "dependencies": {
-                "moment": "^2.29.4"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -7482,9 +6507,9 @@
             }
         },
         "node_modules/nanoid": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "dev": true,
             "funding": [
                 {
@@ -7649,21 +6674,7 @@
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
             "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "dependencies": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            },
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             },
@@ -7675,6 +6686,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.4"
             }
@@ -7683,6 +6695,7 @@
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
             "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+            "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -7772,11 +6785,6 @@
             "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
             "dev": true
         },
-        "node_modules/overlayscrollbars": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.3.tgz",
-            "integrity": "sha512-1nB/B5kaakJuHXaLXLRK0bUIilWhUGT6q5g+l2s5vqYdLle/sd0kscBHkQC1kuuDg9p9WR4MTdySDOPbeL/86g=="
-        },
         "node_modules/p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -7841,7 +6849,8 @@
         "node_modules/pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
         },
         "node_modules/param-case": {
             "version": "3.0.4",
@@ -7989,32 +6998,6 @@
                 "node": ">=0.12"
             }
         },
-        "node_modules/pdfkit": {
-            "version": "0.12.3",
-            "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.12.3.tgz",
-            "integrity": "sha512-+qDLgm2yq6WOKcxTb43lDeo3EtMIDQs0CK1RNqhHC9iT6u0KOmgwAClkYh9xFw2ATbmUZzt4f7KMwDCOfPDluA==",
-            "dependencies": {
-                "crypto-js": "^4.0.0",
-                "fontkit": "^1.8.1",
-                "linebreak": "^1.0.2",
-                "png-js": "^1.0.0"
-            }
-        },
-        "node_modules/pdfmake": {
-            "version": "0.1.72",
-            "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.1.72.tgz",
-            "integrity": "sha512-xZrPS+Safjf1I8ZYtMoXX83E6C6Pd1zFwa168yNTeeJWHclqf1z9DoYajjlY2uviN7gGyxwVZeou39uSk1oh1g==",
-            "dependencies": {
-                "iconv-lite": "^0.6.2",
-                "linebreak": "^1.0.2",
-                "pdfkit": "^0.12.0",
-                "svg-to-pdfkit": "^0.1.8",
-                "xmldoc": "^1.1.2"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8045,33 +7028,21 @@
                 "node": ">=8"
             }
         },
-        "node_modules/png-js": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-            "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
-        },
         "node_modules/popper.js": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
             "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
             "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
+            "dev": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
             }
         },
-        "node_modules/possible-typed-array-names": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-            "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/postcss": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-            "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+            "version": "8.5.5",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
+            "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
             "dev": true,
             "funding": [
                 {
@@ -8088,7 +7059,7 @@
                 }
             ],
             "dependencies": {
-                "nanoid": "^3.3.8",
+                "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -8656,22 +7627,6 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
-        "node_modules/prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-            "dev": true,
-            "optional": true,
-            "bin": {
-                "prettier": "bin-prettier.js"
-            },
-            "engines": {
-                "node": ">=10.13.0"
-            },
-            "funding": {
-                "url": "https://github.com/prettier/prettier?sponsor=1"
-            }
-        },
         "node_modules/pretty-time": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
@@ -8693,7 +7648,8 @@
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
@@ -8821,14 +7777,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/raphael": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
-            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
-            "dependencies": {
-                "eve-raphael": "0.5.0"
-            }
-        },
         "node_modules/raw-body": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -8860,6 +7808,7 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -8873,12 +7822,14 @@
         "node_modules/readable-stream/node_modules/safe-buffer": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+            "dev": true
         },
         "node_modules/readable-stream/node_modules/string_decoder": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
@@ -8925,12 +7876,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "dev": true
-        },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
@@ -8945,25 +7890,6 @@
             "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.0.tgz",
             "integrity": "sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==",
             "dev": true
-        },
-        "node_modules/regexp.prototype.flags": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-            "dependencies": {
-                "call-bind": "^1.0.8",
-                "define-properties": "^1.2.1",
-                "es-errors": "^1.3.0",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "set-function-name": "^2.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
         },
         "node_modules/regexpu-core": {
             "version": "6.2.0",
@@ -9126,11 +8052,6 @@
             "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
             "dev": true
         },
-        "node_modules/restructure": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
-            "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg=="
-        },
         "node_modules/retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -9219,26 +8140,11 @@
                 }
             ]
         },
-        "node_modules/safe-regex-test": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-            "dependencies": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "is-regex": "^1.2.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "node_modules/sass": {
             "version": "1.83.4",
@@ -9343,11 +8249,6 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
-        "node_modules/sax": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
-        },
         "node_modules/schema-utils": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -9371,11 +8272,6 @@
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
             "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
             "dev": true
-        },
-        "node_modules/select2": {
-            "version": "4.0.13",
-            "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
-            "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
         },
         "node_modules/selfsigned": {
             "version": "2.4.1",
@@ -9556,6 +8452,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
             "dependencies": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -9568,24 +8465,11 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/set-function-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "dependencies": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
-        },
         "node_modules/setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
@@ -9661,6 +8545,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3",
@@ -9679,6 +8564,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3"
@@ -9694,6 +8580,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -9711,6 +8598,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
             "dependencies": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -9785,11 +8673,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "node_modules/sparklines": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/sparklines/-/sparklines-1.3.0.tgz",
-            "integrity": "sha512-CkFtpDE3hmOeu1IJyIQIOH0AQtHnPj1c61ALxJZQ9cPEFKDgWC1fcNAHuwPi1i1klTDYvlKKseoYHSwe7JmdLA=="
-        },
         "node_modules/spdy": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -9855,18 +8738,6 @@
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
             "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
             "dev": true
-        },
-        "node_modules/stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "dependencies": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            }
         },
         "node_modules/stream-browserify": {
             "version": "2.0.2",
@@ -9989,12 +8860,6 @@
                 "postcss": "^8.2.15"
             }
         },
-        "node_modules/summernote": {
-            "version": "0.8.20",
-            "resolved": "https://registry.npmjs.org/summernote/-/summernote-0.8.20.tgz",
-            "integrity": "sha512-W9RhjQjsn+b1s9xiJQgJbCiYGJaDAc9CdEqXo+D13WuStG8lCdtKaO5AiNiSSMJsQJN2EfGSwbBQt+SFE2B8Kw==",
-            "hasInstallScript": true
-        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10019,14 +8884,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/svg-to-pdfkit": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz",
-            "integrity": "sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==",
-            "dependencies": {
-                "pdfkit": ">=0.8.1"
-            }
-        },
         "node_modules/svgo": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -10048,14 +8905,6 @@
                 "node": ">=10.13.0"
             }
         },
-        "node_modules/sweetalert2": {
-            "version": "10.16.11",
-            "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.16.11.tgz",
-            "integrity": "sha512-Rdfabv2G89Tr8vmUTb1auWCYYesKBEWnkYPSi7XaiCIW0ZXXGK8Nw1wYKPEMLU6O8gMSMJe5m6MRKqMQsAQy9A==",
-            "funding": {
-                "url": "https://sweetalert2.github.io/#donations"
-            }
-        },
         "node_modules/tapable": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
@@ -10063,51 +8912,6 @@
             "dev": true,
             "engines": {
                 "node": ">=6"
-            }
-        },
-        "node_modules/tempusdominus-bootstrap-4": {
-            "version": "5.39.2",
-            "resolved": "https://registry.npmjs.org/tempusdominus-bootstrap-4/-/tempusdominus-bootstrap-4-5.39.2.tgz",
-            "integrity": "sha512-8Au4miSAsMGdsElPg87EUmsN7aGJFaRA5Y8Ale7dDTfhhnQL1Za53LclIJkq+t/7NO5+Ufr1jY7tmEPvWGHaVg==",
-            "dependencies": {
-                "bootstrap": "^4.6.1",
-                "jquery": "^3.6.0",
-                "moment": "^2.29.2",
-                "moment-timezone": "^0.5.34",
-                "popper.js": "^1.16.1"
-            },
-            "peerDependencies": {
-                "bootstrap": ">=4.5.2",
-                "jquery": "^3.5.1",
-                "moment": "^2.29.0",
-                "moment-timezone": "^0.5.31",
-                "popper.js": "^1.16.1",
-                "tempusdominus-core": "5.19.3"
-            }
-        },
-        "node_modules/tempusdominus-core": {
-            "version": "5.19.3",
-            "resolved": "https://registry.npmjs.org/tempusdominus-core/-/tempusdominus-core-5.19.3.tgz",
-            "integrity": "sha512-WXBVXcBG/hErB6u9gdUs+vzANvCU1kd1ykzL4kolPB3h1OEv20OKUW5qz1iynxyqRFPa1NWY9gwRu5d+MjXEuQ==",
-            "peer": true,
-            "dependencies": {
-                "jquery": "^3.6.0",
-                "moment": "~2.29.2",
-                "moment-timezone": "^0.5.34"
-            },
-            "peerDependencies": {
-                "jquery": "^3.0",
-                "moment": "^2.29.2",
-                "moment-timezone": "^0.5.0"
-            }
-        },
-        "node_modules/tempusdominus-core/node_modules/moment": {
-            "version": "2.29.4",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-            "peer": true,
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/terser": {
@@ -10239,11 +9043,6 @@
                 "node": ">=0.6.0"
             }
         },
-        "node_modules/tiny-inflate": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
-        },
         "node_modules/to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -10262,14 +9061,6 @@
                 "node": ">=8.0"
             }
         },
-        "node_modules/toastr": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/toastr/-/toastr-2.1.4.tgz",
-            "integrity": "sha512-LIy77F5n+sz4tefMmFOntcJ6HL0Fv3k1TDnNmFZ0bU/GcvIIfy6eG2v7zQmMiYgaalAiUv75ttFrPn5s0gyqlA==",
-            "dependencies": {
-                "jquery": ">=1.12.0"
-            }
-        },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -10282,7 +9073,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true
         },
         "node_modules/tty-browserify": {
             "version": "0.0.0",
@@ -10340,15 +9132,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/unicode-properties": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-            "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-            "dependencies": {
-                "base64-js": "^1.3.0",
-                "unicode-trie": "^2.0.0"
-            }
-        },
         "node_modules/unicode-property-aliases-ecmascript": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
@@ -10358,24 +9141,11 @@
                 "node": ">=4"
             }
         },
-        "node_modules/unicode-trie": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-            "dependencies": {
-                "pako": "^0.2.5",
-                "tiny-inflate": "^1.0.0"
-            }
-        },
-        "node_modules/unicode-trie/node_modules/pako": {
-            "version": "0.2.9",
-            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-            "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
-        },
         "node_modules/universalify": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
             "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true,
             "engines": {
                 "node": ">= 10.0.0"
             }
@@ -10418,11 +9188,6 @@
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
             }
-        },
-        "node_modules/uplot": {
-            "version": "1.6.31",
-            "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
-            "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -10467,7 +9232,8 @@
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
         },
         "node_modules/util/node_modules/inherits": {
             "version": "2.0.3",
@@ -10509,14 +9275,24 @@
             "dev": true
         },
         "node_modules/vue": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-            "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
-            "deprecated": "Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.",
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.16.tgz",
+            "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
             "dev": true,
             "dependencies": {
-                "@vue/compiler-sfc": "2.7.16",
-                "csstype": "^3.1.0"
+                "@vue/compiler-dom": "3.5.16",
+                "@vue/compiler-sfc": "3.5.16",
+                "@vue/runtime-dom": "3.5.16",
+                "@vue/server-renderer": "3.5.16",
+                "@vue/shared": "3.5.16"
+            },
+            "peerDependencies": {
+                "typescript": "*"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/vue-loader": {
@@ -10584,14 +9360,20 @@
             }
         },
         "node_modules/vue-template-compiler": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-0.1.0.tgz",
+            "integrity": "sha512-Y/kgG0p3Co10OEjlhAtHrEzPFgJvWqkMm0xqFsjFpytZ499Q/KqkkYTfeB7ghty+nEdrzOXd++glw3CyxGnmYg==",
             "dev": true,
             "dependencies": {
                 "de-indent": "^1.0.2",
-                "he": "^1.2.0"
+                "entities": "^1.1.1"
             }
+        },
+        "node_modules/vue-template-compiler/node_modules/entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+            "dev": true
         },
         "node_modules/watchpack": {
             "version": "2.4.2",
@@ -11021,60 +9803,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/which-boxed-primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-            "dependencies": {
-                "is-bigint": "^1.1.0",
-                "is-boolean-object": "^1.2.1",
-                "is-number-object": "^1.1.1",
-                "is-string": "^1.1.1",
-                "is-symbol": "^1.1.1"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-collection": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-            "dependencies": {
-                "is-map": "^2.0.3",
-                "is-set": "^2.0.3",
-                "is-weakmap": "^2.0.2",
-                "is-weakset": "^2.0.3"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/which-typed-array": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-            "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
-            "dependencies": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "for-each": "^0.3.3",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2"
-            },
-            "engines": {
-                "node": ">= 0.4"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
-            }
-        },
         "node_modules/wildcard": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -11123,14 +9851,6 @@
                 "utf-8-validate": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/xmldoc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.3.0.tgz",
-            "integrity": "sha512-y7IRWW6PvEnYQZNZFMRLNJw+p3pezM4nKYPfr15g4OOW9i8VpeydycFuipE2297OvZnh3jSb2pxOt9QpkZUVng==",
-            "dependencies": {
-                "sax": "^1.2.4"
             }
         },
         "node_modules/xtend": {
@@ -11206,14 +9926,14 @@
             }
         },
         "@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             }
         },
         "@babel/compat-data": {
@@ -11430,15 +10150,15 @@
             }
         },
         "@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "dev": true
         },
         "@babel/helper-validator-option": {
@@ -11459,22 +10179,22 @@
             }
         },
         "@babel/helpers": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.0.tgz",
-            "integrity": "sha512-tbhNuIxNcVb21pInl3ZSjksLCvgdZy9KwJ8brv993QtIVKJBBkYXz4q4ZbAv31GdnC+R90np23L5FbEBlthAEw==",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.6.tgz",
+            "integrity": "sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.25.9",
-                "@babel/types": "^7.26.0"
+                "@babel/template": "^7.27.2",
+                "@babel/types": "^7.27.6"
             }
         },
         "@babel/parser": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.5.tgz",
-            "integrity": "sha512-SRJ4jYmXRqV1/Xc+TIVG84WjHBXKlxO9sHQnA2Pf12QQEAp1LOh6kDzNHXcUnbH1QI0FDoPPVOt+vyUDucxpaw==",
+            "version": "7.27.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+            "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.26.5"
+                "@babel/types": "^7.27.3"
             }
         },
         "@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
@@ -12198,23 +10918,20 @@
             }
         },
         "@babel/runtime": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-            "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
-            "dev": true,
-            "requires": {
-                "regenerator-runtime": "^0.14.0"
-            }
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
+            "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+            "dev": true
         },
         "@babel/template": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.25.9.tgz",
-            "integrity": "sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==",
+            "version": "7.27.2",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.25.9",
-                "@babel/parser": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.2",
+                "@babel/types": "^7.27.1"
             }
         },
         "@babel/traverse": {
@@ -12233,13 +10950,13 @@
             }
         },
         "@babel/types": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.5.tgz",
-            "integrity": "sha512-L6mZmwFDK6Cjh1nRCLXpa6no13ZIioJDz7mdkzHv399pThrTa/k0nUlNaenOeh2kWu/iaOQYElEpKPUswUa9Vg==",
+            "version": "7.27.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.6.tgz",
+            "integrity": "sha512-ETyHEk2VHHvl9b9jZP5IHPavHYk57EhanlRRuae9XCpb/j5bDCbPPMOBfCWhnl/7EDJz0jEMCi/RhccCE8r1+Q==",
             "dev": true,
             "requires": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
             }
         },
         "@bcgov/bc-sans": {
@@ -12319,11 +11036,6 @@
             "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
             "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
             "dev": true
-        },
-        "@lgaitan/pace-progress": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@lgaitan/pace-progress/-/pace-progress-1.0.7.tgz",
-            "integrity": "sha512-GMoTcF6WBpno7a7Iyx7M79os26d5bCDbh7YTZmXZM8YuLR3DDtwo0/CBYddStGD6QIBTieFDz4IAQiO0dAdRGw=="
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -12468,29 +11180,18 @@
             "dev": true,
             "optional": true
         },
-        "@swc/helpers": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.3.17.tgz",
-            "integrity": "sha512-tb7Iu+oZ+zWJZ3HJqwx8oNwSDIU440hmVMDPhpACWQWnrZHK99Bxs70gT1L2dnr5Hg50ZRWEFkQCAnOVVV0z1Q==",
-            "requires": {
-                "tslib": "^2.4.0"
-            }
-        },
-        "@sweetalert2/theme-bootstrap-4": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/@sweetalert2/theme-bootstrap-4/-/theme-bootstrap-4-4.0.5.tgz",
-            "integrity": "sha512-pe5mQ98sgrphNVq6Xe5BsWxsfI1Z8zT9C2oux6+4B6Qt30qYo58Q+bnzRs8pV95O9/URt/QJZyl+R8SabMeW6g=="
+        "@popperjs/core": {
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+            "dev": true,
+            "peer": true
         },
         "@trysound/sax": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
             "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
             "dev": true
-        },
-        "@ttskch/select2-bootstrap4-theme": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/@ttskch/select2-bootstrap4-theme/-/select2-bootstrap4-theme-1.5.2.tgz",
-            "integrity": "sha512-gAj8qNy/VYwQDBkACm0USM66kxFai8flX83ayRXPNhzZckEgSqIBB9sM74SCM3ssgeX+ZVy4BifTnLis+KpIyg=="
         },
         "@types/babel__core": {
             "version": "7.20.5",
@@ -12830,17 +11531,110 @@
                 "@types/node": "*"
             }
         },
-        "@vue/compiler-sfc": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.16.tgz",
-            "integrity": "sha512-KWhJ9k5nXuNtygPU7+t1rX6baZeqOYLEforUPjgNDBnLicfHCoi48H87Q8XyLZOrNNsmhuwKqtpDQWjEFe6Ekg==",
+        "@vue/compiler-core": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.16.tgz",
+            "integrity": "sha512-AOQS2eaQOaaZQoL1u+2rCJIKDruNXVBZSiUD3chnUrsoX5ZTQMaCvXlWNIfxBJuU15r1o7+mpo5223KVtIhAgQ==",
             "dev": true,
             "requires": {
-                "@babel/parser": "^7.23.5",
-                "postcss": "^8.4.14",
-                "prettier": "^1.18.2 || ^2.0.0",
-                "source-map": "^0.6.1"
+                "@babel/parser": "^7.27.2",
+                "@vue/shared": "3.5.16",
+                "entities": "^4.5.0",
+                "estree-walker": "^2.0.2",
+                "source-map-js": "^1.2.1"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "4.5.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+                    "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+                    "dev": true
+                }
             }
+        },
+        "@vue/compiler-dom": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.16.tgz",
+            "integrity": "sha512-SSJIhBr/teipXiXjmWOVWLnxjNGo65Oj/8wTEQz0nqwQeP75jWZ0n4sF24Zxoht1cuJoWopwj0J0exYwCJ0dCQ==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-core": "3.5.16",
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "@vue/compiler-sfc": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.16.tgz",
+            "integrity": "sha512-rQR6VSFNpiinDy/DVUE0vHoIDUF++6p910cgcZoaAUm3POxgNOOdS/xgoll3rNdKYTYPnnbARDCZOyZ+QSe6Pw==",
+            "dev": true,
+            "requires": {
+                "@babel/parser": "^7.27.2",
+                "@vue/compiler-core": "3.5.16",
+                "@vue/compiler-dom": "3.5.16",
+                "@vue/compiler-ssr": "3.5.16",
+                "@vue/shared": "3.5.16",
+                "estree-walker": "^2.0.2",
+                "magic-string": "^0.30.17",
+                "postcss": "^8.5.3",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "@vue/compiler-ssr": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.16.tgz",
+            "integrity": "sha512-d2V7kfxbdsjrDSGlJE7my1ZzCXViEcqN6w14DOsDrUCHEA6vbnVCpRFfrc4ryCP/lCKzX2eS1YtnLE/BuC9f/A==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-dom": "3.5.16",
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "@vue/reactivity": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.16.tgz",
+            "integrity": "sha512-FG5Q5ee/kxhIm1p2bykPpPwqiUBV3kFySsHEQha5BJvjXdZTUfmya7wP7zC39dFuZAcf/PD5S4Lni55vGLMhvA==",
+            "dev": true,
+            "requires": {
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "@vue/runtime-core": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.16.tgz",
+            "integrity": "sha512-bw5Ykq6+JFHYxrQa7Tjr+VSzw7Dj4ldR/udyBZbq73fCdJmyy5MPIFR9IX/M5Qs+TtTjuyUTCnmK3lWWwpAcFQ==",
+            "dev": true,
+            "requires": {
+                "@vue/reactivity": "3.5.16",
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "@vue/runtime-dom": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.16.tgz",
+            "integrity": "sha512-T1qqYJsG2xMGhImRUV9y/RseB9d0eCYZQ4CWca9ztCuiPj/XWNNN+lkNBuzVbia5z4/cgxdL28NoQCvC0Xcfww==",
+            "dev": true,
+            "requires": {
+                "@vue/reactivity": "3.5.16",
+                "@vue/runtime-core": "3.5.16",
+                "@vue/shared": "3.5.16",
+                "csstype": "^3.1.3"
+            }
+        },
+        "@vue/server-renderer": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.16.tgz",
+            "integrity": "sha512-BrX0qLiv/WugguGsnQUJiYOE0Fe5mZTwi6b7X/ybGB0vfrPH9z0gD/Y6WOR1sGCgX4gc25L1RYS5eYQKDMoNIg==",
+            "dev": true,
+            "requires": {
+                "@vue/compiler-ssr": "3.5.16",
+                "@vue/shared": "3.5.16"
+            }
+        },
+        "@vue/shared": {
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.16.tgz",
+            "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg==",
+            "dev": true
         },
         "@webassemblyjs/ast": {
             "version": "1.14.1",
@@ -13058,72 +11852,9 @@
             }
         },
         "admin-lte": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-3.1.0.tgz",
-            "integrity": "sha512-JkmmkjbGgB5RCPwpaUCEktpZz/Ez/vBdfCNx8J3u8doaRRUUV1/oj4PuIiOV+xrNMt05q87131xoGySr/eA4uA==",
-            "requires": {
-                "@fortawesome/fontawesome-free": "^5.15.3",
-                "@lgaitan/pace-progress": "^1.0.7",
-                "@sweetalert2/theme-bootstrap-4": "^4.0.3",
-                "@ttskch/select2-bootstrap4-theme": "^1.5.2",
-                "bootstrap": "^4.6.0",
-                "bootstrap-colorpicker": "^3.2.0",
-                "bootstrap-slider": "^11.0.2",
-                "bootstrap-switch": "3.3.4",
-                "bootstrap4-duallistbox": "^4.0.2",
-                "bs-custom-file-input": "^1.3.4",
-                "bs-stepper": "^1.7.0",
-                "chart.js": "^2.9.4",
-                "codemirror": "^5.60.0",
-                "datatables.net": "^1.10.24",
-                "datatables.net-autofill-bs4": "^2.3.5",
-                "datatables.net-bs4": "^1.10.24",
-                "datatables.net-buttons-bs4": "^1.7.0",
-                "datatables.net-colreorder-bs4": "^1.5.3",
-                "datatables.net-fixedcolumns-bs4": "^3.3.2",
-                "datatables.net-fixedheader-bs4": "^3.1.8",
-                "datatables.net-keytable-bs4": "^2.6.1",
-                "datatables.net-responsive-bs4": "^2.2.7",
-                "datatables.net-rowgroup-bs4": "^1.1.2",
-                "datatables.net-rowreorder-bs4": "^1.2.7",
-                "datatables.net-scroller-bs4": "^2.0.3",
-                "datatables.net-searchbuilder-bs4": "^1.0.1",
-                "datatables.net-searchpanes-bs4": "^1.2.2",
-                "datatables.net-select-bs4": "^1.3.2",
-                "daterangepicker": "^3.1.0",
-                "dropzone": "^5.8.1",
-                "ekko-lightbox": "^5.3.0",
-                "fastclick": "^1.0.6",
-                "filterizr": "^2.2.4",
-                "flag-icon-css": "^3.5.0",
-                "flot": "^4.2.2",
-                "fs-extra": "^9.1.0",
-                "fullcalendar": "^5.5.1",
-                "icheck-bootstrap": "^3.0.1",
-                "inputmask": "^5.0.5",
-                "ion-rangeslider": "^2.3.1",
-                "jquery": "^3.6.0",
-                "jquery-knob-chif": "^1.2.13",
-                "jquery-mapael": "^2.2.0",
-                "jquery-mousewheel": "^3.1.13",
-                "jquery-ui-dist": "^1.12.1",
-                "jquery-validation": "^1.19.3",
-                "jqvmap-novulnerability": "^1.5.1",
-                "jsgrid": "^1.5.3",
-                "jszip": "^3.6.0",
-                "moment": "^2.29.1",
-                "overlayscrollbars": "^1.13.1",
-                "pdfmake": "^0.1.70",
-                "popper.js": "^1.16.1",
-                "raphael": "^2.3.0",
-                "select2": "^4.0.13",
-                "sparklines": "^1.3.0",
-                "summernote": "^0.8.18",
-                "sweetalert2": "^10.15.6",
-                "tempusdominus-bootstrap-4": "^5.39.0",
-                "toastr": "^2.1.4",
-                "uplot": "^1.6.7"
-            }
+            "version": "4.0.0-beta3",
+            "resolved": "https://registry.npmjs.org/admin-lte/-/admin-lte-4.0.0-beta3.tgz",
+            "integrity": "sha512-q2VoAOu1DtZ7z41M2gQ05VMNYkFCAMxFU+j/HUMwCOlr/e3VhO+qww2SGJw4OxBw5nZQ7YV78+wK2RiB7ConzQ=="
         },
         "ajv": {
             "version": "6.12.6",
@@ -13215,15 +11946,6 @@
                 "picomatch": "^2.0.4"
             }
         },
-        "array-buffer-byte-length": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
-            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
-            "requires": {
-                "call-bound": "^1.0.3",
-                "is-array-buffer": "^3.0.5"
-            }
-        },
         "array-flatten": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -13288,11 +12010,6 @@
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "dev": true
         },
-        "at-least-node": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
-        },
         "autoprefixer": {
             "version": "10.4.20",
             "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -13305,14 +12022,6 @@
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.1",
                 "postcss-value-parser": "^4.2.0"
-            }
-        },
-        "available-typed-arrays": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
-            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
-            "requires": {
-                "possible-typed-array-names": "^1.0.0"
             }
         },
         "axios": {
@@ -13385,7 +12094,8 @@
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+            "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+            "dev": true
         },
         "batch": {
             "version": "0.6.1",
@@ -13483,41 +12193,16 @@
             "dev": true
         },
         "bootstrap": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.2.tgz",
-            "integrity": "sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+            "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+            "dev": true,
             "requires": {}
-        },
-        "bootstrap-colorpicker": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/bootstrap-colorpicker/-/bootstrap-colorpicker-3.4.0.tgz",
-            "integrity": "sha512-7vA0hvLrat3ptobEKlT9+6amzBUJcDAoh6hJRQY/AD+5dVZYXXf1ivRfrTwmuwiVLJo9rZwM8YB4lYzp6agzqg==",
-            "requires": {
-                "bootstrap": ">=4.0",
-                "jquery": ">=2.2",
-                "popper.js": ">=1.10"
-            }
-        },
-        "bootstrap-slider": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/bootstrap-slider/-/bootstrap-slider-11.0.2.tgz",
-            "integrity": "sha512-CdwS+Z6X79OkLes9RfDgPB9UIY/+81wTkm6ktdSB6hdyiRbjJLFQIjZdnEr55tDyXZfgC7U6yeSXkNN9ZdGqjA=="
-        },
-        "bootstrap-switch": {
-            "version": "3.3.4",
-            "resolved": "https://registry.npmjs.org/bootstrap-switch/-/bootstrap-switch-3.3.4.tgz",
-            "integrity": "sha512-7YQo+Ir6gCUqC36FFp1Zvec5dRF/+obq+1drMtdIMi9Xc84Kx63Evi0kdcp4HfiGsZpiz6IskyYDNlSKcxsL7w==",
-            "requires": {}
-        },
-        "bootstrap4-duallistbox": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/bootstrap4-duallistbox/-/bootstrap4-duallistbox-4.0.2.tgz",
-            "integrity": "sha512-vQdANVE2NN0HMaZO9qWJy0C7u04uTpAmtUGO3KLq3xAZKCboJweQ437hDTszI6pbYV2olJCGZMbdhvIkBNGeGQ=="
         },
         "brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "requires": {
                 "balanced-match": "^1.0.0",
@@ -13538,14 +12223,6 @@
             "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
             "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
             "dev": true
-        },
-        "brotli": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
-            "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
-            "requires": {
-                "base64-js": "^1.1.2"
-            }
         },
         "browserify-aes": {
             "version": "1.2.0",
@@ -13634,16 +12311,6 @@
                 "update-browserslist-db": "^1.1.1"
             }
         },
-        "bs-custom-file-input": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/bs-custom-file-input/-/bs-custom-file-input-1.3.4.tgz",
-            "integrity": "sha512-NBsQzTnef3OW1MvdKBbMHAYHssCd613MSeJV7z2McXznWtVMnJCy7Ckyc+PwxV6Pk16cu6YBcYWh/ZE0XWNKCA=="
-        },
-        "bs-stepper": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/bs-stepper/-/bs-stepper-1.7.0.tgz",
-            "integrity": "sha512-+DX7UKKgw2GI6ucsSCRd19VHYrxf/8znRCLs1lQVVLxz+h7EqgIOxoHcJ0/QTaaNoR9Cwg78ydo6hXIasyd3LA=="
-        },
         "buffer": {
             "version": "4.9.2",
             "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
@@ -13683,6 +12350,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
             "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+            "dev": true,
             "requires": {
                 "call-bind-apply-helpers": "^1.0.0",
                 "es-define-property": "^1.0.0",
@@ -13694,6 +12362,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
             "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "dev": true,
             "requires": {
                 "es-errors": "^1.3.0",
                 "function-bind": "^1.1.2"
@@ -13703,6 +12372,7 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
             "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "dev": true,
             "requires": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "get-intrinsic": "^1.2.6"
@@ -13757,32 +12427,6 @@
             "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
             "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
             "dev": true
-        },
-        "chart.js": {
-            "version": "2.9.4",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
-            "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
-            "requires": {
-                "chartjs-color": "^2.1.0",
-                "moment": "^2.10.2"
-            }
-        },
-        "chartjs-color": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
-            "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
-            "requires": {
-                "chartjs-color-string": "^0.6.0",
-                "color-convert": "^1.9.3"
-            }
-        },
-        "chartjs-color-string": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
-            "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
-            "requires": {
-                "color-name": "^1.0.0"
-            }
         },
         "chokidar": {
             "version": "3.6.0",
@@ -13846,11 +12490,6 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
-        "clone": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
-        },
         "clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -13862,36 +12501,17 @@
                 "shallow-clone": "^3.0.0"
             }
         },
-        "codemirror": {
-            "version": "5.65.18",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.18.tgz",
-            "integrity": "sha512-Gaz4gHnkbHMGgahNt3CA5HBk5lLQBqmD/pBgeB4kQU6OedZmqMBjlRF0LSrp2tJ4wlLNPm2FfaUd1pDy0mdlpA=="
-        },
         "collect.js": {
             "version": "4.36.1",
             "resolved": "https://registry.npmjs.org/collect.js/-/collect.js-4.36.1.tgz",
             "integrity": "sha512-jd97xWPKgHn6uvK31V6zcyPd40lUJd7gpYxbN2VOVxGWO4tyvS9Li4EpsFjXepGTo2tYcOTC4a8YsbQXMJ4XUw==",
             "dev": true
         },
-        "color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "requires": {
-                "color-name": "1.1.3"
-            },
-            "dependencies": {
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-                }
-            }
-        },
         "color-name": {
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+            "dev": true
         },
         "colord": {
             "version": "2.9.3",
@@ -14059,7 +12679,8 @@
         "core-util-is": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+            "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+            "dev": true
         },
         "cosmiconfig": {
             "version": "7.1.0",
@@ -14155,11 +12776,6 @@
                 "randombytes": "^2.1.0",
                 "randomfill": "^1.0.4"
             }
-        },
-        "crypto-js": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
-            "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
         },
         "css-declaration-sorter": {
             "version": "6.4.1",
@@ -14315,347 +12931,6 @@
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
             "dev": true
         },
-        "datatables.net": {
-            "version": "1.13.11",
-            "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.11.tgz",
-            "integrity": "sha512-AE6RkMXziRaqzPcu/pl3SJXeRa6fmXQG/fVjuRESujvkzqDCYEeKTTpPMuVJSGYJpPi32WGSphVNNY1G4nSN/g==",
-            "requires": {
-                "jquery": "1.8 - 4"
-            }
-        },
-        "datatables.net-autofill": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-autofill/-/datatables.net-autofill-2.7.0.tgz",
-            "integrity": "sha512-zy7Jglke0VXu7RzyGYufMLLlSJkhr+rWJubBw0cozlaXtrqR2CNjY8LBBJA19GwBeoDCNrbojNge0YN8l44b8g==",
-            "requires": {
-                "datatables.net": ">=1.11",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-autofill-bs4": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-autofill-bs4/-/datatables.net-autofill-bs4-2.7.0.tgz",
-            "integrity": "sha512-vVMvZeioGhmvd7URJAvXnOYod/ZWKhCDsLB7Onw7SaJmeawf4CaY7lAU79ee0531Kf0FWuLOKlZcaEt8p1w4qQ==",
-            "requires": {
-                "datatables.net-autofill": "2.7.0",
-                "datatables.net-bs4": ">=1.11",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-bs4": {
-            "version": "1.13.11",
-            "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-1.13.11.tgz",
-            "integrity": "sha512-1LnxzQDFKpwvBETc8wtUtQ+pUXhs6NJomNST5pRzzHAccckkj9rZeOp3mevKDnDJKuNhBM1Y0rIeZGylJnqh9A==",
-            "requires": {
-                "datatables.net": "1.13.11",
-                "jquery": "1.8 - 4"
-            }
-        },
-        "datatables.net-buttons": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-buttons/-/datatables.net-buttons-1.7.1.tgz",
-            "integrity": "sha512-D2OxZeR18jhSx+l0xcfAJzfUH7l3LHCu0e606fV7+v3hMhphOfljjZYLaiRmGiR9lqO/f5xE/w2a+OtG/QMavw==",
-            "requires": {
-                "datatables.net": "^1.10.15",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-buttons-bs4": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-buttons-bs4/-/datatables.net-buttons-bs4-1.7.1.tgz",
-            "integrity": "sha512-s+fwsgAAWp7mOKwuztPH06kaw2JNAJ71VNTw/TqGQTL6BK9FshweDKZSRIB/ePcc/Psiy8fhNEj3XHxx4OO6BA==",
-            "requires": {
-                "datatables.net-bs4": "^1.10.15",
-                "datatables.net-buttons": "1.7.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-colreorder": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/datatables.net-colreorder/-/datatables.net-colreorder-1.7.2.tgz",
-            "integrity": "sha512-F8TYMFXtWLtsjciwS7hkP/Fbp3XS6WHuHLc+iMFtQqiQmbMo/59GK7YSxKuxSoqTTJU/opaPXQYjODnIuNEc/g==",
-            "requires": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-colreorder-bs4": {
-            "version": "1.7.2",
-            "resolved": "https://registry.npmjs.org/datatables.net-colreorder-bs4/-/datatables.net-colreorder-bs4-1.7.2.tgz",
-            "integrity": "sha512-iVlvHwD82ZCDuaDaAXsD6OukNjgWNe44+f0yu43a1bOwK1ncXYiBSohlEuIhynHnESexN2vg4saj4a0rEMNx+w==",
-            "requires": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-colreorder": "1.7.2",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-fixedcolumns": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedcolumns/-/datatables.net-fixedcolumns-3.3.3.tgz",
-            "integrity": "sha512-xo6MeI2xc/Ufk4ffrpao+OiPo8/GPB8cO80gA6NFgYBVw6eP9pPa2NsV+gSWRVr7d3A8iZC7mUZT5WdtliNHEA==",
-            "requires": {
-                "datatables.net": "^1.10.15",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-fixedcolumns-bs4": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedcolumns-bs4/-/datatables.net-fixedcolumns-bs4-3.3.3.tgz",
-            "integrity": "sha512-d0dqCYk93wnCT382hW2Y1YMwgJXpTfdTu3Tb+UKQvt7OApxKYuWUFfKde+wHtIhqodswZ1jrMfYmxZHJYAysZQ==",
-            "requires": {
-                "datatables.net-bs4": "^1.10.15",
-                "datatables.net-fixedcolumns": "3.3.3",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-fixedheader": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedheader/-/datatables.net-fixedheader-3.4.1.tgz",
-            "integrity": "sha512-c9FJAShG5r8RJDIszWQvMFe6Ie+njfbHB9GhzOPjEF7zhbsMUQEkoYq1qW3ppOxY5psadDrT+D3f4iGM589u6w==",
-            "requires": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-fixedheader-bs4": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-fixedheader-bs4/-/datatables.net-fixedheader-bs4-3.4.1.tgz",
-            "integrity": "sha512-Oq6yCpswdFRn+nwrjOjD0nmpH3F0glz/ppgdT8vA6U/8qkguze4d3qZyEYd7osqrCeX9ccUZR9ptpqRYb6sVtg==",
-            "requires": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-fixedheader": "3.4.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-keytable": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-keytable/-/datatables.net-keytable-2.12.1.tgz",
-            "integrity": "sha512-MR/qvBxVXld3i+YZfLAv/yCMvzh1trEIMpLo7YU0DP/CIWewHhkFeTS0G3tJgLjBes4v4tyR0Zjf6R9aMtMBEw==",
-            "requires": {
-                "datatables.net": ">=1.11.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-keytable-bs4": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-keytable-bs4/-/datatables.net-keytable-bs4-2.12.1.tgz",
-            "integrity": "sha512-7ZUNFTfbjeQl9w7Yu2G2zNs3UFpc07rpJm84AE43ecLg+pj7w9tXxRQlvkz4G1uL6DqkUswOBiCpySUy3R2QLw==",
-            "requires": {
-                "datatables.net-bs4": ">=1.11.0",
-                "datatables.net-keytable": "2.12.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-responsive": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-responsive/-/datatables.net-responsive-2.5.1.tgz",
-            "integrity": "sha512-hyJb2faIzEWUX5Yn4HOSq/6NNB9SXDVbI4OU9ny+XU/2ghZEz4676spOgzpDHTdWvCfM+t1mbUsT70fDiTTr9w==",
-            "requires": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-responsive-bs4": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-responsive-bs4/-/datatables.net-responsive-bs4-2.5.1.tgz",
-            "integrity": "sha512-cOVCG9zRioqJiqZUPXel5/vxKGt8EFhxgzVafDNy2hY3ZO+UMMuRKcs2br/QMoojbXzpKNf2rL/lM7NoXKVKZA==",
-            "requires": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-responsive": "2.5.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-rowgroup": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowgroup/-/datatables.net-rowgroup-1.5.1.tgz",
-            "integrity": "sha512-yDn+UCG9vrztt4obqt0YogyjH/i1D5Fyxnt4r5++T/ZaYhjKLU8zG9hkQXMx81M7RgeOtkv0eEpo/c+72w8T0w==",
-            "requires": {
-                "datatables.net": "^2",
-                "jquery": ">=1.7"
-            },
-            "dependencies": {
-                "datatables.net": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-                    "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-                    "requires": {
-                        "jquery": ">=1.7"
-                    }
-                }
-            }
-        },
-        "datatables.net-rowgroup-bs4": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowgroup-bs4/-/datatables.net-rowgroup-bs4-1.5.1.tgz",
-            "integrity": "sha512-1TMpTrQR8nXXZp5JBwemNAVEMWznE5/k2jJ1dVsXGyngtiZ2aVy0ls5vqQHaOPJuG0O0aIP7l+rU0+T4umHdow==",
-            "requires": {
-                "datatables.net-bs4": "^2",
-                "datatables.net-rowgroup": "1.5.1",
-                "jquery": ">=1.7"
-            },
-            "dependencies": {
-                "datatables.net": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-                    "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-                    "requires": {
-                        "jquery": ">=1.7"
-                    }
-                },
-                "datatables.net-bs4": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-2.2.1.tgz",
-                    "integrity": "sha512-YJpbGGTqrOhS6p8BolGv16mdmljaq4ewhc0dbm3yd02UQ86A2cWQ2tDq6lE966tvRD43JE0PPAc5wLgsRozReg==",
-                    "requires": {
-                        "datatables.net": "2.2.1",
-                        "jquery": ">=1.7"
-                    }
-                }
-            }
-        },
-        "datatables.net-rowreorder": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowreorder/-/datatables.net-rowreorder-1.5.0.tgz",
-            "integrity": "sha512-Kkq57tdJHrUCYkS8vywhL5tqKtl2q3K3p8A6wkIdwMX2b8YVjtywhQbXvvVLZnlMQsdX194FXVK1AgAwcm4hFg==",
-            "requires": {
-                "datatables.net": ">=1.11.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-rowreorder-bs4": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-rowreorder-bs4/-/datatables.net-rowreorder-bs4-1.5.0.tgz",
-            "integrity": "sha512-4C9tzLRaisO+IOdJ1n6NRQ8ak0zC0IbX50Ed5hg+5PT7VJLI9klH+GBwE6hpF28UTWk7E6somzOwnRHLexqXdA==",
-            "requires": {
-                "datatables.net-bs4": ">=1.11.0",
-                "datatables.net-rowreorder": "1.5.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-scroller": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-scroller/-/datatables.net-scroller-2.4.3.tgz",
-            "integrity": "sha512-ce6Qa7ObGQmLJYvm6eMglf54L+01/Omn3N1pw7SiQjGYv8AKRRp1ex+U0NWmx3QaWp0iEeTnBaM4G6ay4juYZg==",
-            "requires": {
-                "datatables.net": "1.11 - 2",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-scroller-bs4": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-scroller-bs4/-/datatables.net-scroller-bs4-2.4.3.tgz",
-            "integrity": "sha512-ca02sqd8VJTafqZhCOETXvvyACFh08aUl4JD+gxg7/1JKjvki0hnpyUkU5SBYgV0aNT1B2ecK+PZf4E/dWjtFg==",
-            "requires": {
-                "datatables.net-bs4": "1.11 - 2",
-                "datatables.net-scroller": "2.4.3",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-searchbuilder": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchbuilder/-/datatables.net-searchbuilder-1.8.1.tgz",
-            "integrity": "sha512-kjbPw8pC3NPBzP1BtG4WHGaMJet27WYLWZnBERuw5F/b6F4I2FAaxUiNuq8Ryu3EmWyWlgnfTeHums4XNwc8fg==",
-            "requires": {
-                "datatables.net": "^2.1",
-                "jquery": ">=1.7"
-            },
-            "dependencies": {
-                "datatables.net": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-                    "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-                    "requires": {
-                        "jquery": ">=1.7"
-                    }
-                }
-            }
-        },
-        "datatables.net-searchbuilder-bs4": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchbuilder-bs4/-/datatables.net-searchbuilder-bs4-1.8.1.tgz",
-            "integrity": "sha512-JiAqQ1/L7JpaBvs1m6BfPX0mf93X0oaGwqPNpB7ff1mIW0R62uyLyNmtc0lis53GqrZ1ejZemzWxwwnSHwY37g==",
-            "requires": {
-                "datatables.net-bs4": "^2.1",
-                "datatables.net-searchbuilder": "1.8.1",
-                "jquery": ">=1.7"
-            },
-            "dependencies": {
-                "datatables.net": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-                    "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-                    "requires": {
-                        "jquery": ">=1.7"
-                    }
-                },
-                "datatables.net-bs4": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/datatables.net-bs4/-/datatables.net-bs4-2.2.1.tgz",
-                    "integrity": "sha512-YJpbGGTqrOhS6p8BolGv16mdmljaq4ewhc0dbm3yd02UQ86A2cWQ2tDq6lE966tvRD43JE0PPAc5wLgsRozReg==",
-                    "requires": {
-                        "datatables.net": "2.2.1",
-                        "jquery": ">=1.7"
-                    }
-                }
-            }
-        },
-        "datatables.net-searchpanes": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchpanes/-/datatables.net-searchpanes-2.3.3.tgz",
-            "integrity": "sha512-iARaOcKPCotCx5Ip5TrJl+lvhYOpEXHzp7xMukcD2fmOkTPgK0CMRKQPF7eJx1aY4nWtm9ythBt6v1TRpEnO1w==",
-            "requires": {
-                "datatables.net": "^2",
-                "jquery": ">=1.7"
-            },
-            "dependencies": {
-                "datatables.net": {
-                    "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-2.2.1.tgz",
-                    "integrity": "sha512-Hz7f+a77xGdroAzej88aobT5nkQIJ2Oy1JI7yh2cl0QAXQSJDXOKkOLknu+nphVP8CP8w9MtLCmwMst/F8niiQ==",
-                    "requires": {
-                        "jquery": ">=1.7"
-                    }
-                }
-            }
-        },
-        "datatables.net-searchpanes-bs4": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/datatables.net-searchpanes-bs4/-/datatables.net-searchpanes-bs4-1.4.0.tgz",
-            "integrity": "sha512-Floxzmw2cQkUQdI7Vv4IWtLqLmwPrmY6MPncbEWq4YvkSeaZW7OHzSmZLLUjMn2P6Huvz59WUVcwL0lSDui6GQ==",
-            "requires": {
-                "datatables.net-bs4": ">=1.10.25",
-                "datatables.net-searchpanes": ">=1.3.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-select": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-select/-/datatables.net-select-1.7.1.tgz",
-            "integrity": "sha512-yC+GoBDVsnbaFTYKmZ2v5Bftc66zSZCYHbPYZb/ccdvxytEEudjc9R3wn6fgkOrVx3C2X/8keQc4a7EJvdOErg==",
-            "requires": {
-                "datatables.net": "^1.13.0",
-                "jquery": ">=1.7"
-            }
-        },
-        "datatables.net-select-bs4": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/datatables.net-select-bs4/-/datatables.net-select-bs4-1.7.1.tgz",
-            "integrity": "sha512-iHG4C8RdJIpsGIGDCXofUflHN1fa2N0E83MZPuqQXh1ZBkeJzd700rnru2mJXbvFc+wM9vf0Xxr6C5YsYFprgA==",
-            "requires": {
-                "datatables.net-bs4": "^1.13.0",
-                "datatables.net-select": "1.7.1",
-                "jquery": ">=1.7"
-            }
-        },
-        "daterangepicker": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/daterangepicker/-/daterangepicker-3.1.0.tgz",
-            "integrity": "sha512-DxWXvvPq4srWLCqFugqSV+6CBt/CvQ0dnpXhQ3gl0autcIDAruG1PuGG3gC7yPRNytAD1oU1AcUOzaYhOawhTw==",
-            "requires": {
-                "jquery": ">=1.10",
-                "moment": "^2.9.0"
-            }
-        },
         "de-indent": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
@@ -14671,38 +12946,6 @@
                 "ms": "^2.1.3"
             }
         },
-        "deep-equal": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-            "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-            "requires": {
-                "array-buffer-byte-length": "^1.0.0",
-                "call-bind": "^1.0.5",
-                "es-get-iterator": "^1.1.3",
-                "get-intrinsic": "^1.2.2",
-                "is-arguments": "^1.1.1",
-                "is-array-buffer": "^3.0.2",
-                "is-date-object": "^1.0.5",
-                "is-regex": "^1.1.4",
-                "is-shared-array-buffer": "^1.0.2",
-                "isarray": "^2.0.5",
-                "object-is": "^1.1.5",
-                "object-keys": "^1.1.1",
-                "object.assign": "^4.1.4",
-                "regexp.prototype.flags": "^1.5.1",
-                "side-channel": "^1.0.4",
-                "which-boxed-primitive": "^1.0.2",
-                "which-collection": "^1.0.1",
-                "which-typed-array": "^1.1.13"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-                }
-            }
-        },
         "default-gateway": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-6.0.3.tgz",
@@ -14716,6 +12959,7 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
             "requires": {
                 "es-define-property": "^1.0.0",
                 "es-errors": "^1.3.0",
@@ -14732,6 +12976,7 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
             "requires": {
                 "define-data-property": "^1.0.1",
                 "has-property-descriptors": "^1.0.0",
@@ -14778,11 +13023,6 @@
             "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
-        },
-        "dfa": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
-            "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
         },
         "diffie-hellman": {
             "version": "5.0.3",
@@ -14917,6 +13157,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+            "dev": true,
             "requires": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-errors": "^1.3.0",
@@ -14928,11 +13169,6 @@
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true
-        },
-        "ekko-lightbox": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/ekko-lightbox/-/ekko-lightbox-5.3.0.tgz",
-            "integrity": "sha512-mbacwySuVD3Ad6F2hTkjSTvJt59bcVv2l/TmBerp4xZnLak8tPtA4AScUn4DL42c1ksTiAO6sGhJZ52P/1Qgew=="
         },
         "electron-to-chromium": {
             "version": "1.5.84",
@@ -15015,35 +13251,14 @@
         "es-define-property": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
+            "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+            "dev": true
         },
         "es-errors": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
-        },
-        "es-get-iterator": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-            "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-            "requires": {
-                "call-bind": "^1.0.2",
-                "get-intrinsic": "^1.1.3",
-                "has-symbols": "^1.0.3",
-                "is-arguments": "^1.1.1",
-                "is-map": "^2.0.2",
-                "is-set": "^2.0.2",
-                "is-string": "^1.0.7",
-                "isarray": "^2.0.5",
-                "stop-iteration-iterator": "^1.0.0"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.5",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
-                }
-            }
+            "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+            "dev": true
         },
         "es-module-lexer": {
             "version": "1.6.0",
@@ -15055,6 +13270,7 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+            "dev": true,
             "requires": {
                 "es-errors": "^1.3.0"
             }
@@ -15104,6 +13320,12 @@
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true
         },
+        "estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true
+        },
         "esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -15115,16 +13337,6 @@
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "dev": true
-        },
-        "ev-emitter": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ev-emitter/-/ev-emitter-1.1.1.tgz",
-            "integrity": "sha512-ipiDYhdQSCZ4hSbX4rMW+XzNKMD1prg/sTvoVmSLkuQ1MVlwjJQQA+sW8tMYR3BLUr9KjodFV4pvzunvRhd33Q=="
-        },
-        "eve-raphael": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/eve-raphael/-/eve-raphael-0.5.0.tgz",
-            "integrity": "sha512-jrxnPsCGqng1UZuEp9DecX/AuSyAszATSjf4oEcRxvfxa1Oux4KkIPKBAAWWnpdwfARtr+Q0o9aPYWjsROD7ug=="
         },
         "eventemitter3": {
             "version": "4.0.7",
@@ -15255,21 +13467,11 @@
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
             "dev": true
         },
-        "fast-memoize": {
-            "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-            "integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
-        },
         "fast-uri": {
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
             "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
             "dev": true
-        },
-        "fastclick": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/fastclick/-/fastclick-1.0.6.tgz",
-            "integrity": "sha512-cXyDBT4g0uWl/Xe75QspBDAgAWQ0lkPi/zgp6YFEUHj6WV6VIZl7R6TiDZhdOVU3W4ehp/8tG61Jev1jit+ztQ=="
         },
         "fastest-levenshtein": {
             "version": "1.0.16",
@@ -15333,15 +13535,6 @@
                 "to-regex-range": "^5.0.1"
             }
         },
-        "filterizr": {
-            "version": "2.2.4",
-            "resolved": "https://registry.npmjs.org/filterizr/-/filterizr-2.2.4.tgz",
-            "integrity": "sha512-hqyEdg7RrvJMVFOeF0yysS75HP6jLu0wBSUtSPAc3BysAtHpwcXaPnR1kYp2uZtd3YXyhH6JRfF9+H4SRvrqXg==",
-            "requires": {
-                "fast-memoize": "^2.5.1",
-                "imagesloaded": "^4.1.4"
-            }
-        },
         "finalhandler": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
@@ -15395,21 +13588,11 @@
                 "path-exists": "^4.0.0"
             }
         },
-        "flag-icon-css": {
-            "version": "3.5.0",
-            "resolved": "https://registry.npmjs.org/flag-icon-css/-/flag-icon-css-3.5.0.tgz",
-            "integrity": "sha512-pgJnJLrtb0tcDgU1fzGaQXmR8h++nXvILJ+r5SmOXaaL/2pocunQo2a8TAXhjQnBpRLPtZ1KCz/TYpqeNuE2ew=="
-        },
         "flat": {
             "version": "5.0.2",
             "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true
-        },
-        "flot": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/flot/-/flot-4.2.6.tgz",
-            "integrity": "sha512-Iz4HCet1ZBQnjGwECz4jseD1zMnh7m2XJIMI6A62l8h2SeceLYOEmYGNQto1XhkSM9fUmqzyKhWwJ+RolWLydg=="
         },
         "follow-redirects": {
             "version": "1.15.9",
@@ -15421,30 +13604,6 @@
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
             "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg=="
-        },
-        "fontkit": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.9.0.tgz",
-            "integrity": "sha512-HkW/8Lrk8jl18kzQHvAw9aTHe1cqsyx5sDnxncx652+CIfhawokEPkeM3BoIC+z/Xv7a0yMr0f3pRRwhGH455g==",
-            "requires": {
-                "@swc/helpers": "^0.3.13",
-                "brotli": "^1.3.2",
-                "clone": "^2.1.2",
-                "deep-equal": "^2.0.5",
-                "dfa": "^1.2.0",
-                "restructure": "^2.0.1",
-                "tiny-inflate": "^1.0.3",
-                "unicode-properties": "^1.3.1",
-                "unicode-trie": "^2.0.0"
-            }
-        },
-        "for-each": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-            "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-            "requires": {
-                "is-callable": "^1.1.3"
-            }
         },
         "form-data": {
             "version": "4.0.1",
@@ -15475,17 +13634,6 @@
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true
         },
-        "fs-extra": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-            "requires": {
-                "at-least-node": "^1.0.0",
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^6.0.1",
-                "universalify": "^2.0.0"
-            }
-        },
         "fs-monkey": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.6.tgz",
@@ -15505,20 +13653,11 @@
             "dev": true,
             "optional": true
         },
-        "fullcalendar": {
-            "version": "5.11.5",
-            "resolved": "https://registry.npmjs.org/fullcalendar/-/fullcalendar-5.11.5.tgz",
-            "integrity": "sha512-eaVD6zOvuFXVpoMKlg2FQAj8e+PcpitBMwlzwRJJr1zOi/dXMYAksx2hLzwtsr93FVUNSSo16xwMTTZz6+prKQ=="
-        },
         "function-bind": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
-        },
-        "functions-have-names": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "dev": true
         },
         "gensync": {
             "version": "1.0.0-beta.2",
@@ -15536,6 +13675,7 @@
             "version": "1.2.7",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
             "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+            "dev": true,
             "requires": {
                 "call-bind-apply-helpers": "^1.0.1",
                 "es-define-property": "^1.0.1",
@@ -15553,6 +13693,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+            "dev": true,
             "requires": {
                 "dunder-proto": "^1.0.1",
                 "es-object-atoms": "^1.0.0"
@@ -15618,12 +13759,14 @@
         "gopd": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
+            "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+            "dev": true
         },
         "graceful-fs": {
             "version": "4.2.11",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+            "dev": true
         },
         "growly": {
             "version": "1.3.0",
@@ -15637,11 +13780,6 @@
             "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
             "dev": true
         },
-        "has-bigints": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
-            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="
-        },
         "has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -15652,6 +13790,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
             "requires": {
                 "es-define-property": "^1.0.0"
             }
@@ -15659,15 +13798,8 @@
         "has-symbols": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
-        },
-        "has-tostringtag": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-            "requires": {
-                "has-symbols": "^1.0.3"
-            }
+            "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+            "dev": true
         },
         "hash-base": {
             "version": "3.0.5",
@@ -15699,6 +13831,7 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dev": true,
             "requires": {
                 "function-bind": "^1.1.2"
             }
@@ -15863,9 +13996,9 @@
             }
         },
         "http-proxy-middleware": {
-            "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-            "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+            "version": "2.0.9",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
             "dev": true,
             "requires": {
                 "@types/http-proxy": "^1.17.8",
@@ -15891,14 +14024,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/icheck-bootstrap/-/icheck-bootstrap-3.0.1.tgz",
             "integrity": "sha512-Rj3SybdcMcayhsP4IJ+hmCNgCKclaFcs/5zwCuLXH1WMo468NegjhZVxbSNKhEjJjnwc4gKETogUmPYSQ9lEZQ=="
-        },
-        "iconv-lite": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-            "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-            }
         },
         "icss-utils": {
             "version": "5.1.0",
@@ -15934,14 +14059,6 @@
                 "replace-ext": "^1.0.0"
             }
         },
-        "imagesloaded": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/imagesloaded/-/imagesloaded-4.1.4.tgz",
-            "integrity": "sha512-ltiBVcYpc/TYTF5nolkMNsnREHW+ICvfQ3Yla2Sgr71YFwQ86bDwV9hgpFhFtrGPuwEx5+LqOHIrdXBdoWwwsA==",
-            "requires": {
-                "ev-emitter": "^1.0.0"
-            }
-        },
         "img-loader": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/img-loader/-/img-loader-4.0.0.tgz",
@@ -15972,11 +14089,6 @@
                     }
                 }
             }
-        },
-        "immediate": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-            "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
         },
         "immutable": {
             "version": "5.0.3",
@@ -16017,22 +14129,8 @@
         "inherits": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "inputmask": {
-            "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
-            "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ=="
-        },
-        "internal-slot": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
-            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "hasown": "^2.0.2",
-                "side-channel": "^1.1.0"
-            }
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+            "dev": true
         },
         "interpret": {
             "version": "2.2.0",
@@ -16040,50 +14138,17 @@
             "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
             "dev": true
         },
-        "ion-rangeslider": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/ion-rangeslider/-/ion-rangeslider-2.3.1.tgz",
-            "integrity": "sha512-6V+24FD13/feliI485gnRHZYD9Ev64M5NAFTxnVib516ATHa9PlXQrC+nOiPngouRYTCLPJyokAJEi3e1Umi5g==",
-            "requires": {}
-        },
         "ipaddr.js": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
             "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
             "dev": true
         },
-        "is-arguments": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
-            "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            }
-        },
-        "is-array-buffer": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
-            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
-            "requires": {
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            }
-        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "dev": true
-        },
-        "is-bigint": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
-            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
-            "requires": {
-                "has-bigints": "^1.0.2"
-            }
         },
         "is-binary-path": {
             "version": "2.1.0",
@@ -16094,25 +14159,11 @@
                 "binary-extensions": "^2.0.0"
             }
         },
-        "is-boolean-object": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
-            "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
-            }
-        },
         "is-buffer": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
-        },
-        "is-callable": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
         },
         "is-core-module": {
             "version": "2.16.1",
@@ -16121,15 +14172,6 @@
             "dev": true,
             "requires": {
                 "hasown": "^2.0.2"
-            }
-        },
-        "is-date-object": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
-            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "has-tostringtag": "^1.0.2"
             }
         },
         "is-docker": {
@@ -16159,25 +14201,11 @@
                 "is-extglob": "^2.1.1"
             }
         },
-        "is-map": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
-            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="
-        },
         "is-number": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true
-        },
-        "is-number-object": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
-            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
-            "requires": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            }
         },
         "is-plain-obj": {
             "version": "3.0.0",
@@ -16194,68 +14222,11 @@
                 "isobject": "^3.0.1"
             }
         },
-        "is-regex": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
-            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2",
-                "hasown": "^2.0.2"
-            }
-        },
-        "is-set": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
-            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg=="
-        },
-        "is-shared-array-buffer": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
-            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
-            "requires": {
-                "call-bound": "^1.0.3"
-            }
-        },
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true
-        },
-        "is-string": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
-            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
-            "requires": {
-                "call-bound": "^1.0.3",
-                "has-tostringtag": "^1.0.2"
-            }
-        },
-        "is-symbol": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
-            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "has-symbols": "^1.1.0",
-                "safe-regex-test": "^1.1.0"
-            }
-        },
-        "is-weakmap": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
-            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w=="
-        },
-        "is-weakset": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
-            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
-            "requires": {
-                "call-bound": "^1.0.3",
-                "get-intrinsic": "^1.2.6"
-            }
         },
         "is-wsl": {
             "version": "2.2.0",
@@ -16269,7 +14240,8 @@
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+            "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+            "dev": true
         },
         "isexe": {
             "version": "2.0.0",
@@ -16308,49 +14280,8 @@
         "jquery": {
             "version": "3.7.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
-        },
-        "jquery-knob-chif": {
-            "version": "1.2.13",
-            "resolved": "https://registry.npmjs.org/jquery-knob-chif/-/jquery-knob-chif-1.2.13.tgz",
-            "integrity": "sha512-dveq9MZCr68bRrsziuRusKS+/ciT1yOOHdENOSTcXVRM9MsEyCK/DjqR9nc7V3on41269PFdDE2Fuib8Cw4jAA=="
-        },
-        "jquery-mapael": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/jquery-mapael/-/jquery-mapael-2.2.0.tgz",
-            "integrity": "sha512-B5cVcCkfs7Ezia1Zs8bEfVacYD/GvaASyqQeidApR/NJ1C4igcExk9VULVsgLcTPkxohcZrrz5uCaPXvuKeZWw==",
-            "requires": {
-                "jquery": "^3.0 || ^2.0 || ^1.0",
-                "jquery-mousewheel": "^3.1",
-                "raphael": "^2.2.0 || ^2.1.1"
-            }
-        },
-        "jquery-mousewheel": {
-            "version": "3.1.13",
-            "resolved": "https://registry.npmjs.org/jquery-mousewheel/-/jquery-mousewheel-3.1.13.tgz",
-            "integrity": "sha512-GXhSjfOPyDemM005YCEHvzrEALhKDIswtxSHSR2e4K/suHVJKJxxRCGz3skPjNxjJjQa9AVSGGlYjv1M3VLIPg=="
-        },
-        "jquery-ui-dist": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/jquery-ui-dist/-/jquery-ui-dist-1.13.3.tgz",
-            "integrity": "sha512-qeTR3SOSQ0jgxaNXSFU6+JtxdzNUSJKgp8LCzVrVKntM25+2YBJW1Ea8B2AwjmmSHfPLy2dSlZxJQN06OfVFhg==",
-            "requires": {
-                "jquery": ">=1.8.0 <4.0.0"
-            }
-        },
-        "jquery-validation": {
-            "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.21.0.tgz",
-            "integrity": "sha512-xNot0rlUIgu7duMcQ5qb6MGkGL/Z1PQaRJQoZAURW9+a/2PGOUxY36o/WyNeP2T9R6jvWB8Z9lUVvvQWI/Zs5w==",
-            "requires": {}
-        },
-        "jqvmap-novulnerability": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/jqvmap-novulnerability/-/jqvmap-novulnerability-1.5.1.tgz",
-            "integrity": "sha512-O6Jr7AGiut9iNJMelPdy8pH83tNXadOqmhJm5FZy9gtaZ5uuhZK3VNu+YLFuTpXeZI8YXUvlFUYbJJi5XHA+tw==",
-            "requires": {
-                "jquery": "^3.4.0"
-            }
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "dev": true
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -16363,11 +14294,6 @@
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true
-        },
-        "jsgrid": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/jsgrid/-/jsgrid-1.5.3.tgz",
-            "integrity": "sha512-/BJgQp7gZe8o/VgNelwXc21jHc9HN+l7WPOkBhC9b9jPXFtOrU9ftNLPVBmKYCNlIulAbGTW8SDJI0mpw7uWxQ=="
         },
         "json-parse-even-better-errors": {
             "version": "2.3.1",
@@ -16391,20 +14317,10 @@
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
             "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
-            }
-        },
-        "jszip": {
-            "version": "3.10.1",
-            "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
-            "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
-            "requires": {
-                "lie": "~3.3.0",
-                "pako": "~1.0.2",
-                "readable-stream": "~2.3.6",
-                "setimmediate": "^1.0.5"
             }
         },
         "junk": {
@@ -16506,35 +14422,11 @@
                 "shell-quote": "^1.8.1"
             }
         },
-        "lie": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
-            "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-            "requires": {
-                "immediate": "~3.0.5"
-            }
-        },
         "lilconfig": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
             "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
             "dev": true
-        },
-        "linebreak": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
-            "integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
-            "requires": {
-                "base64-js": "0.0.8",
-                "unicode-trie": "^2.0.0"
-            },
-            "dependencies": {
-                "base64-js": {
-                    "version": "0.0.8",
-                    "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
-                    "integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw=="
-                }
-            }
         },
         "lines-and-columns": {
             "version": "1.2.4",
@@ -16610,6 +14502,15 @@
                 "yallist": "^3.0.2"
             }
         },
+        "magic-string": {
+            "version": "0.30.17",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "dev": true,
+            "requires": {
+                "@jridgewell/sourcemap-codec": "^1.5.0"
+            }
+        },
         "make-dir": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -16630,7 +14531,8 @@
         "math-intrinsics": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
+            "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+            "dev": true
         },
         "md5": {
             "version": "2.3.0",
@@ -16805,19 +14707,6 @@
             "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
             "dev": true
         },
-        "moment": {
-            "version": "2.30.1",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-            "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how=="
-        },
-        "moment-timezone": {
-            "version": "0.5.46",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.46.tgz",
-            "integrity": "sha512-ZXm9b36esbe7OmdABqIWJuBBiLLwAjrN7CE+7sYdCCx82Nabt1wHDj8TVseS59QIlfFPbOoiBPm6ca9BioG4hw==",
-            "requires": {
-                "moment": "^2.29.4"
-            }
-        },
         "ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -16835,9 +14724,9 @@
             }
         },
         "nanoid": {
-            "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "dev": true
         },
         "negotiator": {
@@ -16965,26 +14854,20 @@
         "object-inspect": {
             "version": "1.13.3",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
-            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA=="
-        },
-        "object-is": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
-            "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
-            "requires": {
-                "call-bind": "^1.0.7",
-                "define-properties": "^1.2.1"
-            }
+            "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+            "dev": true
         },
         "object-keys": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true
         },
         "object.assign": {
             "version": "4.1.7",
             "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
             "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+            "dev": true,
             "requires": {
                 "call-bind": "^1.0.8",
                 "call-bound": "^1.0.3",
@@ -17050,11 +14933,6 @@
             "integrity": "sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==",
             "dev": true
         },
-        "overlayscrollbars": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/overlayscrollbars/-/overlayscrollbars-1.13.3.tgz",
-            "integrity": "sha512-1nB/B5kaakJuHXaLXLRK0bUIilWhUGT6q5g+l2s5vqYdLle/sd0kscBHkQC1kuuDg9p9WR4MTdySDOPbeL/86g=="
-        },
         "p-limit": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -17098,7 +14976,8 @@
         "pako": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+            "dev": true
         },
         "param-case": {
             "version": "3.0.4",
@@ -17216,29 +15095,6 @@
                 "sha.js": "^2.4.8"
             }
         },
-        "pdfkit": {
-            "version": "0.12.3",
-            "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.12.3.tgz",
-            "integrity": "sha512-+qDLgm2yq6WOKcxTb43lDeo3EtMIDQs0CK1RNqhHC9iT6u0KOmgwAClkYh9xFw2ATbmUZzt4f7KMwDCOfPDluA==",
-            "requires": {
-                "crypto-js": "^4.0.0",
-                "fontkit": "^1.8.1",
-                "linebreak": "^1.0.2",
-                "png-js": "^1.0.0"
-            }
-        },
-        "pdfmake": {
-            "version": "0.1.72",
-            "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.1.72.tgz",
-            "integrity": "sha512-xZrPS+Safjf1I8ZYtMoXX83E6C6Pd1zFwa168yNTeeJWHclqf1z9DoYajjlY2uviN7gGyxwVZeou39uSk1oh1g==",
-            "requires": {
-                "iconv-lite": "^0.6.2",
-                "linebreak": "^1.0.2",
-                "pdfkit": "^0.12.0",
-                "svg-to-pdfkit": "^0.1.8",
-                "xmldoc": "^1.1.2"
-            }
-        },
         "picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -17260,28 +15116,19 @@
                 "find-up": "^4.0.0"
             }
         },
-        "png-js": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/png-js/-/png-js-1.0.0.tgz",
-            "integrity": "sha512-k+YsbhpA9e+EFfKjTCH3VW6aoKlyNYI6NYdTfDL4CIvFnvsuO84ttonmZE7rc+v23SLTH8XX+5w/Ak9v0xGY4g=="
-        },
         "popper.js": {
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-        },
-        "possible-typed-array-names": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
-            "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q=="
+            "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+            "dev": true
         },
         "postcss": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
-            "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
+            "version": "8.5.5",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
+            "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
             "dev": true,
             "requires": {
-                "nanoid": "^3.3.8",
+                "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             }
@@ -17634,13 +15481,6 @@
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
-        "prettier": {
-            "version": "2.8.8",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
-            "dev": true,
-            "optional": true
-        },
         "pretty-time": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
@@ -17656,7 +15496,8 @@
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+            "dev": true
         },
         "proxy-addr": {
             "version": "2.0.7",
@@ -17756,14 +15597,6 @@
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true
         },
-        "raphael": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/raphael/-/raphael-2.3.0.tgz",
-            "integrity": "sha512-w2yIenZAQnp257XUWGni4bLMVxpUpcIl7qgxEgDIXtmSypYtlNxfXWpOBxs7LBTps5sDwhRnrToJrMUrivqNTQ==",
-            "requires": {
-                "eve-raphael": "0.5.0"
-            }
-        },
         "raw-body": {
             "version": "2.5.2",
             "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
@@ -17791,6 +15624,7 @@
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+            "dev": true,
             "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -17804,12 +15638,14 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+                    "dev": true
                 },
                 "string_decoder": {
                     "version": "1.1.1",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -17849,12 +15685,6 @@
                 "regenerate": "^1.4.2"
             }
         },
-        "regenerator-runtime": {
-            "version": "0.14.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-            "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-            "dev": true
-        },
         "regenerator-transform": {
             "version": "0.15.2",
             "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.2.tgz",
@@ -17869,19 +15699,6 @@
             "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.3.0.tgz",
             "integrity": "sha512-TVILVSz2jY5D47F4mA4MppkBrafEaiUWJO/TcZHEIuI13AqoZMkK1WMA4Om1YkYbTx+9Ki1/tSUXbceyr9saRg==",
             "dev": true
-        },
-        "regexp.prototype.flags": {
-            "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
-            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
-            "requires": {
-                "call-bind": "^1.0.8",
-                "define-properties": "^1.2.1",
-                "es-errors": "^1.3.0",
-                "get-proto": "^1.0.1",
-                "gopd": "^1.2.0",
-                "set-function-name": "^2.0.2"
-            }
         },
         "regexpu-core": {
             "version": "6.2.0",
@@ -18005,11 +15822,6 @@
                 }
             }
         },
-        "restructure": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/restructure/-/restructure-2.0.1.tgz",
-            "integrity": "sha512-e0dOpjm5DseomnXx2M5lpdZ5zoHqF1+bqdMJUohoYVVQa7cBdnk7fdmeI6byNWP/kiME72EeTiSypTCVnpLiDg=="
-        },
         "retry": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
@@ -18056,20 +15868,11 @@
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true
         },
-        "safe-regex-test": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
-            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
-            "requires": {
-                "call-bound": "^1.0.2",
-                "es-errors": "^1.3.0",
-                "is-regex": "^1.2.1"
-            }
-        },
         "safer-buffer": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+            "dev": true
         },
         "sass": {
             "version": "1.83.4",
@@ -18126,11 +15929,6 @@
                 }
             }
         },
-        "sax": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
-            "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
-        },
         "schema-utils": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -18147,11 +15945,6 @@
             "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
             "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
             "dev": true
-        },
-        "select2": {
-            "version": "4.0.13",
-            "resolved": "https://registry.npmjs.org/select2/-/select2-4.0.13.tgz",
-            "integrity": "sha512-1JeB87s6oN/TDxQQYCvS5EFoQyvV6eYMZZ0AeA4tdFDYWN3BAGZ8npr17UBFddU0lgAt3H0yjX3X6/ekOj1yjw=="
         },
         "selfsigned": {
             "version": "2.4.1",
@@ -18308,6 +16101,7 @@
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
             "requires": {
                 "define-data-property": "^1.1.4",
                 "es-errors": "^1.3.0",
@@ -18317,21 +16111,11 @@
                 "has-property-descriptors": "^1.0.2"
             }
         },
-        "set-function-name": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
-            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
-            "requires": {
-                "define-data-property": "^1.1.4",
-                "es-errors": "^1.3.0",
-                "functions-have-names": "^1.2.3",
-                "has-property-descriptors": "^1.0.2"
-            }
-        },
         "setimmediate": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+            "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+            "dev": true
         },
         "setprototypeof": {
             "version": "1.2.0",
@@ -18389,6 +16173,7 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "dev": true,
             "requires": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3",
@@ -18401,6 +16186,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+            "dev": true,
             "requires": {
                 "es-errors": "^1.3.0",
                 "object-inspect": "^1.13.3"
@@ -18410,6 +16196,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
             "requires": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -18421,6 +16208,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
             "requires": {
                 "call-bound": "^1.0.2",
                 "es-errors": "^1.3.0",
@@ -18480,11 +16268,6 @@
                 "source-map": "^0.6.0"
             }
         },
-        "sparklines": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/sparklines/-/sparklines-1.3.0.tgz",
-            "integrity": "sha512-CkFtpDE3hmOeu1IJyIQIOH0AQtHnPj1c61ALxJZQ9cPEFKDgWC1fcNAHuwPi1i1klTDYvlKKseoYHSwe7JmdLA=="
-        },
         "spdy": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
@@ -18542,15 +16325,6 @@
             "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
             "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
             "dev": true
-        },
-        "stop-iteration-iterator": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
-            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
-            "requires": {
-                "es-errors": "^1.3.0",
-                "internal-slot": "^1.1.0"
-            }
         },
         "stream-browserify": {
             "version": "2.0.2",
@@ -18643,11 +16417,6 @@
                 "postcss-selector-parser": "^6.0.4"
             }
         },
-        "summernote": {
-            "version": "0.8.20",
-            "resolved": "https://registry.npmjs.org/summernote/-/summernote-0.8.20.tgz",
-            "integrity": "sha512-W9RhjQjsn+b1s9xiJQgJbCiYGJaDAc9CdEqXo+D13WuStG8lCdtKaO5AiNiSSMJsQJN2EfGSwbBQt+SFE2B8Kw=="
-        },
         "supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -18662,14 +16431,6 @@
             "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true
-        },
-        "svg-to-pdfkit": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/svg-to-pdfkit/-/svg-to-pdfkit-0.1.8.tgz",
-            "integrity": "sha512-QItiGZBy5TstGy+q8mjQTMGRlDDOARXLxH+sgVm1n/LYeo0zFcQlcCh8m4zi8QxctrxB9Kue/lStc/RD5iLadQ==",
-            "requires": {
-                "pdfkit": ">=0.8.1"
-            }
         },
         "svgo": {
             "version": "2.8.0",
@@ -18686,47 +16447,11 @@
                 "stable": "^0.1.8"
             }
         },
-        "sweetalert2": {
-            "version": "10.16.11",
-            "resolved": "https://registry.npmjs.org/sweetalert2/-/sweetalert2-10.16.11.tgz",
-            "integrity": "sha512-Rdfabv2G89Tr8vmUTb1auWCYYesKBEWnkYPSi7XaiCIW0ZXXGK8Nw1wYKPEMLU6O8gMSMJe5m6MRKqMQsAQy9A=="
-        },
         "tapable": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true
-        },
-        "tempusdominus-bootstrap-4": {
-            "version": "5.39.2",
-            "resolved": "https://registry.npmjs.org/tempusdominus-bootstrap-4/-/tempusdominus-bootstrap-4-5.39.2.tgz",
-            "integrity": "sha512-8Au4miSAsMGdsElPg87EUmsN7aGJFaRA5Y8Ale7dDTfhhnQL1Za53LclIJkq+t/7NO5+Ufr1jY7tmEPvWGHaVg==",
-            "requires": {
-                "bootstrap": "^4.6.1",
-                "jquery": "^3.6.0",
-                "moment": "^2.29.2",
-                "moment-timezone": "^0.5.34",
-                "popper.js": "^1.16.1"
-            }
-        },
-        "tempusdominus-core": {
-            "version": "5.19.3",
-            "resolved": "https://registry.npmjs.org/tempusdominus-core/-/tempusdominus-core-5.19.3.tgz",
-            "integrity": "sha512-WXBVXcBG/hErB6u9gdUs+vzANvCU1kd1ykzL4kolPB3h1OEv20OKUW5qz1iynxyqRFPa1NWY9gwRu5d+MjXEuQ==",
-            "peer": true,
-            "requires": {
-                "jquery": "^3.6.0",
-                "moment": "~2.29.2",
-                "moment-timezone": "^0.5.34"
-            },
-            "dependencies": {
-                "moment": {
-                    "version": "2.29.4",
-                    "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-                    "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-                    "peer": true
-                }
-            }
         },
         "terser": {
             "version": "5.37.0",
@@ -18817,11 +16542,6 @@
                 "setimmediate": "^1.0.4"
             }
         },
-        "tiny-inflate": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
-            "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
-        },
         "to-arraybuffer": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
@@ -18837,14 +16557,6 @@
                 "is-number": "^7.0.0"
             }
         },
-        "toastr": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/toastr/-/toastr-2.1.4.tgz",
-            "integrity": "sha512-LIy77F5n+sz4tefMmFOntcJ6HL0Fv3k1TDnNmFZ0bU/GcvIIfy6eG2v7zQmMiYgaalAiUv75ttFrPn5s0gyqlA==",
-            "requires": {
-                "jquery": ">=1.12.0"
-            }
-        },
         "toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -18854,7 +16566,8 @@
         "tslib": {
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true
         },
         "tty-browserify": {
             "version": "0.0.0",
@@ -18900,41 +16613,17 @@
             "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
             "dev": true
         },
-        "unicode-properties": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
-            "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
-            "requires": {
-                "base64-js": "^1.3.0",
-                "unicode-trie": "^2.0.0"
-            }
-        },
         "unicode-property-aliases-ecmascript": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
             "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
             "dev": true
         },
-        "unicode-trie": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
-            "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
-            "requires": {
-                "pako": "^0.2.5",
-                "tiny-inflate": "^1.0.0"
-            },
-            "dependencies": {
-                "pako": {
-                    "version": "0.2.9",
-                    "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-                    "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
-                }
-            }
-        },
         "universalify": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
-            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+            "dev": true
         },
         "unpipe": {
             "version": "1.0.0",
@@ -18951,11 +16640,6 @@
                 "escalade": "^3.2.0",
                 "picocolors": "^1.1.1"
             }
-        },
-        "uplot": {
-            "version": "1.6.31",
-            "resolved": "https://registry.npmjs.org/uplot/-/uplot-1.6.31.tgz",
-            "integrity": "sha512-sQZqSwVCbJGnFB4IQjQYopzj5CoTZJ4Br1fG/xdONimqgHmsacvCjNesdGDypNKFbrhLGIeshYhy89FxPF+H+w=="
         },
         "uri-js": {
             "version": "4.4.1",
@@ -19004,7 +16688,8 @@
         "util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+            "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+            "dev": true
         },
         "utils-merge": {
             "version": "1.0.1",
@@ -19031,13 +16716,16 @@
             "dev": true
         },
         "vue": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.16.tgz",
-            "integrity": "sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==",
+            "version": "3.5.16",
+            "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.16.tgz",
+            "integrity": "sha512-rjOV2ecxMd5SiAmof2xzh2WxntRcigkX/He4YFJ6WdRvVUrbt6DxC1Iujh10XLl8xCDRDtGKMeO3D+pRQ1PP9w==",
             "dev": true,
             "requires": {
-                "@vue/compiler-sfc": "2.7.16",
-                "csstype": "^3.1.0"
+                "@vue/compiler-dom": "3.5.16",
+                "@vue/compiler-sfc": "3.5.16",
+                "@vue/runtime-dom": "3.5.16",
+                "@vue/server-renderer": "3.5.16",
+                "@vue/shared": "3.5.16"
             }
         },
         "vue-loader": {
@@ -19090,13 +16778,21 @@
             }
         },
         "vue-template-compiler": {
-            "version": "2.7.16",
-            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz",
-            "integrity": "sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==",
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-0.1.0.tgz",
+            "integrity": "sha512-Y/kgG0p3Co10OEjlhAtHrEzPFgJvWqkMm0xqFsjFpytZ499Q/KqkkYTfeB7ghty+nEdrzOXd++glw3CyxGnmYg==",
             "dev": true,
             "requires": {
                 "de-indent": "^1.0.2",
-                "he": "^1.2.0"
+                "entities": "^1.1.1"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+                    "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+                    "dev": true
+                }
             }
         },
         "watchpack": {
@@ -19390,42 +17086,6 @@
                 "isexe": "^2.0.0"
             }
         },
-        "which-boxed-primitive": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
-            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
-            "requires": {
-                "is-bigint": "^1.1.0",
-                "is-boolean-object": "^1.2.1",
-                "is-number-object": "^1.1.1",
-                "is-string": "^1.1.1",
-                "is-symbol": "^1.1.1"
-            }
-        },
-        "which-collection": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
-            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
-            "requires": {
-                "is-map": "^2.0.3",
-                "is-set": "^2.0.3",
-                "is-weakmap": "^2.0.2",
-                "is-weakset": "^2.0.3"
-            }
-        },
-        "which-typed-array": {
-            "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-            "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
-            "requires": {
-                "available-typed-arrays": "^1.0.7",
-                "call-bind": "^1.0.8",
-                "call-bound": "^1.0.3",
-                "for-each": "^0.3.3",
-                "gopd": "^1.2.0",
-                "has-tostringtag": "^1.0.2"
-            }
-        },
         "wildcard": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
@@ -19455,14 +17115,6 @@
             "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "requires": {}
-        },
-        "xmldoc": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/xmldoc/-/xmldoc-1.3.0.tgz",
-            "integrity": "sha512-y7IRWW6PvEnYQZNZFMRLNJw+p3pezM4nKYPfr15g4OOW9i8VpeydycFuipE2297OvZnh3jSb2pxOt9QpkZUVng==",
-            "requires": {
-                "sax": "^1.2.4"
-            }
         },
         "xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "axios": "^1.0",
-        "bootstrap": "^4.0.0",
+        "bootstrap": "^5.3.6",
         "jquery": "^3.2",
         "laravel-mix": "^6.0.49",
         "lodash": "^4.17.19",
@@ -20,14 +20,14 @@
         "resolve-url-loader": "^5.0.0",
         "sass": "^1.32.11",
         "sass-loader": "^10.1.1",
-        "vue": "^2.5.17",
+        "vue": "^3.5.16",
         "vue-loader": "^17.4.2",
-        "vue-template-compiler": "^2.6.10"
+        "vue-template-compiler": "^0.1.0"
     },
     "dependencies": {
         "@bcgov/bc-sans": "^1.0.1",
         "@fortawesome/fontawesome-free": "^5.15.4",
-        "admin-lte": "~3.1.0",
+        "admin-lte": "^4.0.0-beta3",
         "dropzone": "^5.9.0",
         "font-awesome": "^4.7.0",
         "icheck-bootstrap": "^3.0.1"


### PR DESCRIPTION
as of June 10, 2025, there are security more than 10 security patch request

> composer audit
Found 1 security vulnerability advisory affecting 1 package:
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package | league/commonmark |
| Severity | medium |
| CVE | CVE-2025-46734 |
| Title | league/commonmark contains a XSS vulnerability in Attributes extension |
| URL | https://github.com/advisories/GHSA-3527-qv2q-pfvx |
| Affected versions | <2.7.0 |
| Reported at | 2025-05-05T20:40:36+00:00 |
+-------------------+----------------------------------------------------------------------------------+
>npm audit
# npm audit report
:
:
12 vulnerabilities (2 low, 10 moderate)

Action Required


Step 1 -- Auditing

> composer audit
+-------------------+----------------------------------------------------------------------------------+
| Package | league/commonmark |
| Severity | medium |
| CVE | CVE-2025-46734 |
| Title | league/commonmark contains a XSS vulnerability in Attributes extension |
| URL | https://github.com/advisories/GHSA-3527-qv2q-pfvx |
| Affected versions | <2.7.0 |
| Reported at | 2025-05-05T20:40:36+00:00 |+-------------------+----------------------------------------------------------------------------------+

>npm audit
# npm audit report

@babel/helpers <7.26.10
Severity: moderate
Babel has inefficient RegExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8
fix available via `npm audit fix`
node_modules/@babel/helpers

@babel/runtime <7.26.10
Severity: moderate
Babel has inefficient RegExp complexity in generated code with .replace when transpiling named capturing groups - https://github.com/advisories/GHSA-968p-4wvh-cqc8
fix available via `npm audit fix`
node_modules/@babel/runtime

bootstrap 4.0.0 - 4.6.2
Severity: moderate
Bootstrap Cross-Site Scripting (XSS) vulnerability - https://github.com/advisories/GHSA-vc8w-jr9v-vj7f
fix available via `npm audit fix --force`
Will install bootstrap@5.3.6, which is a breaking change
node_modules/bootstrap
admin-lte 3.0.0-alpha - 3.2.0
Depends on vulnerable versions of bootstrap
Depends on vulnerable versions of summernote
Depends on vulnerable versions of tempusdominus-bootstrap-4
node_modules/admin-lte
tempusdominus-bootstrap-4 <=5.0.1 || >=5.39.0
Depends on vulnerable versions of bootstrap
node_modules/tempusdominus-bootstrap-4

http-proxy-middleware 1.3.0 - 2.0.8
Severity: moderate
http-proxy-middleware allows fixRequestBody to proceed even if bodyParser has failed - https://github.com/advisories/GHSA-9gqv-wp59-fq42
http-proxy-middleware can call writeBody twice because "else if" is not used - https://github.com/advisories/GHSA-4www-5p9h-95mh
fix available via `npm audit fix`
node_modules/http-proxy-middleware

summernote <=0.8.20
Severity: moderate
SummerNote Cross Site Scripting Vulnerability - https://github.com/advisories/GHSA-cc55-mvqc-g9mg
fix available via `npm audit fix`
node_modules/summernote

sweetalert2 >=10.16.10 <11.0.0
sweetalert2 v10.16.10 and above contains hidden functionality - https://github.com/advisories/GHSA-457r-cqc8-9vj9
fix available via `npm audit fix`
node_modules/sweetalert2

vue 2.0.0-alpha.1 - 2.7.16
ReDoS vulnerability in vue package that is exploitable through inefficient regex evaluation in the parseHTML function - https://github.com/advisories/GHSA-5j4c-8p2g-v4jx
fix available via `npm audit fix --force`
Will install vue@3.5.16, which is a breaking change
node_modules/vue

vue-template-compiler >=2.0.0
Severity: moderate
vue-template-compiler vulnerable to client-side Cross-Site Scripting (XSS) - https://github.com/advisories/GHSA-g3ch-rx76-35fx
fix available via `npm audit fix --force`
Will install vue-template-compiler@0.1.0, which is a breaking change
node_modules/vue-template-compiler

webpack-dev-server <=5.2.0
Severity: moderate
webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser - https://github.com/advisories/GHSA-9jgg-88mc-972h
webpack-dev-server users' source code may be stolen when they access a malicious web site - https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
No fix available
node_modules/webpack-dev-server
laravel-mix *
Depends on vulnerable versions of webpack-dev-server
node_modules/laravel-mix

12 vulnerabilities (2 low, 10 moderate)


-----------------------------------------
Step 2 -- Action Taken -- Upgrading package

> composer update league/commonmark
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
- Upgrading league/commonmark (2.6.1 => 2.7.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
INFO: Could not find files for the given pattern(s).
- Upgrading league/commonmark (2.6.1 => 2.7.0): Extracting archive
:
:
121 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.


> npm audit fix --force
npm WARN using --force Recommended protections disabled.
npm WARN audit Updating bootstrap to 5.3.6, which is a SemVer major change.
npm WARN audit Updating vue to 3.5.16, which is a SemVer major change.
npm WARN audit Updating vue-template-compiler to 0.1.0, which is a SemVer major change.
npm WARN audit Updating admin-lte to 4.0.0-beta3, which is a SemVer major change.
npm WARN audit No fix available for laravel-mix@*

added 13 packages, removed 145 packages, changed 16 packages, and audited 788 packages in 8s

102 packages are looking for funding
run `npm fund` for details

# npm audit report

webpack-dev-server <=5.2.0
Severity: moderate
webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser - https://github.com/advisories/GHSA-9jgg-88mc-972h
webpack-dev-server users' source code may be stolen when they access a malicious web site - https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
No fix available
node_modules/webpack-dev-server
laravel-mix *
Depends on vulnerable versions of webpack-dev-server
node_modules/laravel-mix

2 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

-----------------------------------------
Step 3 -- Action Taken -- Run automated test scripts

> php artisan test
Tests: 1261 passed (3324 assertions)
Duration: 633.71s

-----------------------------------------
Step 4 -- Action Taken -- Deploy and verify on DEV and TEST regions


Jun 11 - Deployed on DEV and TEST regions. Ready for testing.

Jun 12 - The upgrade package are general and cover lots of area. I already did my test scripts (over 1261 test and 3324 assertions) and all passed, However, these scripts mainly focus on form data entry and database updates. There are no scripts for the UI. You might want to concentrate on testing the following core functions in the TEST region. Thank you so much.
Testing for the following on TEST region
. IDIR login
. Donations > Donate (Self Service)
. Volunteering > eForm (Self Service)
. Donations > Export Summary (Test PDF)
. Statistics > Leaderboard > Download as PDF
. Statistics > Leaderboard > Chart
. Admin > Pledge Administration > Maintain EE Pledges > Edit
. Admin > Pledge Administration > Maintain Event Pledges > Edit
. CRA Charities -> Charity List Maintenance -> File upload
. Admin -> Reporting -> Pay Period Report -> Export
. Admin -> Reporting -> Program reports -> Annual pledges and Events -> Export
. System > Auditing > Table Audit Log
. System > Schedule Jobs (verify recent process run to completed)

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/ycOuYM0z9E2XpeyjKveQCmUALvuk?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)