### PR TITLE
[jp-0243] BCP 40c - correct error message to reflects the valid frequency options

### DIFF
--- a/app/Imports/DonationsImportBCP.php
+++ b/app/Imports/DonationsImportBCP.php
@@ -163,7 +163,7 @@ class DonationsImportBCP implements  ToModel, SkipsEmptyRows, WithValidation, Wi
             '1.max' => 'The 1 field must be 6 characters.',
             '2.numeric' => 'The 2 field must be a number',
             '3.date' =>  'The 3 field is not a valid date',
-            '4.in'  =>   'The 4 field is invalid frequency (either Biweekly or One-Time Deduction)',
+            '4.in'  =>   'The 4 field is invalid frequency (either "Bi-Weekly" or "One-Time")',
             '5.numeric' => 'The 5 field must be a number',
 
             'pledge.exists' => 'No pledge was setup for this pecsf_id.',


### PR DESCRIPTION
Needed to be able to upload One-Time Deduction listing to Greenfield, error'd out. James determined that it needed to be only 'One-Time' in the field. Uploaded correctly. Problem solved.

**Enhancement Request on the error message for prevent confusion:**
Great catch on this issue. I've identified that the error message in the log file is misleading.

For BCP file types, Column E (frequency) only accepts two valid values:

"Bi-Weekly"
"One-Time"
Once you update Column E with one of these expected frequency values, the file should upload successfully.

**To correct the error message so it properly reflects the valid frequency options "Bi-Weekly" and "One-Time". This will help prevent similar confusion in the future.**

[Ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/ElE8qbK6qke2mKyHsYn4KGUAFpaW?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)
