### PR TITLE
(MASTER) [jp-0242] Error on DonationDataReportExport process 

### DIFF
--- a/app/Exports/DonationDataReportExport.php
+++ b/app/Exports/DonationDataReportExport.php
@@ -112,9 +112,9 @@ class DonationDataReportExport implements FromQuery, WithHeadings, WithMapping, 
             $row->process_history_id,
             $row->process_history->status,
             $row->process_history->end_at,
-            $row->process_history ? $row->process_history->created_by->name : '',
+            $row->process_history->created_by ? $row->process_history->created_by->name : '',
             $row->created_at,
-            $row->process_history ? $row->process_history->updated_by->name : '',
+            $row->process_history->updated_by ? $row->process_history->updated_by->name : '',
             $row->updated_at
         ];
     }

--- a/app/Exports/DonationDataReportExport.php
+++ b/app/Exports/DonationDataReportExport.php
@@ -112,9 +112,9 @@ class DonationDataReportExport implements FromQuery, WithHeadings, WithMapping, 
             $row->process_history_id,
             $row->process_history->status,
             $row->process_history->end_at,
-            $row->process_history->created_by->name,
+            $row->process_history ? $row->process_history->created_by->name : '',
             $row->created_at,
-            $row->process_history->updated_by->name,
+            $row->process_history ? $row->process_history->updated_by->name : '',
             $row->updated_at
         ];
     }


### PR DESCRIPTION
**Issue Description**
Error encountered when executing "Export Donation Data" function in Test region:

ErrorException: Attempt to read property "name" on null in /var/www/html/app/Exports/DonationDataReportExport.php:115

**Root Cause Analysis**
The error is caused by data integrity issues resulting from:

Data restoration from Production backup to Test environment
Cleanup operations performed on the process history table
Missing or null references in the process history data that the export function expects to be present

**Proposed Solution**
Implement a null-check validation before accessing the "name" property in the DonationDataReportExport.php file at line 115. This will involve:

1. Adding conditional logic to verify that the process history object exists and is not null
2. Implementing appropriate error handling or default values when the expected data is missing
3. Ensuring graceful degradation of the export functionality when process history data is incomplete

**Files Involved**
/var/www/html/app/Exports/DonationDataReportExport.php (line 115)

[ticket](https://planner.cloud.microsoft/webui/v1/plan/ZOb3bFXcakWu8Gl2Zd_PuGUAFIJt/view/board/task/xxkhE2kKzkmDXFIsyObVUmUAGmCy?tid=6fdb5200-3d0d-4a8a-b036-d3685e359adc)