### PR TITLE
(MASTER) [jp-0235] Security update required -- 2 HIGH security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2933,6 +2933,21 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dev": true,
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/axios": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
@@ -3369,9 +3384,9 @@
             }
         },
         "node_modules/call-bind-apply-helpers": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-            "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -3382,13 +3397,13 @@
             }
         },
         "node_modules/call-bound": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "dev": true,
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "get-intrinsic": "^1.2.6"
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5003,6 +5018,21 @@
                 "node": ">=0.10.3"
             }
         },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
@@ -5102,17 +5132,17 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-            "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "dependencies": {
-                "call-bind-apply-helpers": "^1.0.1",
+                "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
+                "es-object-atoms": "^1.1.1",
                 "function-bind": "^1.1.2",
-                "get-proto": "^1.0.0",
+                "get-proto": "^1.0.1",
                 "gopd": "^1.2.0",
                 "has-symbols": "^1.1.0",
                 "hasown": "^2.0.2",
@@ -5273,6 +5303,21 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "dependencies": {
+                "has-symbols": "^1.0.3"
+            },
             "engines": {
                 "node": ">= 0.4"
             },
@@ -5772,6 +5817,18 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -5875,6 +5932,21 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-wsl": {
@@ -6983,19 +7055,51 @@
             }
         },
         "node_modules/pbkdf2": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-            "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+            "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
             "dev": true,
             "dependencies": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "~1.1.3",
+                "create-hmac": "^1.1.7",
+                "ripemd160": "=2.0.1",
+                "safe-buffer": "^5.2.1",
+                "sha.js": "^2.4.11",
+                "to-buffer": "^1.2.0"
             },
             "engines": {
                 "node": ">=0.12"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+            "dev": true,
+            "dependencies": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.1"
+            }
+        },
+        "node_modules/pbkdf2/node_modules/ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+            "dev": true,
+            "dependencies": {
+                "hash-base": "^2.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "node_modules/picocolors": {
@@ -7037,6 +7141,15 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
+            }
+        },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/postcss": {
@@ -9049,6 +9162,26 @@
             "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==",
             "dev": true
         },
+        "node_modules/to-buffer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+            "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+            "dev": true,
+            "dependencies": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/to-buffer/node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -9093,6 +9226,20 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/undici-types": {
@@ -9801,6 +9948,27 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+            "dev": true,
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/wildcard": {
@@ -12024,6 +12192,15 @@
                 "postcss-value-parser": "^4.2.0"
             }
         },
+        "available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dev": true,
+            "requires": {
+                "possible-typed-array-names": "^1.0.0"
+            }
+        },
         "axios": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
@@ -12359,9 +12536,9 @@
             }
         },
         "call-bind-apply-helpers": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
-            "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+            "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
             "dev": true,
             "requires": {
                 "es-errors": "^1.3.0",
@@ -12369,13 +12546,13 @@
             }
         },
         "call-bound": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-            "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
             "dev": true,
             "requires": {
-                "call-bind-apply-helpers": "^1.0.1",
-                "get-intrinsic": "^1.2.6"
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
             }
         },
         "callsites": {
@@ -13605,6 +13782,15 @@
             "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
             "integrity": "sha512-U6kGnykA/6bFmg1M/oT9EkFeIYv7JlX3bozwQJWiiLz6L0w3F5vBVPxHlwyX/vtNq1ckcpRKOB9f2Qal/VtFpg=="
         },
+        "for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "requires": {
+                "is-callable": "^1.2.7"
+            }
+        },
         "form-data": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
