### PR TITLE
(TEST) [jp-0238b] Schedule adjustment required for Job 'ImportEmployeeJob' due to peak traffic

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -218,13 +218,13 @@ class Kernel extends ConsoleKernel
                         // Non-Production -- Demography data and user profiles                        
                         $schedule->command('command:ImportEmployeeJob')
                                 ->weekdays()
-                                ->at('4:00')
+                                ->at('3:30')
                                 ->sendOutputTo(storage_path('logs/ImportEmployeeJob.log'))
                                 ->onOneServer(); 
 
                         $schedule->command('command:SyncUserProfile')
                                 ->weekdays()
-                                ->at('4:30')
+                                ->at('4:00')
                                 ->sendOutputTo(storage_path('logs/SyncUserProfile.log'))
                                 ->onOneServer(); 
                 } else {


### PR DESCRIPTION
Alert: "PECSF [prod] -- The Process (13778 - command:ImportEmployeeJob) was failed to complete."

Process ID : 13778
Process Name : command:ImportEmployeeJob
Failed at : 2025-08-05 04:07:58

The process was failed with the following error message:

cURL error 28: Operation timed out after 30001 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://analytics-api.psa.gov.bc.ca/apiserver/api.rsc/Datamart_PECSF_peoplesoft_employee_demographic?$top=1000&$skip=26000&$filter=&$orderBy=EMPLID%20asc,%20EMPL_RCD%20asc,%20EFFDT%20desc,%20EFFSEQ%20desc,%20date_updated%20desc

**Root Cause:** Timeout errors are occurring on both our side and the BI side. Analysis shows heavy API usage from other consumers between 3:00-4:00 AM, potentially compounded by increased demographic data volume.

**Resolution Plan:** Reschedule the process from 4:00 AM to 3:30 AM to avoid peak API traffic periods.










