### PR TITLE
(MASTER) [jp-0241] Security update required -- 1 CRITICAL and 1 high vulnerability

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5488,20 +5488,20 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "1.29.9",
+            "version": "1.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "ffb47b639649fc9c8a6fa67977a27b756592ed85"
+                "reference": "2f39286e0136673778b7a142b3f0d141e43d1714"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/ffb47b639649fc9c8a6fa67977a27b756592ed85",
-                "reference": "ffb47b639649fc9c8a6fa67977a27b756592ed85",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/2f39286e0136673778b7a142b3f0d141e43d1714",
+                "reference": "2f39286e0136673778b7a142b3f0d141e43d1714",
                 "shasum": ""
             },
             "require": {
-                "composer/pcre": "^3.3",
+                "composer/pcre": "^1||^2||^3",
                 "ext-ctype": "*",
                 "ext-dom": "*",
                 "ext-fileinfo": "*",
@@ -5588,9 +5588,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.29.9"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/1.30.0"
             },
-            "time": "2025-01-26T04:55:00+00:00"
+            "time": "2025-08-10T06:28:02+00:00"
         },
         {
             "name": "phpoption/phpoption",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8608,16 +8608,23 @@
             "dev": true
         },
         "node_modules/sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
             "dev": true,
             "dependencies": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
             },
             "bin": {
                 "sha.js": "bin.js"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/shallow-clone": {
@@ -16405,13 +16412,14 @@
             "dev": true
         },
         "sha.js": {
-            "version": "2.4.11",
-            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "version": "2.4.12",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+            "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
             "dev": true,
             "requires": {
-                "inherits": "^2.0.1",
-                "safe-buffer": "^5.0.1"
+                "inherits": "^2.0.4",
+                "safe-buffer": "^5.2.1",
+                "to-buffer": "^1.2.0"
             }
         },
         "shallow-clone": {

--- a/tests/Feature/ChallengePageTest.php
+++ b/tests/Feature/ChallengePageTest.php
@@ -253,6 +253,8 @@ class ChallengePageTest extends TestCase
         $this->actingAs($this->user);
         $response = $this->get('/challenge/download?sort=region');
 
+        $filename = 'Daily_Campaign_Update_Region_' . today()->format('Y-m-d') . '.xlsx';
+
         $setting = Setting::first();
 
         if (today() > $setting->campaign_start_date && today() <= $setting->campaign_final_date) {


### PR DESCRIPTION
1. sha.js is missing type checks leading to hash rewind and passing on crafted data

Package                             Affected versions       Patched version
sha.js (npm)                  <= 2.4.11                     2.4.12

This is the same as GHSA-cpq7-6gpm-g9rc but just for sha.js, as it has its own implementation.

Missing input type checks can allow types other than a well-formed Buffer or string,
resulting in invalid values, hanging and rewinding the hash state (including turning a tagged hash into an untagged hash),
or other generally undefined behaviour.

2. PhpSpreadsheet vulnerable to SSRF when reading and displaying a processed HTML document in the browser

Package                                                     Affected versions             Patched version                     
phpoffice/phpspreadsheet(Composer)        < 1.30.0                            1.30.0

Product: PhpSpreadsheet
Version: 3.8.0
CWE-ID: CWE-918: Server-Side Request Forgery (SSRF)
CVSS vector v.3.1: 7.5 (AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N)
CVSS vector v.4.0: 8.7 (AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N)
Description: SSRF occurs when a processed HTML document is read and displayed in the browser
Impact: Server-Side Request Forgery
Vulnerable component: the PhpOffice\PhpSpreadsheet\Worksheet\Drawing class, setPath method
Exploitation conditions: getting a string from the user that is passed to the HTML reader
Mitigation: improved processing of the $path variable of the setPath method of the PhpOffice\PhpSpreadsheet\Worksheet\Drawing class is needed
Researcher: Aleksey Solovev (Positive Technologies)


**-----------------------------------------
Step 1 -- Auditing**

> composer audit
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package | phpoffice/phpspreadsheet |
| Severity | high |
| CVE | CVE-2025-54370 |
| Title | PhpSpreadsheet vulnerable to SSRF when reading and displaying a processed HTML |
| | document in the browser |
| URL | https://github.com/PHPOffice/PhpSpreadsheet/security/advisories/GHSA-rx7m-68vc-p |
| | pxh |
| Affected versions | <1.30.0|>=2.0.0,<2.1.0|>=2.1.0,<2.1.12|>=2.2.0,<2.3.0|>=2.3.0,<2.4.0|>=3.0.0,<3. |
| | 10.0|>=4.0.0,<5.0.0 |
| Reported at | 2025-08-03T01:06:00+00:00 |
+-------------------+----------------------------------------------------------------------------------+

> npm audit
# npm audit report

sha.js <=2.4.11
Severity: critical
sha.js is missing type checks leading to hash rewind and passing on crafted data - https://github.com/advisories/GHSA-95m3-7q98-8xr5
fix available via `npm audit fix`
node_modules/sha.js

webpack-dev-server <=5.2.0
Severity: moderate
webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser - https://github.com/advisories/GHSA-9jgg-88mc-972h
webpack-dev-server users' source code may be stolen when they access a malicious web site - https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
No fix available
node_modules/webpack-dev-server
laravel-mix *
Depends on vulnerable versions of webpack-dev-server
node_modules/laravel-mix

3 vulnerabilities (2 moderate, 1 critical)

To address issues that do not require attention, run:
npm audit fix

Some issues need review, and may require choosing
a different dependency.
>

**-----------------------------------------
Step 2 -- Action Taken -- Upgrading package**

> composer update phpoffice/phpspreadsheet
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
- Upgrading phpoffice/phpspreadsheet (1.29.9 => 1.30.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 0 installs, 1 update, 0 removals
INFO: Could not find files for the given pattern(s).
- Downloading phpoffice/phpspreadsheet (1.30.0)
- Upgrading phpoffice/phpspreadsheet (1.29.9 => 1.30.0): Extracting archive
Generating optimized autoload files
:
:
121 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
No security vulnerability advisories found.


> npm audit fix

changed 1 package, and audited 802 packages in 1s

109 packages are looking for funding
run `npm fund` for details

# npm audit report

webpack-dev-server <=5.2.0
Severity: moderate
webpack-dev-server users' source code may be stolen when they access a malicious web site with non-Chromium based browser - https://github.com/advisories/GHSA-9jgg-88mc-972h
webpack-dev-server users' source code may be stolen when they access a malicious web site - https://github.com/advisories/GHSA-4v9v-hfq4-rm2v
No fix available
node_modules/webpack-dev-server
laravel-mix *
Depends on vulnerable versions of webpack-dev-server
node_modules/laravel-mix

2 moderate severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.
>

===================================
Sept 8 - Run the automated HTTP test scripts

Tests: 1261 passed (3350 assertions)
Duration: 599.69s


Sept 9 - Deployed on DEV and TEST regions. Ready for testing
Sept 9 - The upgrade package are general and cover lots of area. I already did my test scripts (over 1261 test and 3324 assertions) and all passed, However, these scripts mainly focus on form data entry and database updates. There are no scripts for the UI. You might want to concentrate on testing the following core functions in the TEST region.

Testing for the following on TEST region
. IDIR login
. Donations > Donate (Self Service)
. Volunteering > eForm (Self Service)
. Donations > Export Summary (Test PDF)
. Statistics > Leaderboard > Download as PDF
. Statistics > Leaderboard > Chart
. Admin > Pledge Administration > Maintain EE Pledges > Edit
. Admin > Pledge Administration > Maintain Event Pledges > Edit
. CRA Charities -> Charity List Maintenance -> File upload
. Admin -> Reporting -> Pay Period Report -> Export
. Admin -> Reporting -> Program reports -> Annual pledges and Events -> Export
. System > Auditing > Table Audit Log
. System > Schedule Jobs (verify recent process run to completed)