@@ -13672,17 +13858,17 @@
             "dev": true
         },
         "get-intrinsic": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-            "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+            "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
             "dev": true,
             "requires": {
-                "call-bind-apply-helpers": "^1.0.1",
+                "call-bind-apply-helpers": "^1.0.2",
                 "es-define-property": "^1.0.1",
                 "es-errors": "^1.3.0",
-                "es-object-atoms": "^1.0.0",
+                "es-object-atoms": "^1.1.1",
                 "function-bind": "^1.1.2",
-                "get-proto": "^1.0.0",
+                "get-proto": "^1.0.1",
                 "gopd": "^1.2.0",
                 "has-symbols": "^1.1.0",
                 "hasown": "^2.0.2",
@@ -13800,6 +13986,15 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "dev": true
+        },
+        "has-tostringtag": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.3"
+            }
         },
         "hash-base": {
             "version": "3.0.5",
@@ -14165,6 +14360,12 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
         },
+        "is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true
+        },
         "is-core-module": {
             "version": "2.16.1",
             "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -14227,6 +14428,15 @@
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
             "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
             "dev": true
+        },
+        "is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
+            "requires": {
+                "which-typed-array": "^1.1.16"
+            }
         },
         "is-wsl": {
             "version": "2.2.0",
@@ -15083,16 +15293,50 @@
             "dev": true
         },
         "pbkdf2": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.2.tgz",
-            "integrity": "sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.3.tgz",
+            "integrity": "sha512-wfRLBZ0feWRhCIkoMB6ete7czJcnNnqRpcoWQBLqatqXXmelSRqfdDK4F3u9T2s2cXas/hQJcryI/4lAL+XTlA==",
             "dev": true,
             "requires": {
-                "create-hash": "^1.1.2",
-                "create-hmac": "^1.1.4",
-                "ripemd160": "^2.0.1",
-                "safe-buffer": "^5.0.1",
-                "sha.js": "^2.4.8"
+                "create-hash": "~1.1.3",
+                "create-hmac": "^1.1.7",
+                "ripemd160": "=2.0.1",
+                "safe-buffer": "^5.2.1",
+                "sha.js": "^2.4.11",
+                "to-buffer": "^1.2.0"
+            },
+            "dependencies": {
+                "create-hash": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+                    "integrity": "sha512-snRpch/kwQhcdlnZKYanNF1m0RDlrCdSKQaH87w1FCFPVPNCQ/Il9QJKAX2jVBZddRdaHBMC+zXa9Gw9tmkNUA==",
+                    "dev": true,
+                    "requires": {
+                        "cipher-base": "^1.0.1",
+                        "inherits": "^2.0.1",
+                        "ripemd160": "^2.0.0",
+                        "sha.js": "^2.4.0"
+                    }
+                },
+                "hash-base": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+                    "integrity": "sha512-0TROgQ1/SxE6KmxWSvXHvRj90/Xo1JvZShofnYF+f6ZsGtR4eES7WfrQzPalmyagfKZCXpVnitiRebZulWsbiw==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.1"
+                    }
+                },
+                "ripemd160": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+                    "integrity": "sha512-J7f4wutN8mdbV08MJnXibYpCOPHR+yzy+iQ/AsjMv2j8cLavQ8VGagDFUwwTAdF8FmRKVeNpbTTEwNHCW1g94w==",
+                    "dev": true,
+                    "requires": {
+                        "hash-base": "^2.0.0",
+                        "inherits": "^2.0.1"
+                    }
+                }
             }
         },
         "picocolors": {
@@ -15120,6 +15364,12 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
             "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
+            "dev": true
+        },
+        "possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
             "dev": true
         },
         "postcss": {
@@ -16548,6 +16798,25 @@
             "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA==",
             "dev": true
         },
