### PR TITLE
[jp-0238] Schedule adjustment required for Job 'ImportPayCalendar' due to BI maintenance changes 

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -138,7 +138,7 @@ class Kernel extends ConsoleKernel
                         $schedule->command('command:ImportPayCalendar')
                                 ->weekly()
                                 ->mondays()
-                                ->at('2:00')
+                                ->at('2:15')
                                 //  ->everyFifteenMinutes()
                                 ->sendOutputTo(storage_path('logs/ImportPayCalendar.log'))
                                 ->onOneServer(); 


### PR DESCRIPTION
**Alert**: "PECSF [prod] -- The Process (13621 - command:ImportPayCalendar) was failed to complete."

Process ID : 13621
Process Name : command:ImportPayCalendar
Failed at : 2025-07-28 02:00:03

The process was failed with the following error message:

502 Bad Gateway


**Root Cause:** This failure occurred due to a recent change in the BI maintenance schedule, which has been moved from 3:00 AM to 2:00 AM, creating a conflict with our ImportPayCalendar process.

The advise from BI team
"Note, we moved our log rotation cron job from 3 to 2 AM Pacific. The job restarts tomcat in the process."

**Resolution Plan:** I have already created a ticket to reschedule our process timing to avoid this scheduling conflict, with implementation planned for August.
Need to reschedule the schedule process "ImportPayCalendar" from 2:00am to 2:15am.

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/YFvEhzHrE0WYsCy7kJ_2lGUAAhv3?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)