+        "to-buffer": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.1.tgz",
+            "integrity": "sha512-tB82LpAIWjhLYbqjx3X4zEeHN6M8CiuOEy2JY8SEQVdYRe3CCHOFaqrBW1doLDrfpWhplcW7BL+bO3/6S3pcDQ==",
+            "dev": true,
+            "requires": {
+                "isarray": "^2.0.5",
+                "safe-buffer": "^5.2.1",
+                "typed-array-buffer": "^1.0.3"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+                    "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+                    "dev": true
+                }
+            }
+        },
         "to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -16583,6 +16852,17 @@
             "requires": {
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
+            }
+        },
+        "typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "requires": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
             }
         },
         "undici-types": {
@@ -17084,6 +17364,21 @@
             "dev": true,
             "requires": {
                 "isexe": "^2.0.0"
+            }
+        },
+        "which-typed-array": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+            "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
+            "dev": true,
+            "requires": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
             }
         },
         "wildcard": {


### PR DESCRIPTION
**Dependabot alerts : 2 critical vulnerability**

**A) pbkdf2 returns predictable uninitialized/zero-filled memory for non-normalized or unimplemented algos Critical Development
#139 opened 2 weeks ago • Detected in pbkdf2 (npm) • package-lock.json**

Package               Affected versions    Patched version
pbkdf2 (npm)            >= 3.0.10, <= 3.1.2           3.1.3

Summary
This affects both:

Unsupported algos (e.g. sha3-256 / sha3-512 / sha512-256)
Supported but non-normalized algos (e.g. Sha256 / Sha512 / SHA1 / sha-1 / sha-256 / sha-512)
All of those work correctly in Node.js, but this polyfill silently returns highly predictable ouput

**B) pbkdf2 silently disregards Uint8Array input, returning static keys Critical Development
#138 opened 2 weeks ago • Detected in pbkdf2 (npm) • package-lock.json**

Package               Affected versions    Patched version
pbkdf2 (npm)            <= 3.1.2                      3.1.3

Summary
On historic but declared as supported Node.js versions (0.12-2.x), pbkdf2 silently disregards Uint8Array input

This only affects Node.js <3.0.0, but pbkdf2 claims to:

Support Node.js >= 0.12 (and there seems to be ongoing effort in this repo to maintain that)
Support Uint8Array input (input is typechecked against Uint8Array, and the error message includes e.g. "Password must be a string, a Buffer, a typed array or a DataView"


-----------------------------------------
Step 1 -- Auditing

>composer audit
No security vulnerability advisories found.


> npm audit
# npm audit report

pbkdf2 <=3.1.2
Severity: critical
pbkdf2 silently disregards Uint8Array input, returning static keys - https://github.com/advisories/GHSA-v62p-rq8g-8h59
pbkdf2 returns predictable uninitialized/zero-filled memory for non-normalized or unimplemented algos - https://github.com/advisories/GHSA-h7cp-r72f-jxh6
fix available via `npm audit fix`
node_modules/pbkdf2

webpack-dev-server <=5.2.0
Severity: moderate
webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser - https://github.com/advisories/GHSA-9jgg-88mc-972h
webpack-dev-server users' source code may be stolen when they access a malicious web site - https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
No fix available
node_modules/webpack-dev-server
laravel-mix *
Depends on vulnerable versions of webpack-dev-server
node_modules/laravel-mix

3 vulnerabilities (2 moderate, 1 critical)

To address issues that do not require attention, run:
npm audit fix

Some issues need review, and may require choosing
a different dependency.
>


-----------------------------------------
Step 2 -- Action Taken -- Upgrading package

> npm audit fix

added 13 packages, changed 4 packages, and audited 801 packages in 2s

108 packages are looking for funding
run `npm fund` for details

# npm audit report

webpack-dev-server <=5.2.0
Severity: moderate
webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser - https://github.com/advisories/GHSA-9jgg-88mc-972h
webpack-dev-server users' source code may be stolen when they access a malicious web site - https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
No fix available
node_modules/webpack-dev-server
laravel-mix *
Depends on vulnerable versions of webpack-dev-server
node_modules/laravel-mix

2 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.
>

===================================
July 7 - Run the automated HTTP test scripts

Tests: 1261 passed (3324 assertions)
Duration: 681.99s

====================================

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/eZtrKphZ0022_79CjUP2f2UAM7FF?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)
